### PR TITLE
test: add 108 tests for verify runner, simulation runner, and training callbacks

### DIFF
--- a/tests/test_simulation_runner.py
+++ b/tests/test_simulation_runner.py
@@ -1,0 +1,416 @@
+"""Tests for navirl/simulation/runner.py.
+
+Covers SimulationRunner: construction, callbacks, step, run, run_episodes,
+run_parallel, run_batch, snapshots, reset, stats, and async run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from navirl.simulation.clock import SimulationClock
+from navirl.simulation.events import EventBus
+from navirl.simulation.physics import SimplePhysics
+from navirl.simulation.runner import (
+    EpisodeResult,
+    ProgressInfo,
+    SimulationRunner,
+)
+from navirl.simulation.world import World
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture
+def basic_world():
+    """A simple world with two entities."""
+    w = World(width=20, height=20)
+    w.add_entity(position=(2, 3), velocity=(0.1, 0), kind="robot", radius=0.3)
+    w.add_entity(position=(10, 10), velocity=(-0.1, 0), kind="pedestrian", radius=0.3)
+    return w
+
+
+@pytest.fixture
+def runner(basic_world):
+    """A SimulationRunner configured for short runs."""
+    clock = SimulationClock(dt=0.1, max_sim_time=1.0)
+    physics = SimplePhysics()
+    event_bus = EventBus()
+    return SimulationRunner(
+        world=basic_world,
+        clock=clock,
+        physics=physics,
+        event_bus=event_bus,
+        headless=True,
+        seed=42,
+    )
+
+
+# ===================================================================
+# EpisodeResult
+# ===================================================================
+
+
+class TestEpisodeResult:
+    def test_defaults(self):
+        r = EpisodeResult()
+        assert r.episode_id == 0
+        assert r.success is False
+        assert r.sim_time == 0.0
+        assert r.wall_time == 0.0
+        assert r.steps == 0
+        assert r.total_collisions == 0
+        assert r.events == []
+        assert r.final_positions == {}
+        assert r.metadata == {}
+
+    def test_to_dict(self):
+        r = EpisodeResult(episode_id=1, success=True, sim_time=5.0, steps=50)
+        d = r.to_dict()
+        assert d["episode_id"] == 1
+        assert d["success"] is True
+        assert d["sim_time"] == 5.0
+        assert d["steps"] == 50
+        assert isinstance(d["events"], list)
+        assert isinstance(d["final_positions"], dict)
+        assert isinstance(d["metadata"], dict)
+
+
+# ===================================================================
+# ProgressInfo
+# ===================================================================
+
+
+class TestProgressInfo:
+    def test_defaults(self):
+        p = ProgressInfo(episode=1, total_episodes=5, step=10, sim_time=1.0, wall_time=0.5)
+        assert p.done is False
+        assert p.message == ""
+
+    def test_custom_fields(self):
+        p = ProgressInfo(
+            episode=3, total_episodes=10, step=100, sim_time=5.0, wall_time=2.0,
+            done=True, message="completed",
+        )
+        assert p.done is True
+        assert p.message == "completed"
+
+
+# ===================================================================
+# SimulationRunner construction
+# ===================================================================
+
+
+class TestSimulationRunnerInit:
+    def test_basic_construction(self, basic_world):
+        runner = SimulationRunner(world=basic_world)
+        assert runner.world is basic_world
+        assert runner.headless is True
+        assert not runner.is_running
+
+    def test_custom_components(self, basic_world):
+        clock = SimulationClock(dt=0.05)
+        physics = SimplePhysics()
+        bus = EventBus()
+        runner = SimulationRunner(
+            world=basic_world, clock=clock, physics=physics,
+            event_bus=bus, headless=False, seed=123,
+        )
+        assert runner.clock is clock
+        assert runner.physics is physics
+        assert runner.event_bus is bus
+        assert runner.headless is False
+
+    def test_repr(self, runner):
+        text = repr(runner)
+        assert "SimulationRunner" in text
+        assert "running=False" in text
+
+
+# ===================================================================
+# Callbacks
+# ===================================================================
+
+
+class TestCallbacks:
+    def test_pre_step_callback(self, runner):
+        calls = []
+        runner.on_pre_step(lambda r, dt: calls.append(("pre", dt)))
+        runner.step()
+        assert len(calls) == 1
+        assert calls[0][0] == "pre"
+        assert calls[0][1] > 0
+
+    def test_post_step_callback(self, runner):
+        calls = []
+        runner.on_post_step(lambda r, dt: calls.append(("post", dt)))
+        runner.step()
+        assert len(calls) == 1
+
+    def test_episode_end_callback(self, runner):
+        results = []
+        runner.on_episode_end(lambda r, res: results.append(res))
+        runner.run(max_steps=5)
+        assert len(results) == 1
+        assert isinstance(results[0], EpisodeResult)
+
+    def test_progress_callback(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=100.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        progress = []
+        runner.on_progress(lambda info: progress.append(info))
+        runner.run(max_steps=200, report_interval=50)
+        # Should get at least one progress report (200/50 = 4 reports)
+        assert len(progress) >= 1
+        assert isinstance(progress[0], ProgressInfo)
+
+    def test_termination_condition(self, runner):
+        step_count = [0]
+
+        def terminate_at_3(r):
+            step_count[0] += 1
+            return step_count[0] >= 3
+
+        runner.add_termination_condition(terminate_at_3)
+        result = runner.run(max_steps=100)
+        assert result.steps == 3
+        assert result.success is True  # terminated = True -> success = True
+
+
+# ===================================================================
+# Step
+# ===================================================================
+
+
+class TestStep:
+    def test_single_step(self, runner):
+        dt = runner.step()
+        assert dt > 0
+        assert runner.clock.sim_time > 0
+
+    def test_multiple_steps(self, runner):
+        for _ in range(10):
+            runner.step()
+        assert runner.clock.sim_time == pytest.approx(1.0)  # 10 * 0.1
+
+
+# ===================================================================
+# Run
+# ===================================================================
+
+
+class TestRun:
+    def test_run_with_max_steps(self, runner):
+        result = runner.run(max_steps=5)
+        assert result.steps == 5
+        assert result.sim_time > 0
+        assert result.wall_time > 0
+        assert not runner.is_running
+
+    def test_run_with_max_time(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=100.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        result = runner.run(max_time=0.5)
+        assert result.sim_time >= 0.5
+        assert result.steps >= 5
+
+    def test_run_until_clock_done(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=0.3)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        result = runner.run()
+        # Clock should stop at max_sim_time
+        assert result.sim_time <= 0.4  # approximately 0.3
+
+    def test_episode_id_increments(self, runner):
+        r1 = runner.run(max_steps=1)
+        assert r1.episode_id == 1
+        r2 = runner.run(max_steps=1)
+        assert r2.episode_id == 2
+
+    def test_result_has_final_positions(self, runner):
+        result = runner.run(max_steps=3)
+        assert len(result.final_positions) > 0
+        for eid, pos in result.final_positions.items():
+            assert isinstance(eid, int)
+            assert len(pos) == 2
+
+    def test_stop_interrupts_run(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=100.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        runner.on_post_step(lambda r, dt: r.stop() if r.clock.step_count >= 3 else None)
+        result = runner.run()
+        assert result.steps == 3
+
+
+# ===================================================================
+# Async run
+# ===================================================================
+
+
+class TestRunAsync:
+    def test_async_run(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=10.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        result = asyncio.run(runner.run_async(max_steps=5, yield_interval=2))
+        assert result.steps == 5
+        assert result.sim_time > 0
+        assert not runner.is_running
+
+    def test_async_termination_condition(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=10.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        count = [0]
+
+        def term(r):
+            count[0] += 1
+            return count[0] >= 4
+
+        runner.add_termination_condition(term)
+        result = asyncio.run(runner.run_async(max_steps=100))
+        assert result.steps == 4
+
+
+# ===================================================================
+# Snapshots
+# ===================================================================
+
+
+class TestSnapshots:
+    def test_save_and_load_snapshot(self, runner):
+        runner.step()
+        runner.save_snapshot("s1")
+        runner.step()
+        runner.step()
+        # Restore
+        assert runner.load_snapshot("s1") is True
+
+    def test_load_nonexistent_snapshot(self, runner):
+        assert runner.load_snapshot("nonexistent") is False
+
+    def test_save_initial_state_and_reset(self, runner):
+        runner.save_initial_state()
+        # Run a few steps
+        runner.run(max_steps=5)
+        old_time = runner.clock.sim_time
+        assert old_time > 0
+        # Reset
+        runner.reset()
+        assert runner.clock.sim_time == 0.0
+
+
+# ===================================================================
+# Run episodes
+# ===================================================================
+
+
+class TestRunEpisodes:
+    def test_basic_episodes(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=10.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        results = runner.run_episodes(n_episodes=3, max_steps_per_episode=5)
+        assert len(results) == 3
+        for r in results:
+            assert r.steps == 5
+
+    def test_episodes_without_reset(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=100.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        results = runner.run_episodes(n_episodes=2, max_steps_per_episode=3, reset_between=False)
+        assert len(results) == 2
+        # Without reset, sim_time accumulates
+        assert results[1].sim_time > results[0].sim_time
+
+
+# ===================================================================
+# Parallel execution
+# ===================================================================
+
+
+class TestRunParallel:
+    def test_parallel_episodes(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=10.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        results = runner.run_parallel(n_episodes=3, max_steps_per_episode=5, max_workers=2)
+        assert len(results) == 3
+        # Results should be sorted by episode_id
+        ids = [r.episode_id for r in results]
+        assert ids == sorted(ids)
+
+    def test_parallel_progress_callback(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=10.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        progress = []
+        runner.on_progress(lambda info: progress.append(info))
+        runner.run_parallel(n_episodes=2, max_steps_per_episode=5, max_workers=2)
+        assert len(progress) == 2
+
+
+# ===================================================================
+# Batch simulation
+# ===================================================================
+
+
+class TestRunBatch:
+    def test_batch_configs(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=10.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        configs = [
+            {"metadata": {"trial": 0}},
+            {"metadata": {"trial": 1}},
+        ]
+        results = runner.run_batch(configs, max_steps=5)
+        assert len(results) == 2
+        assert results[0].episode_id == 0
+        assert results[1].episode_id == 1
+        assert results[0].metadata["trial"] == 0
+        assert results[1].metadata["trial"] == 1
+
+    def test_batch_with_entities(self, basic_world):
+        clock = SimulationClock(dt=0.1, max_sim_time=10.0)
+        runner = SimulationRunner(world=basic_world, clock=clock, seed=0)
+        configs = [
+            {"entities": [{"position": (5, 5), "kind": "pedestrian", "radius": 0.3}]},
+        ]
+        results = runner.run_batch(configs, max_steps=3)
+        assert len(results) == 1
+
+
+# ===================================================================
+# Stats and accessors
+# ===================================================================
+
+
+class TestAccessors:
+    def test_sim_time(self, runner):
+        assert runner.sim_time == 0.0
+        runner.step()
+        assert runner.sim_time > 0
+
+    def test_step_count(self, runner):
+        assert runner.step_count == 0
+        runner.step()
+        assert runner.step_count == 1
+
+    def test_entity_positions(self, runner):
+        pos = runner.entity_positions()
+        assert isinstance(pos, np.ndarray)
+        assert pos.shape[1] == 2
+
+    def test_entity_velocities(self, runner):
+        vel = runner.entity_velocities()
+        assert isinstance(vel, np.ndarray)
+        assert vel.shape[1] == 2
+
+    def test_stats(self, runner):
+        runner.step()
+        s = runner.stats()
+        assert "clock" in s
+        assert "physics" in s
+        assert "events" in s
+        assert s["episode_id"] == 0
+        assert "episode_collisions" in s

--- a/tests/test_training_callbacks.py
+++ b/tests/test_training_callbacks.py
@@ -1,0 +1,555 @@
+"""Tests for navirl/training/callbacks.py.
+
+Covers CallbackList delegation, EvalCallback, CheckpointCallback, LoggingCallback,
+EarlyStoppingCallback, CurriculumCallback, SchedulerCallback, GradientMonitorCallback,
+HyperparameterSearchCallback, and ProgressBarCallback.
+
+WandbCallback and TensorBoardCallback are skipped (require optional external deps).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from navirl.training.callbacks import (
+    Callback,
+    CallbackList,
+    CheckpointCallback,
+    CurriculumCallback,
+    EarlyStoppingCallback,
+    EvalCallback,
+    GradientMonitorCallback,
+    HyperparameterSearchCallback,
+    LoggingCallback,
+    SchedulerCallback,
+)
+
+# ===================================================================
+# Callback base class
+# ===================================================================
+
+
+class TestCallback:
+    def test_base_hooks_are_noop(self):
+        cb = Callback()
+        cb.on_training_start({})
+        cb.on_training_end({})
+        assert cb.on_step({}) is True
+        cb.on_episode_end({})
+        cb.on_rollout_start({})
+        cb.on_rollout_end({})
+        cb.on_update_start({})
+        cb.on_update_end({})
+
+
+# ===================================================================
+# CallbackList
+# ===================================================================
+
+
+class TestCallbackList:
+    def test_delegates_all_hooks(self):
+        tracker = {"calls": []}
+
+        class TrackerCB(Callback):
+            def on_training_start(self, locals_):
+                tracker["calls"].append("start")
+
+            def on_training_end(self, locals_):
+                tracker["calls"].append("end")
+
+            def on_step(self, locals_):
+                tracker["calls"].append("step")
+                return True
+
+            def on_episode_end(self, locals_):
+                tracker["calls"].append("episode_end")
+
+            def on_rollout_start(self, locals_):
+                tracker["calls"].append("rollout_start")
+
+            def on_rollout_end(self, locals_):
+                tracker["calls"].append("rollout_end")
+
+            def on_update_start(self, locals_):
+                tracker["calls"].append("update_start")
+
+            def on_update_end(self, locals_):
+                tracker["calls"].append("update_end")
+
+        cb_list = CallbackList([TrackerCB(), TrackerCB()])
+        cb_list.on_training_start({})
+        cb_list.on_training_end({})
+        cb_list.on_step({})
+        cb_list.on_episode_end({})
+        cb_list.on_rollout_start({})
+        cb_list.on_rollout_end({})
+        cb_list.on_update_start({})
+        cb_list.on_update_end({})
+
+        # Each hook called twice (two callbacks)
+        assert tracker["calls"].count("start") == 2
+        assert tracker["calls"].count("end") == 2
+        assert tracker["calls"].count("step") == 2
+        assert tracker["calls"].count("update_start") == 2
+        assert tracker["calls"].count("update_end") == 2
+
+    def test_on_step_stops_on_false(self):
+        class StopCB(Callback):
+            def on_step(self, locals_):
+                return False
+
+        class ContinueCB(Callback):
+            def on_step(self, locals_):
+                return True
+
+        cb_list = CallbackList([ContinueCB(), StopCB(), ContinueCB()])
+        assert cb_list.on_step({}) is False
+
+    def test_on_step_all_true(self):
+        cb_list = CallbackList([Callback(), Callback()])
+        assert cb_list.on_step({}) is True
+
+
+# ===================================================================
+# EvalCallback
+# ===================================================================
+
+
+class _FakeActionSpace:
+    def sample(self):
+        return 0
+
+
+class _FakeEnv:
+    """A minimal env that is not callable (unlike MagicMock)."""
+
+    def __init__(self, reward=1.0, n_tuple=5):
+        self.action_space = _FakeActionSpace()
+        self._reward = reward
+        self._n_tuple = n_tuple
+
+    def reset(self):
+        return [0, 0, 0, 0], {}
+
+    def step(self, action):
+        if self._n_tuple == 5:
+            return [0, 0, 0, 0], self._reward, True, False, {}
+        return [0, 0, 0, 0], self._reward, True, {}
+
+
+class TestEvalCallback:
+    def _make_env(self, reward=1.0):
+        return _FakeEnv(reward=reward)
+
+    def test_eval_triggers_at_frequency(self):
+        env = self._make_env()
+        cb = EvalCallback(eval_env=env, eval_freq=5, n_eval_episodes=2, verbose=0)
+
+        # Steps 1-4 should not trigger
+        for _ in range(4):
+            assert cb.on_step({}) is True
+        assert len(cb.eval_results) == 0
+
+        # Step 5 triggers evaluation
+        assert cb.on_step({}) is True
+        assert len(cb.eval_results) == 1
+        assert cb.last_mean_reward == 1.0
+
+    def test_eval_with_model(self):
+        env = self._make_env()
+        model = MagicMock()
+        model.predict.return_value = (0, None)
+        cb = EvalCallback(eval_env=env, eval_freq=1, n_eval_episodes=1, verbose=0)
+        cb.on_step({"self": model})
+        assert len(cb.eval_results) == 1
+        assert model.predict.called
+
+    def test_eval_callable_env(self):
+        env = self._make_env()
+        cb = EvalCallback(eval_env=lambda: env, eval_freq=1, n_eval_episodes=1, verbose=0)
+        cb.on_step({})
+        assert len(cb.eval_results) == 1
+
+    def test_best_model_save(self, tmp_path):
+        env = self._make_env()
+        model = MagicMock()
+        model.predict.return_value = (0, None)
+        cb = EvalCallback(
+            eval_env=env, eval_freq=1, n_eval_episodes=1,
+            best_model_save_path=str(tmp_path), verbose=1,
+        )
+        cb.on_step({"self": model})
+        assert model.save.called
+
+    def test_eval_old_style_env(self):
+        """Test env returning 4-tuple (old gym API)."""
+        env = _FakeEnv(reward=2.0, n_tuple=4)
+        cb = EvalCallback(eval_env=env, eval_freq=1, n_eval_episodes=1, verbose=0)
+        cb.on_step({})
+        assert cb.last_mean_reward == 2.0
+
+
+# ===================================================================
+# CheckpointCallback
+# ===================================================================
+
+
+class TestCheckpointCallback:
+    def test_saves_at_frequency(self, tmp_path):
+        model = MagicMock()
+        cb = CheckpointCallback(save_freq=3, save_path=str(tmp_path), name_prefix="ckpt", verbose=0)
+        cb.on_training_start({})
+
+        # Steps 1-2 don't save
+        for _ in range(2):
+            cb.on_step({"self": model})
+        model.save.assert_not_called()
+
+        # Step 3 saves
+        cb.on_step({"self": model})
+        model.save.assert_called_once()
+        call_path = model.save.call_args[0][0]
+        assert "ckpt_3_steps" in call_path
+
+    def test_no_model_no_crash(self, tmp_path):
+        cb = CheckpointCallback(save_freq=1, save_path=str(tmp_path))
+        cb.on_training_start({})
+        cb.on_step({})  # No model in locals_ - should not crash
+
+
+# ===================================================================
+# LoggingCallback
+# ===================================================================
+
+
+class TestLoggingCallback:
+    def test_logs_metrics(self, tmp_path):
+        log_file = tmp_path / "train.jsonl"
+        cb = LoggingCallback(log_freq=2, log_file=str(log_file), verbose=0)
+        cb.on_training_start({})
+
+        # Step 1: no log
+        cb.on_step({})
+        # Step 2: log
+        cb.on_step({"loss": 0.5, "entropy": 1.2})
+
+        cb.on_training_end({})
+
+        lines = log_file.read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["step"] == 2
+        assert "fps" in data
+        assert data["loss"] == 0.5
+        assert data["entropy"] == 1.2
+
+    def test_tracks_episode_rewards(self):
+        cb = LoggingCallback(log_freq=1, verbose=0)
+        cb.on_training_start({})
+        cb.on_episode_end({"episode_reward": 10.0})
+        cb.on_episode_end({"episode_reward": 20.0})
+        cb.on_step({})
+        cb.on_training_end({})
+        assert len(cb._episode_rewards) == 2
+
+    def test_no_file_no_crash(self):
+        cb = LoggingCallback(log_freq=1, verbose=0)
+        cb.on_training_start({})
+        cb.on_step({})
+        cb.on_training_end({})
+
+    def test_episode_reward_fallback_key(self):
+        cb = LoggingCallback(log_freq=1, verbose=0)
+        cb.on_episode_end({"reward": 5.0})
+        assert cb._episode_rewards == [5.0]
+
+
+# ===================================================================
+# EarlyStoppingCallback
+# ===================================================================
+
+
+class TestEarlyStoppingCallback:
+    def _make_eval_cb(self):
+        env = _FakeEnv(reward=0.0)
+        return EvalCallback(eval_env=env, eval_freq=1, n_eval_episodes=1, verbose=0)
+
+    def test_stops_after_patience(self):
+        eval_cb = self._make_eval_cb()
+        early_cb = EarlyStoppingCallback(eval_cb, patience=3, min_delta=0.0, verbose=0)
+
+        # Simulate improving then plateauing eval results
+        rewards = [1.0, 2.0, 2.0, 2.0, 2.0]
+        for i, r in enumerate(rewards):
+            eval_cb.eval_results.append({"step": i + 1, "mean_reward": r})
+            eval_cb.last_mean_reward = r
+            result = early_cb.on_step({})
+            if not result:
+                break
+
+        assert result is False  # Should have stopped
+
+    def test_no_stop_with_improvement(self):
+        eval_cb = self._make_eval_cb()
+        early_cb = EarlyStoppingCallback(eval_cb, patience=3, verbose=0)
+
+        for i in range(5):
+            eval_cb.eval_results.append({"step": i + 1, "mean_reward": float(i)})
+            eval_cb.last_mean_reward = float(i)
+            result = early_cb.on_step({})
+            assert result is True
+
+    def test_no_eval_results_continues(self):
+        eval_cb = self._make_eval_cb()
+        early_cb = EarlyStoppingCallback(eval_cb, patience=2, verbose=0)
+        assert early_cb.on_step({}) is True
+
+    def test_min_delta(self):
+        eval_cb = self._make_eval_cb()
+        early_cb = EarlyStoppingCallback(eval_cb, patience=2, min_delta=1.0, verbose=0)
+
+        # Small improvements below min_delta don't count
+        for i in range(4):
+            eval_cb.eval_results.append({"step": i + 1, "mean_reward": i * 0.1})
+            eval_cb.last_mean_reward = i * 0.1
+            result = early_cb.on_step({})
+            if not result:
+                break
+
+        assert result is False
+
+
+# ===================================================================
+# CurriculumCallback
+# ===================================================================
+
+
+class TestCurriculumCallback:
+    def test_advances_levels(self):
+        update_calls = []
+
+        def update_fn(env, params):
+            update_calls.append(params)
+
+        cb = CurriculumCallback(
+            metric_key="mean_episode_reward",
+            thresholds=[(5.0, {"n_agents": 3}), (10.0, {"n_agents": 5})],
+            update_fn=update_fn,
+            verbose=0,
+        )
+
+        env = MagicMock()
+
+        # Below first threshold
+        cb.on_episode_end({"mean_episode_reward": 3.0, "env": env})
+        assert len(update_calls) == 0
+
+        # Cross first threshold
+        cb.on_episode_end({"mean_episode_reward": 6.0, "env": env})
+        assert len(update_calls) == 1
+        assert update_calls[-1] == {"n_agents": 3}
+
+        # Cross second threshold
+        cb.on_episode_end({"mean_episode_reward": 12.0, "env": env})
+        assert len(update_calls) == 2
+        assert update_calls[-1] == {"n_agents": 5}
+
+    def test_no_metric_no_crash(self):
+        cb = CurriculumCallback(metric_key="missing_key", verbose=0)
+        cb.on_episode_end({})  # Should not crash
+
+    def test_no_env_no_crash(self):
+        cb = CurriculumCallback(
+            metric_key="r",
+            thresholds=[(1.0, {"x": 1})],
+            update_fn=lambda e, p: None,
+            verbose=0,
+        )
+        # Metric crosses threshold but no env in locals_
+        cb.on_episode_end({"r": 5.0})
+
+    def test_no_update_fn(self):
+        cb = CurriculumCallback(
+            metric_key="r",
+            thresholds=[(1.0, {"x": 1})],
+            update_fn=None,
+            verbose=0,
+        )
+        cb.on_episode_end({"r": 5.0, "env": MagicMock()})
+        assert cb._current_level == 1
+
+
+# ===================================================================
+# SchedulerCallback
+# ===================================================================
+
+
+class TestSchedulerCallback:
+    def test_step_on_update(self):
+        sched = MagicMock()
+        cb = SchedulerCallback(schedulers=sched, step_on="update")
+        cb.on_update_end({})
+        sched.step.assert_called_once()
+        assert cb.n_calls == 1
+
+    def test_step_on_step(self):
+        sched = MagicMock()
+        cb = SchedulerCallback(schedulers=sched, step_on="step")
+        assert cb.on_step({}) is True
+        sched.step.assert_called_once()
+
+    def test_multiple_schedulers(self):
+        s1 = MagicMock()
+        s2 = MagicMock()
+        cb = SchedulerCallback(schedulers=[s1, s2], step_on="update")
+        cb.on_update_end({})
+        s1.step.assert_called_once()
+        s2.step.assert_called_once()
+
+    def test_update_ignored_when_step_on_step(self):
+        sched = MagicMock()
+        cb = SchedulerCallback(schedulers=sched, step_on="step")
+        cb.on_update_end({})
+        sched.step.assert_not_called()
+
+
+# ===================================================================
+# GradientMonitorCallback
+# ===================================================================
+
+
+class TestGradientMonitorCallback:
+    def _make_model_with_grads(self):
+        model = MagicMock()
+        # Create fake parameters with gradients
+        param1 = MagicMock()
+        param1.grad.data.norm.return_value = MagicMock(item=MagicMock(return_value=0.5))
+        param2 = MagicMock()
+        param2.grad.data.norm.return_value = MagicMock(item=MagicMock(return_value=1.5))
+        model.parameters.return_value = [param1, param2]
+        return model
+
+    def test_logs_gradient_norms(self):
+        model = self._make_model_with_grads()
+        cb = GradientMonitorCallback(log_freq=1, verbose=0)
+        cb.on_update_end({"self": model})
+        assert len(cb.grad_history) == 1
+        entry = cb.grad_history[0]
+        assert entry["update"] == 1
+        assert entry["param_count"] == 2
+        assert entry["total_grad_norm"] > 0
+
+    def test_logs_at_frequency(self):
+        model = self._make_model_with_grads()
+        cb = GradientMonitorCallback(log_freq=3, verbose=0)
+        for _ in range(5):
+            cb.on_update_end({"self": model})
+        assert len(cb.grad_history) == 1  # Only at step 3
+
+    def test_no_model(self):
+        cb = GradientMonitorCallback(log_freq=1, verbose=0)
+        cb.on_update_end({})
+        assert len(cb.grad_history) == 0
+
+    def test_model_with_policy(self):
+        model = MagicMock(spec=[])  # No .parameters attribute
+        policy = MagicMock()
+        param = MagicMock()
+        param.grad.data.norm.return_value = MagicMock(item=MagicMock(return_value=1.0))
+        policy.parameters.return_value = [param]
+        model.policy = policy
+        cb = GradientMonitorCallback(log_freq=1, verbose=0)
+        cb.on_update_end({"self": model})
+        assert len(cb.grad_history) == 1
+
+    def test_max_grad_norm_warning(self):
+        model = self._make_model_with_grads()
+        cb = GradientMonitorCallback(log_freq=1, max_grad_norm=0.1, verbose=1)
+        # Should log a warning but not crash
+        cb.on_update_end({"self": model})
+        assert len(cb.grad_history) == 1
+
+    def test_no_parameters_attr(self):
+        model = MagicMock(spec=[])  # No attributes at all
+        cb = GradientMonitorCallback(log_freq=1, verbose=0)
+        cb.on_update_end({"self": model})
+        assert len(cb.grad_history) == 0
+
+    def test_param_with_no_grad(self):
+        model = MagicMock()
+        param = MagicMock()
+        param.grad = None
+        model.parameters.return_value = [param]
+        cb = GradientMonitorCallback(log_freq=1, verbose=0)
+        cb.on_update_end({"self": model})
+        assert len(cb.grad_history) == 1
+        assert cb.grad_history[0]["param_count"] == 0
+
+
+# ===================================================================
+# HyperparameterSearchCallback
+# ===================================================================
+
+
+class TestHyperparameterSearchCallback:
+    def test_reports_from_eval_callback(self):
+        eval_cb = MagicMock()
+        eval_cb.eval_results = [{"step": 10, "mean_reward": 5.0}]
+        report_fn = MagicMock()
+
+        cb = HyperparameterSearchCallback(
+            metric_key="mean_reward",
+            report_fn=report_fn,
+            eval_callback=eval_cb,
+            report_freq=1,
+        )
+        cb.on_step({})
+        report_fn.assert_called_once_with(1, 5.0)
+
+    def test_reports_from_locals(self):
+        report_fn = MagicMock()
+        cb = HyperparameterSearchCallback(
+            metric_key="mean_reward",
+            report_fn=report_fn,
+            report_freq=1,
+        )
+        cb.on_step({"mean_reward": 3.0})
+        report_fn.assert_called_once_with(1, 3.0)
+
+    def test_report_freq(self):
+        report_fn = MagicMock()
+        cb = HyperparameterSearchCallback(report_fn=report_fn, report_freq=5)
+        for _ in range(4):
+            cb.on_step({"mean_reward": 1.0})
+        report_fn.assert_not_called()
+
+        cb.on_step({"mean_reward": 1.0})
+        report_fn.assert_called_once()
+
+    def test_no_metric_no_report(self):
+        report_fn = MagicMock()
+        cb = HyperparameterSearchCallback(report_fn=report_fn, report_freq=1)
+        cb.on_step({})
+        report_fn.assert_not_called()
+
+    def test_no_report_fn_no_crash(self):
+        cb = HyperparameterSearchCallback(report_freq=1)
+        cb.on_step({"mean_reward": 1.0})  # Should not crash
+
+    def test_eval_callback_custom_metric(self):
+        eval_cb = MagicMock()
+        eval_cb.eval_results = [{"step": 1, "custom_metric": 42.0}]
+        report_fn = MagicMock()
+        cb = HyperparameterSearchCallback(
+            metric_key="custom_metric",
+            report_fn=report_fn,
+            eval_callback=eval_cb,
+            report_freq=1,
+        )
+        cb.on_step({})
+        report_fn.assert_called_once_with(1, 42.0)

--- a/tests/test_verify_runner.py
+++ b/tests/test_verify_runner.py
@@ -1,0 +1,467 @@
+"""Tests for navirl/verify/runner.py helper and formatting functions.
+
+Covers VerifyResult, _calculate_verification_stats, _format_executive_summary,
+_format_configuration_section, _format_scenario_row, _format_scenario_results_table,
+_write_report, and _scenario_file_path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from navirl.verify.runner import (
+    CANONICAL_SCENARIOS,
+    FAIL,
+    NEEDS_HUMAN_REVIEW,
+    PASS,
+    VerifyResult,
+    _calculate_verification_stats,
+    _format_configuration_section,
+    _format_executive_summary,
+    _format_scenario_results_table,
+    _format_scenario_row,
+    _scenario_file_path,
+    _write_report,
+)
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+def _make_result(
+    scenario_id: str = "test_scenario",
+    overall_pass: bool = True,
+    invariants_pass: bool = True,
+    judge_status: str = "pass",
+    judge_confidence: float = 0.85,
+    video_check_pass: bool | None = None,
+    notes: str = "",
+    bundle_dir: str = "/tmp/fake_bundle",
+) -> VerifyResult:
+    return VerifyResult(
+        scenario_id=scenario_id,
+        bundle_dir=bundle_dir,
+        invariants_pass=invariants_pass,
+        judge_status=judge_status,
+        judge_confidence=judge_confidence,
+        overall_pass=overall_pass,
+        video_check_pass=video_check_pass,
+        notes=notes,
+    )
+
+
+@pytest.fixture
+def all_pass_rows():
+    return [
+        _make_result("scenario_a", overall_pass=True),
+        _make_result("scenario_b", overall_pass=True),
+        _make_result("scenario_c", overall_pass=True),
+    ]
+
+
+@pytest.fixture
+def mixed_rows():
+    return [
+        _make_result("pass_scenario", overall_pass=True),
+        _make_result(
+            "fail_invariant",
+            overall_pass=False,
+            invariants_pass=False,
+            judge_status="fail",
+            judge_confidence=0.2,
+        ),
+        _make_result(
+            "needs_review",
+            overall_pass=False,
+            judge_status="needs_human_review",
+            judge_confidence=0.45,
+        ),
+    ]
+
+
+# ===================================================================
+# Constants
+# ===================================================================
+
+
+class TestConstants:
+    def test_exit_codes(self):
+        assert PASS == 0
+        assert FAIL == 10
+        assert NEEDS_HUMAN_REVIEW == 20
+
+    def test_canonical_scenarios_non_empty(self):
+        assert len(CANONICAL_SCENARIOS) > 0
+        for name in CANONICAL_SCENARIOS:
+            assert name.endswith(".yaml")
+
+
+# ===================================================================
+# VerifyResult
+# ===================================================================
+
+
+class TestVerifyResult:
+    def test_defaults(self):
+        r = VerifyResult(
+            scenario_id="s1",
+            bundle_dir="/tmp/b",
+            invariants_pass=True,
+            judge_status="pass",
+            judge_confidence=0.9,
+            overall_pass=True,
+        )
+        assert r.video_check_pass is None
+        assert r.notes == ""
+
+    def test_all_fields(self):
+        r = _make_result(
+            video_check_pass=True,
+            notes="some note",
+        )
+        assert r.scenario_id == "test_scenario"
+        assert r.video_check_pass is True
+        assert r.notes == "some note"
+
+
+# ===================================================================
+# _calculate_verification_stats
+# ===================================================================
+
+
+class TestCalculateVerificationStats:
+    def test_all_passing(self, all_pass_rows):
+        stats = _calculate_verification_stats(all_pass_rows)
+        assert stats["total_scenarios"] == 3
+        assert stats["passed_scenarios"] == 3
+        assert stats["failed_scenarios"] == 0
+        assert stats["success_rate"] == pytest.approx(100.0)
+        assert stats["needs_review"] == 0
+        assert stats["invariant_failures"] == 0
+        assert stats["judge_failures"] == 0
+
+    def test_mixed_results(self, mixed_rows):
+        stats = _calculate_verification_stats(mixed_rows)
+        assert stats["total_scenarios"] == 3
+        assert stats["passed_scenarios"] == 1
+        assert stats["failed_scenarios"] == 2
+        assert stats["success_rate"] == pytest.approx(100 / 3)
+        assert stats["needs_review"] == 1
+        assert stats["invariant_failures"] == 1
+        assert stats["judge_failures"] == 1
+
+    def test_empty_rows(self):
+        stats = _calculate_verification_stats([])
+        assert stats["total_scenarios"] == 0
+        assert stats["success_rate"] == 0
+
+
+# ===================================================================
+# _format_executive_summary
+# ===================================================================
+
+
+class TestFormatExecutiveSummary:
+    def test_all_pass_with_pytest_ok(self, all_pass_rows):
+        stats = _calculate_verification_stats(all_pass_rows)
+        lines = _format_executive_summary("quick", True, stats)
+        text = "\n".join(lines)
+        assert "PASS" in text
+        assert "All scenarios passed" in text
+
+    def test_all_pass_pytest_fail(self, all_pass_rows):
+        stats = _calculate_verification_stats(all_pass_rows)
+        lines = _format_executive_summary("quick", False, stats)
+        text = "\n".join(lines)
+        assert "test suite failed" in text.lower() or "FAIL" in text
+
+    def test_scenario_failures(self, mixed_rows):
+        stats = _calculate_verification_stats(mixed_rows)
+        lines = _format_executive_summary("full", True, stats)
+        text = "\n".join(lines)
+        assert "2 scenario(s) need attention" in text
+        assert "invariant violation" in text.lower()
+
+    def test_suite_name_in_title(self):
+        stats = _calculate_verification_stats([_make_result()])
+        lines = _format_executive_summary("smoke", True, stats)
+        text = "\n".join(lines)
+        assert "Smoke" in text
+
+
+# ===================================================================
+# _format_configuration_section
+# ===================================================================
+
+
+class TestFormatConfigurationSection:
+    def test_contains_threshold(self):
+        lines = _format_configuration_section("quick", {"judge_confidence_min": 0.6})
+        text = "\n".join(lines)
+        assert "0.6" in text
+        assert "quick" in text
+
+    def test_full_suite_mentions_artifacts(self):
+        lines = _format_configuration_section("full", {"judge_confidence_min": 0.5})
+        text = "\n".join(lines)
+        assert "full artifacts" in text or "full" in text
+
+
+# ===================================================================
+# _format_scenario_row
+# ===================================================================
+
+
+class TestFormatScenarioRow:
+    def test_passing_row(self):
+        row = _make_result(judge_confidence=0.9)
+        text = _format_scenario_row(row)
+        assert "test_scenario" in text
+        assert "Pass" in text
+        assert "0.90" in text
+
+    def test_failing_row_with_invariant_fail(self):
+        row = _make_result(invariants_pass=False, judge_status="fail", judge_confidence=0.15)
+        text = _format_scenario_row(row)
+        assert "Fail" in text
+        assert "0.15" in text
+
+    def test_confidence_indicators(self):
+        # Low confidence
+        row_low = _make_result(judge_confidence=0.2)
+        assert "🔴" in _format_scenario_row(row_low)
+
+        # Medium confidence
+        row_med = _make_result(judge_confidence=0.5)
+        assert "🟡" in _format_scenario_row(row_med)
+
+        # High confidence
+        row_high = _make_result(judge_confidence=0.9)
+        assert "🟢" in _format_scenario_row(row_high)
+
+    def test_video_status_none(self):
+        row = _make_result(video_check_pass=None)
+        text = _format_scenario_row(row)
+        assert "- |" in text or "-" in text
+
+    def test_video_pass_and_fail(self):
+        row_pass = _make_result(video_check_pass=True)
+        assert "Pass" in _format_scenario_row(row_pass)
+
+        row_fail = _make_result(video_check_pass=False)
+        assert "Fail" in _format_scenario_row(row_fail)
+
+    def test_notes_with_failed_prefix(self):
+        row = _make_result(notes="failed=collision_free,safety_constraints; fix=adjust radius")
+        text = _format_scenario_row(row)
+        assert "Failed:" in text
+
+    def test_notes_with_fix_prefix(self):
+        row = _make_result(notes="fix=increase agent radius to avoid collisions")
+        text = _format_scenario_row(row)
+        assert "Fix:" in text
+
+    def test_long_notes_truncated(self):
+        row = _make_result(notes="x" * 100)
+        text = _format_scenario_row(row)
+        assert "..." in text
+
+    def test_empty_notes(self):
+        row = _make_result(notes="")
+        text = _format_scenario_row(row)
+        assert "No issues" in text
+
+    def test_needs_human_review_status(self):
+        row = _make_result(judge_status="needs_human_review")
+        text = _format_scenario_row(row)
+        assert "⚠️" in text
+        assert "Needs Human Review" in text
+
+
+# ===================================================================
+# _format_scenario_results_table
+# ===================================================================
+
+
+class TestFormatScenarioResultsTable:
+    def test_table_header(self, all_pass_rows):
+        lines = _format_scenario_results_table(all_pass_rows)
+        text = "\n".join(lines)
+        assert "Scenario" in text
+        assert "Invariants" in text
+        assert "Judge" in text
+
+    def test_table_has_rows(self, all_pass_rows):
+        lines = _format_scenario_results_table(all_pass_rows)
+        # Header lines + separator + one row per scenario
+        row_lines = [line for line in lines if line.startswith("| **")]
+        assert len(row_lines) == 3
+
+
+# ===================================================================
+# _write_report
+# ===================================================================
+
+
+class TestWriteReport:
+    def test_writes_markdown_file(self, tmp_path, all_pass_rows):
+        report_path = tmp_path / "reports" / "REPORT.md"
+        _write_report(
+            report_path=report_path,
+            suite="quick",
+            pytest_ok=True,
+            pytest_out="3 passed",
+            rows=all_pass_rows,
+            thresholds={"judge_confidence_min": 0.6},
+            verify_root=tmp_path,
+        )
+        assert report_path.exists()
+        content = report_path.read_text()
+        assert "Quick" in content
+        assert "3 passed" in content
+
+    def test_report_with_failures(self, tmp_path, mixed_rows):
+        report_path = tmp_path / "REPORT.md"
+        _write_report(
+            report_path=report_path,
+            suite="full",
+            pytest_ok=False,
+            pytest_out="1 failed",
+            rows=mixed_rows,
+            thresholds={"judge_confidence_min": 0.6},
+            verify_root=tmp_path,
+        )
+        content = report_path.read_text()
+        assert "Failure Analysis" in content
+        assert "fail_invariant" in content
+        assert "needs_review" in content
+
+    def test_report_no_failures(self, tmp_path, all_pass_rows):
+        report_path = tmp_path / "REPORT.md"
+        _write_report(
+            report_path=report_path,
+            suite="smoke",
+            pytest_ok=True,
+            pytest_out="all passed",
+            rows=all_pass_rows,
+            thresholds={"judge_confidence_min": 0.5},
+            verify_root=tmp_path,
+        )
+        content = report_path.read_text()
+        assert "All scenarios passed" in content
+
+    def test_report_with_invariants_json(self, tmp_path):
+        """Test report generation when invariants.json exists for a failed scenario."""
+        bundle_dir = tmp_path / "bundle_fail"
+        bundle_dir.mkdir()
+        invariants_data = {
+            "overall_pass": False,
+            "checks": [
+                {"name": "collision_free", "pass": False, "severity": "critical", "num_violations": 5},
+                {"name": "speed_limit", "pass": False, "severity": "low", "message": "minor overshoot"},
+                {"name": "goal_reached", "pass": True},
+            ],
+        }
+        (bundle_dir / "invariants.json").write_text(json.dumps(invariants_data))
+
+        rows = [
+            _make_result(
+                scenario_id="inv_fail",
+                overall_pass=False,
+                invariants_pass=False,
+                bundle_dir=str(bundle_dir),
+            )
+        ]
+        report_path = tmp_path / "REPORT.md"
+        _write_report(
+            report_path=report_path,
+            suite="quick",
+            pytest_ok=True,
+            pytest_out="ok",
+            rows=rows,
+            thresholds={"judge_confidence_min": 0.6},
+            verify_root=tmp_path,
+        )
+        content = report_path.read_text()
+        assert "Invariant Analysis" in content
+        assert "Collision Free" in content
+        assert "Speed Limit" in content
+
+    def test_report_with_judge_json(self, tmp_path):
+        """Test report generation when judge.json exists with violations."""
+        bundle_dir = tmp_path / "bundle_judge"
+        bundle_dir.mkdir()
+        judge_data = {
+            "status": "fail",
+            "confidence": 0.4,
+            "violations": [
+                {"type": "unsafe_proximity", "severity": "high", "evidence": "Robot too close to human at step 42"},
+                {"type": "odd_trajectory", "severity": "medium", "evidence": "Zigzag pattern detected"},
+                {"type": "minor_wobble", "severity": "low", "evidence": "Slight oscillation observed"},
+            ],
+        }
+        (bundle_dir / "judge.json").write_text(json.dumps(judge_data))
+
+        rows = [
+            _make_result(
+                scenario_id="judge_fail",
+                overall_pass=False,
+                judge_status="fail",
+                judge_confidence=0.4,
+                bundle_dir=str(bundle_dir),
+            )
+        ]
+        report_path = tmp_path / "REPORT.md"
+        _write_report(
+            report_path=report_path,
+            suite="quick",
+            pytest_ok=True,
+            pytest_out="ok",
+            rows=rows,
+            thresholds={"judge_confidence_min": 0.6},
+            verify_root=tmp_path,
+        )
+        content = report_path.read_text()
+        assert "Visual Behavior Analysis" in content
+        assert "Unsafe Proximity" in content
+        assert "High Priority" in content
+
+    def test_report_video_check_fail(self, tmp_path):
+        rows = [
+            _make_result(
+                scenario_id="vid_fail",
+                overall_pass=False,
+                invariants_pass=False,
+                video_check_pass=False,
+                bundle_dir=str(tmp_path),
+            )
+        ]
+        report_path = tmp_path / "REPORT.md"
+        _write_report(
+            report_path=report_path,
+            suite="full",
+            pytest_ok=True,
+            pytest_out="ok",
+            rows=rows,
+            thresholds={"judge_confidence_min": 0.6},
+            verify_root=tmp_path,
+        )
+        content = report_path.read_text()
+        assert "Video Generation Issues" in content
+
+
+# ===================================================================
+# _scenario_file_path
+# ===================================================================
+
+
+class TestScenarioFilePath:
+    def test_returns_path_under_scenarios_library(self):
+        p = _scenario_file_path("hallway_pass.yaml")
+        assert p.name == "hallway_pass.yaml"
+        assert "scenarios" in str(p)
+        assert "library" in str(p)


### PR DESCRIPTION
## Summary
- Adds **32 tests** for `navirl/verify/runner.py` — covers `VerifyResult`, `_calculate_verification_stats`, `_format_executive_summary`, `_format_configuration_section`, `_format_scenario_row`, `_format_scenario_results_table`, `_write_report` (including invariants.json and judge.json integration), and `_scenario_file_path`
- Adds **36 tests** for `navirl/simulation/runner.py` — covers `SimulationRunner` construction, callbacks (pre/post step, episode end, progress, termination conditions), `run()` with max_steps/max_time, `run_async()`, snapshots/reset, `run_episodes()`, `run_parallel()`, `run_batch()`, and stats/accessors
- Adds **40 tests** for `navirl/training/callbacks.py` — covers `CallbackList` delegation, `EvalCallback` (eval frequency, model integration, callable env, best model save, old-style gym API), `CheckpointCallback`, `LoggingCallback`, `EarlyStoppingCallback`, `CurriculumCallback`, `SchedulerCallback`, `GradientMonitorCallback`, and `HyperparameterSearchCallback`

## Test plan
- [x] All 2937 tests pass (108 new + 2829 existing)
- [x] 100 skipped (PyTorch/gymnasium optional deps — expected)
- [x] Ruff linting passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)