### PR TITLE
test: add 95 tests for augmentation, aggregator, and human controller base

### DIFF
--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,291 @@
+"""Tests for navirl.experiments.aggregator — batch metrics aggregation."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from navirl.experiments.aggregator import (
+    BatchAggregator,
+    BatchSummary,
+    RunRecord,
+    ScenarioStats,
+    _compute_stats,
+    write_json_summary,
+    write_markdown_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# _compute_stats
+# ---------------------------------------------------------------------------
+
+
+class TestComputeStats:
+    def test_single_value(self):
+        stats = _compute_stats([5.0])
+        assert stats["mean"] == 5.0
+        assert stats["std"] == 0.0
+        assert stats["min"] == 5.0
+        assert stats["max"] == 5.0
+        assert stats["median"] == 5.0
+
+    def test_multiple_values(self):
+        stats = _compute_stats([1.0, 2.0, 3.0, 4.0, 5.0])
+        assert stats["mean"] == 3.0
+        assert stats["min"] == 1.0
+        assert stats["max"] == 5.0
+        assert stats["median"] == 3.0
+
+    def test_empty_returns_nan(self):
+        stats = _compute_stats([])
+        assert math.isnan(stats["mean"])
+        assert math.isnan(stats["min"])
+
+    def test_all_inf_returns_nan(self):
+        stats = _compute_stats([float("inf"), float("inf")])
+        assert math.isnan(stats["mean"])
+
+    def test_filters_inf_values(self):
+        stats = _compute_stats([1.0, float("inf"), 3.0])
+        assert stats["mean"] == 2.0
+        assert stats["min"] == 1.0
+        assert stats["max"] == 3.0
+
+    def test_filters_nan_values(self):
+        stats = _compute_stats([1.0, float("nan"), 3.0])
+        assert stats["mean"] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# RunRecord
+# ---------------------------------------------------------------------------
+
+
+class TestRunRecord:
+    def test_defaults(self):
+        rec = RunRecord(scenario="hallway", seed=42)
+        assert rec.scenario == "hallway"
+        assert rec.seed == 42
+        assert rec.status == "completed"
+        assert rec.error is None
+        assert rec.metrics == {}
+        assert rec.overrides == {}
+
+    def test_with_metrics(self):
+        rec = RunRecord(
+            scenario="crossing",
+            seed=1,
+            metrics={"success_rate": 1.0, "collisions_agent_agent": 0},
+        )
+        assert rec.metrics["success_rate"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# BatchAggregator
+# ---------------------------------------------------------------------------
+
+
+class TestBatchAggregator:
+    def _make_records(self) -> list[RunRecord]:
+        return [
+            RunRecord(
+                scenario="hallway",
+                seed=1,
+                metrics={"success_rate": 1.0, "collisions_agent_agent": 0, "path_length_robot": 5.0},
+            ),
+            RunRecord(
+                scenario="hallway",
+                seed=2,
+                metrics={"success_rate": 1.0, "collisions_agent_agent": 2, "path_length_robot": 6.0},
+            ),
+            RunRecord(
+                scenario="crossing",
+                seed=1,
+                metrics={"success_rate": 0.0, "collisions_agent_agent": 5, "path_length_robot": 10.0},
+            ),
+            RunRecord(
+                scenario="crossing",
+                seed=2,
+                status="failed",
+                error="timeout",
+            ),
+        ]
+
+    def test_add_records(self):
+        agg = BatchAggregator("test_batch")
+        records = self._make_records()
+        for r in records:
+            agg.add_record(r)
+        assert len(agg.records) == 4
+
+    def test_summarize_counts(self):
+        agg = BatchAggregator("test_batch")
+        for r in self._make_records():
+            agg.add_record(r)
+        summary = agg.summarize()
+        assert summary.total_runs == 4
+        assert summary.completed_runs == 3
+        assert summary.failed_runs == 1
+
+    def test_summarize_per_scenario(self):
+        agg = BatchAggregator("test_batch")
+        for r in self._make_records():
+            agg.add_record(r)
+        summary = agg.summarize()
+        assert len(summary.per_scenario) == 2
+        scenario_names = [s.scenario for s in summary.per_scenario]
+        assert "hallway" in scenario_names
+        assert "crossing" in scenario_names
+
+    def test_hallway_successes(self):
+        agg = BatchAggregator("test_batch")
+        for r in self._make_records():
+            agg.add_record(r)
+        summary = agg.summarize()
+        hallway = next(s for s in summary.per_scenario if s.scenario == "hallway")
+        assert hallway.num_runs == 2
+        assert hallway.num_successes == 2
+
+    def test_crossing_successes(self):
+        agg = BatchAggregator("test_batch")
+        for r in self._make_records():
+            agg.add_record(r)
+        summary = agg.summarize()
+        crossing = next(s for s in summary.per_scenario if s.scenario == "crossing")
+        assert crossing.num_runs == 1  # only completed runs
+        assert crossing.num_successes == 0
+
+    def test_global_metrics_computed(self):
+        agg = BatchAggregator("test_batch")
+        for r in self._make_records():
+            agg.add_record(r)
+        summary = agg.summarize()
+        assert "success_rate" in summary.global_metrics
+        assert "collisions_agent_agent" in summary.global_metrics
+        # 3 completed runs: success rates = [1, 1, 0]
+        np.testing.assert_allclose(
+            summary.global_metrics["success_rate"]["mean"],
+            2.0 / 3.0,
+            atol=1e-6,
+        )
+
+    def test_custom_metric_keys(self):
+        agg = BatchAggregator("test_batch")
+        for r in self._make_records():
+            agg.add_record(r)
+        summary = agg.summarize(metric_keys=["path_length_robot"])
+        assert "path_length_robot" in summary.global_metrics
+        assert "success_rate" not in summary.global_metrics
+
+    def test_empty_aggregator(self):
+        agg = BatchAggregator("empty")
+        summary = agg.summarize()
+        assert summary.total_runs == 0
+        assert summary.completed_runs == 0
+        assert summary.failed_runs == 0
+        assert summary.per_scenario == []
+
+    def test_template_name_propagated(self):
+        agg = BatchAggregator("my_template")
+        summary = agg.summarize()
+        assert summary.template_name == "my_template"
+
+    def test_timestamp_populated(self):
+        agg = BatchAggregator("test")
+        summary = agg.summarize()
+        assert summary.timestamp  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# BatchSummary.to_dict
+# ---------------------------------------------------------------------------
+
+
+class TestBatchSummaryToDict:
+    def test_serializable(self):
+        summary = BatchSummary(
+            template_name="test",
+            total_runs=2,
+            completed_runs=2,
+            failed_runs=0,
+            per_scenario=[
+                ScenarioStats(
+                    scenario="hallway",
+                    num_runs=2,
+                    num_successes=2,
+                    metrics={"success_rate": {"mean": 1.0, "std": 0.0, "min": 1.0, "max": 1.0, "median": 1.0}},
+                )
+            ],
+            global_metrics={"success_rate": {"mean": 1.0, "std": 0.0, "min": 1.0, "max": 1.0, "median": 1.0}},
+            timestamp="2026-01-01T00:00:00",
+        )
+        d = summary.to_dict()
+        # Should be JSON-serializable
+        json_str = json.dumps(d)
+        assert "hallway" in json_str
+        assert d["total_runs"] == 2
+        assert len(d["per_scenario"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Output writers
+# ---------------------------------------------------------------------------
+
+
+class TestWriters:
+    def _make_summary(self) -> BatchSummary:
+        return BatchSummary(
+            template_name="test_exp",
+            total_runs=3,
+            completed_runs=2,
+            failed_runs=1,
+            per_scenario=[
+                ScenarioStats(
+                    scenario="hallway",
+                    num_runs=2,
+                    num_successes=1,
+                    metrics={"success_rate": {"mean": 0.5, "std": 0.5, "min": 0.0, "max": 1.0, "median": 0.5}},
+                )
+            ],
+            global_metrics={"success_rate": {"mean": 0.5, "std": 0.5, "min": 0.0, "max": 1.0, "median": 0.5}},
+            timestamp="2026-01-01T00:00:00",
+        )
+
+    def test_write_json_summary(self, tmp_path: Path):
+        summary = self._make_summary()
+        out = tmp_path / "results" / "summary.json"
+        write_json_summary(summary, out)
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert data["template_name"] == "test_exp"
+        assert data["total_runs"] == 3
+
+    def test_write_markdown_summary(self, tmp_path: Path):
+        summary = self._make_summary()
+        out = tmp_path / "results" / "report.md"
+        write_markdown_summary(summary, out)
+        assert out.exists()
+        content = out.read_text()
+        assert "test_exp" in content
+        assert "hallway" in content
+        assert "| success_rate" in content
+
+    def test_write_markdown_empty_metrics(self, tmp_path: Path):
+        summary = BatchSummary(
+            template_name="empty",
+            total_runs=0,
+            completed_runs=0,
+            failed_runs=0,
+            per_scenario=[],
+            global_metrics={},
+        )
+        out = tmp_path / "report.md"
+        write_markdown_summary(summary, out)
+        assert out.exists()
+        content = out.read_text()
+        assert "empty" in content

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -1,0 +1,333 @@
+"""Tests for navirl.data.augmentation — trajectory augmentation functions."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from navirl.data.augmentation import (
+    AugmentationPipeline,
+    add_noise,
+    crop_trajectory,
+    mirror_trajectory,
+    rotate_trajectory,
+    scale_trajectory,
+    time_warp,
+)
+from navirl.data.trajectory import Trajectory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_trajectory(n: int = 10, with_velocities: bool = True) -> Trajectory:
+    """Create a simple straight-line trajectory for testing."""
+    ts = np.linspace(0.0, 1.0, n)
+    positions = np.column_stack([ts, ts * 2.0])  # diagonal line
+    velocities = np.ones((n, 2)) * np.array([1.0, 2.0]) if with_velocities else None
+    return Trajectory(timestamps=ts, positions=positions, velocities=velocities, agent_id="test")
+
+
+# ---------------------------------------------------------------------------
+# rotate_trajectory
+# ---------------------------------------------------------------------------
+
+
+class TestRotateTrajectory:
+    def test_identity_rotation(self):
+        traj = _make_trajectory()
+        result = rotate_trajectory(traj, 0.0)
+        np.testing.assert_allclose(result.positions, traj.positions, atol=1e-12)
+
+    def test_90_degree_rotation(self):
+        traj = _make_trajectory()
+        result = rotate_trajectory(traj, math.pi / 2)
+        # After 90° CCW: (x, y) -> (-y, x)
+        np.testing.assert_allclose(result.positions[:, 0], -traj.positions[:, 1], atol=1e-12)
+        np.testing.assert_allclose(result.positions[:, 1], traj.positions[:, 0], atol=1e-12)
+
+    def test_180_degree_rotation(self):
+        traj = _make_trajectory()
+        result = rotate_trajectory(traj, math.pi)
+        np.testing.assert_allclose(result.positions, -traj.positions, atol=1e-12)
+
+    def test_rotates_velocities(self):
+        traj = _make_trajectory(with_velocities=True)
+        result = rotate_trajectory(traj, math.pi / 2)
+        np.testing.assert_allclose(result.velocities[:, 0], -traj.velocities[:, 1], atol=1e-12)
+        np.testing.assert_allclose(result.velocities[:, 1], traj.velocities[:, 0], atol=1e-12)
+
+    def test_no_velocities(self):
+        traj = _make_trajectory(with_velocities=False)
+        result = rotate_trajectory(traj, math.pi / 4)
+        assert result.velocities is None
+
+    def test_preserves_timestamps(self):
+        traj = _make_trajectory()
+        result = rotate_trajectory(traj, 0.5)
+        np.testing.assert_array_equal(result.timestamps, traj.timestamps)
+
+    def test_preserves_agent_id(self):
+        traj = _make_trajectory()
+        result = rotate_trajectory(traj, 0.5)
+        assert result.agent_id == traj.agent_id
+
+    def test_full_rotation_returns_to_original(self):
+        traj = _make_trajectory()
+        result = rotate_trajectory(traj, 2 * math.pi)
+        np.testing.assert_allclose(result.positions, traj.positions, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# mirror_trajectory
+# ---------------------------------------------------------------------------
+
+
+class TestMirrorTrajectory:
+    def test_mirror_x_flips_y(self):
+        traj = _make_trajectory()
+        result = mirror_trajectory(traj, axis="x")
+        np.testing.assert_allclose(result.positions[:, 0], traj.positions[:, 0])
+        np.testing.assert_allclose(result.positions[:, 1], -traj.positions[:, 1])
+
+    def test_mirror_y_flips_x(self):
+        traj = _make_trajectory()
+        result = mirror_trajectory(traj, axis="y")
+        np.testing.assert_allclose(result.positions[:, 0], -traj.positions[:, 0])
+        np.testing.assert_allclose(result.positions[:, 1], traj.positions[:, 1])
+
+    def test_mirror_velocities_x(self):
+        traj = _make_trajectory(with_velocities=True)
+        result = mirror_trajectory(traj, axis="x")
+        np.testing.assert_allclose(result.velocities[:, 0], traj.velocities[:, 0])
+        np.testing.assert_allclose(result.velocities[:, 1], -traj.velocities[:, 1])
+
+    def test_mirror_velocities_y(self):
+        traj = _make_trajectory(with_velocities=True)
+        result = mirror_trajectory(traj, axis="y")
+        np.testing.assert_allclose(result.velocities[:, 0], -traj.velocities[:, 0])
+        np.testing.assert_allclose(result.velocities[:, 1], traj.velocities[:, 1])
+
+    def test_no_velocities(self):
+        traj = _make_trajectory(with_velocities=False)
+        result = mirror_trajectory(traj, axis="x")
+        assert result.velocities is None
+
+    def test_invalid_axis_raises(self):
+        traj = _make_trajectory()
+        with pytest.raises(ValueError, match="axis must be"):
+            mirror_trajectory(traj, axis="z")
+
+    def test_double_mirror_returns_original(self):
+        traj = _make_trajectory()
+        result = mirror_trajectory(mirror_trajectory(traj, "x"), "x")
+        np.testing.assert_allclose(result.positions, traj.positions)
+
+
+# ---------------------------------------------------------------------------
+# scale_trajectory
+# ---------------------------------------------------------------------------
+
+
+class TestScaleTrajectory:
+    def test_scale_by_one(self):
+        traj = _make_trajectory()
+        result = scale_trajectory(traj, 1.0)
+        np.testing.assert_allclose(result.positions, traj.positions)
+
+    def test_scale_doubles_positions(self):
+        traj = _make_trajectory()
+        result = scale_trajectory(traj, 2.0)
+        np.testing.assert_allclose(result.positions, traj.positions * 2.0)
+
+    def test_scale_velocities(self):
+        traj = _make_trajectory(with_velocities=True)
+        result = scale_trajectory(traj, 3.0)
+        np.testing.assert_allclose(result.velocities, traj.velocities * 3.0)
+
+    def test_scale_no_velocities(self):
+        traj = _make_trajectory(with_velocities=False)
+        result = scale_trajectory(traj, 2.0)
+        assert result.velocities is None
+
+    def test_scale_by_zero(self):
+        traj = _make_trajectory()
+        result = scale_trajectory(traj, 0.0)
+        np.testing.assert_allclose(result.positions, np.zeros_like(traj.positions))
+
+
+# ---------------------------------------------------------------------------
+# add_noise
+# ---------------------------------------------------------------------------
+
+
+class TestAddNoise:
+    def test_zero_noise_preserves(self):
+        traj = _make_trajectory()
+        result = add_noise(traj, std=0.0, seed=42)
+        np.testing.assert_allclose(result.positions, traj.positions, atol=1e-12)
+
+    def test_noise_changes_positions(self):
+        traj = _make_trajectory()
+        result = add_noise(traj, std=1.0, seed=42)
+        assert not np.allclose(result.positions, traj.positions)
+
+    def test_noise_is_reproducible(self):
+        traj = _make_trajectory()
+        r1 = add_noise(traj, std=0.5, seed=123)
+        r2 = add_noise(traj, std=0.5, seed=123)
+        np.testing.assert_array_equal(r1.positions, r2.positions)
+
+    def test_noise_preserves_velocities(self):
+        traj = _make_trajectory(with_velocities=True)
+        result = add_noise(traj, std=0.1, seed=0)
+        np.testing.assert_array_equal(result.velocities, traj.velocities)
+
+    def test_noise_preserves_timestamps(self):
+        traj = _make_trajectory()
+        result = add_noise(traj, std=0.1, seed=0)
+        np.testing.assert_array_equal(result.timestamps, traj.timestamps)
+
+
+# ---------------------------------------------------------------------------
+# time_warp
+# ---------------------------------------------------------------------------
+
+
+class TestTimeWarp:
+    def test_identity_warp(self):
+        traj = _make_trajectory()
+        result = time_warp(traj, factor=1.0)
+        np.testing.assert_allclose(result.timestamps, traj.timestamps)
+
+    def test_slowdown(self):
+        traj = _make_trajectory()
+        result = time_warp(traj, factor=2.0)
+        # Duration should double
+        original_duration = traj.timestamps[-1] - traj.timestamps[0]
+        new_duration = result.timestamps[-1] - result.timestamps[0]
+        np.testing.assert_allclose(new_duration, original_duration * 2.0)
+
+    def test_speedup(self):
+        traj = _make_trajectory()
+        result = time_warp(traj, factor=0.5)
+        original_duration = traj.timestamps[-1] - traj.timestamps[0]
+        new_duration = result.timestamps[-1] - result.timestamps[0]
+        np.testing.assert_allclose(new_duration, original_duration * 0.5)
+
+    def test_velocities_scaled_inversely(self):
+        traj = _make_trajectory(with_velocities=True)
+        factor = 2.0
+        result = time_warp(traj, factor=factor)
+        np.testing.assert_allclose(result.velocities, traj.velocities / factor)
+
+    def test_no_velocities(self):
+        traj = _make_trajectory(with_velocities=False)
+        result = time_warp(traj, factor=2.0)
+        assert result.velocities is None
+
+    def test_positions_preserved(self):
+        traj = _make_trajectory()
+        result = time_warp(traj, factor=2.0)
+        np.testing.assert_allclose(result.positions, traj.positions)
+
+    def test_zero_factor_raises(self):
+        traj = _make_trajectory()
+        with pytest.raises(ValueError, match="factor must be positive"):
+            time_warp(traj, factor=0.0)
+
+    def test_negative_factor_raises(self):
+        traj = _make_trajectory()
+        with pytest.raises(ValueError, match="factor must be positive"):
+            time_warp(traj, factor=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# crop_trajectory
+# ---------------------------------------------------------------------------
+
+
+class TestCropTrajectory:
+    def test_crop_middle(self):
+        traj = _make_trajectory(n=10)
+        result = crop_trajectory(traj, 2, 7)
+        assert len(result) == 5
+        np.testing.assert_allclose(result.timestamps, traj.timestamps[2:7])
+        np.testing.assert_allclose(result.positions, traj.positions[2:7])
+
+    def test_crop_full(self):
+        traj = _make_trajectory(n=10)
+        result = crop_trajectory(traj, 0, 10)
+        assert len(result) == 10
+        np.testing.assert_allclose(result.positions, traj.positions)
+
+    def test_crop_velocities(self):
+        traj = _make_trajectory(n=10, with_velocities=True)
+        result = crop_trajectory(traj, 3, 8)
+        np.testing.assert_allclose(result.velocities, traj.velocities[3:8])
+
+    def test_crop_no_velocities(self):
+        traj = _make_trajectory(n=10, with_velocities=False)
+        result = crop_trajectory(traj, 1, 5)
+        assert result.velocities is None
+
+    def test_crop_preserves_agent_id(self):
+        traj = _make_trajectory(n=10)
+        result = crop_trajectory(traj, 0, 5)
+        assert result.agent_id == traj.agent_id
+
+
+# ---------------------------------------------------------------------------
+# AugmentationPipeline
+# ---------------------------------------------------------------------------
+
+
+class TestAugmentationPipeline:
+    def test_empty_pipeline(self):
+        pipe = AugmentationPipeline()
+        traj = _make_trajectory()
+        result = pipe(traj)
+        np.testing.assert_allclose(result.positions, traj.positions)
+
+    def test_single_transform(self):
+        pipe = AugmentationPipeline()
+        pipe.add(lambda t: scale_trajectory(t, 2.0))
+        traj = _make_trajectory()
+        result = pipe(traj)
+        np.testing.assert_allclose(result.positions, traj.positions * 2.0)
+
+    def test_chained_transforms(self):
+        traj = _make_trajectory()
+        pipe = AugmentationPipeline()
+        pipe.add(lambda t: scale_trajectory(t, 2.0)).add(lambda t: scale_trajectory(t, 3.0))
+        result = pipe(traj)
+        np.testing.assert_allclose(result.positions, traj.positions * 6.0)
+
+    def test_len(self):
+        pipe = AugmentationPipeline()
+        assert len(pipe) == 0
+        pipe.add(lambda t: t)
+        assert len(pipe) == 1
+        pipe.add(lambda t: t)
+        assert len(pipe) == 2
+
+    def test_init_with_transforms(self):
+        transforms = [
+            lambda t: scale_trajectory(t, 2.0),
+            lambda t: mirror_trajectory(t, "x"),
+        ]
+        pipe = AugmentationPipeline(transforms=transforms)
+        assert len(pipe) == 2
+
+    def test_compose_rotate_and_mirror(self):
+        traj = _make_trajectory()
+        pipe = AugmentationPipeline()
+        pipe.add(lambda t: rotate_trajectory(t, math.pi))
+        pipe.add(lambda t: mirror_trajectory(t, "x"))
+        result = pipe(traj)
+        # pi rotation: (x,y)->(-x,-y), then mirror x: (-x,-y)->(-x,y)
+        np.testing.assert_allclose(result.positions[:, 0], -traj.positions[:, 0], atol=1e-12)
+        np.testing.assert_allclose(result.positions[:, 1], traj.positions[:, 1], atol=1e-12)

--- a/tests/test_human_base.py
+++ b/tests/test_human_base.py
@@ -1,0 +1,204 @@
+"""Tests for navirl.humans.base — HumanController ABC validation logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from navirl.core.types import Action
+from navirl.humans.base import HumanController
+
+
+# ---------------------------------------------------------------------------
+# Concrete subclass for testing the ABC
+# ---------------------------------------------------------------------------
+
+
+class _StubController(HumanController):
+    """Minimal concrete implementation for testing base class validation."""
+
+    def reset(self, human_ids, starts, goals, backend=None):
+        super().reset(human_ids, starts, goals, backend)
+
+    def step(self, step, time_s, dt, states, robot_id, emit_event):
+        super().step(step, time_s, dt, states, robot_id, emit_event)
+        return {}
+
+
+def _noop_emit(event_type, agent_id, payload):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Reset validation
+# ---------------------------------------------------------------------------
+
+
+class TestHumanControllerReset:
+    def test_valid_reset(self):
+        ctrl = _StubController(cfg={})
+        ctrl.reset([1, 2], {1: (0.0, 0.0), 2: (1.0, 1.0)}, {1: (5.0, 5.0), 2: (6.0, 6.0)})
+
+    def test_non_list_human_ids_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="human_ids must be a list"):
+            ctrl.reset((1, 2), {1: (0.0, 0.0), 2: (1.0, 1.0)}, {1: (5.0, 5.0), 2: (6.0, 6.0)})
+
+    def test_non_int_ids_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="All human_ids must be integers"):
+            ctrl.reset(["a"], {"a": (0.0, 0.0)}, {"a": (5.0, 5.0)})
+
+    def test_missing_start_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Missing start position"):
+            ctrl.reset([1, 2], {1: (0.0, 0.0)}, {1: (5.0, 5.0), 2: (6.0, 6.0)})
+
+    def test_missing_goal_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Missing goal position"):
+            ctrl.reset([1], {1: (0.0, 0.0)}, {})
+
+    def test_invalid_start_too_short(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Invalid start position"):
+            ctrl.reset([1], {1: (0.0,)}, {1: (5.0, 5.0)})
+
+    def test_invalid_goal_not_tuple(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Invalid goal position"):
+            ctrl.reset([1], {1: (0.0, 0.0)}, {1: 5.0})
+
+    def test_empty_human_ids_ok(self):
+        ctrl = _StubController(cfg={})
+        ctrl.reset([], {}, {})
+
+    def test_list_start_accepted(self):
+        ctrl = _StubController(cfg={})
+        ctrl.reset([1], {1: [0.0, 0.0]}, {1: [5.0, 5.0]})
+
+
+# ---------------------------------------------------------------------------
+# Step validation
+# ---------------------------------------------------------------------------
+
+
+class TestHumanControllerStep:
+    def test_negative_step_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Step must be non-negative"):
+            ctrl.step(-1, 0.0, 0.1, {}, 0, _noop_emit)
+
+    def test_negative_time_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Time must be non-negative"):
+            ctrl.step(0, -1.0, 0.1, {}, 0, _noop_emit)
+
+    def test_zero_dt_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Time step must be positive"):
+            ctrl.step(0, 0.0, 0.0, {}, 0, _noop_emit)
+
+    def test_negative_dt_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="Time step must be positive"):
+            ctrl.step(0, 0.0, -0.1, {}, 0, _noop_emit)
+
+    def test_non_dict_states_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="States must be a dictionary"):
+            ctrl.step(0, 0.0, 0.1, [], 0, _noop_emit)
+
+    def test_non_callable_emit_raises(self):
+        ctrl = _StubController(cfg={})
+        with pytest.raises(ValueError, match="emit_event must be callable"):
+            ctrl.step(0, 0.0, 0.1, {}, 0, "not_callable")
+
+    def test_valid_step_returns(self):
+        ctrl = _StubController(cfg={})
+        result = ctrl.step(0, 0.0, 0.1, {}, 0, _noop_emit)
+        assert result == {}
+
+    def test_step_zero_ok(self):
+        ctrl = _StubController(cfg={})
+        ctrl.step(0, 0.0, 0.01, {}, 0, _noop_emit)
+
+    def test_step_large_values_ok(self):
+        ctrl = _StubController(cfg={})
+        ctrl.step(100000, 9999.0, 0.01, {}, 0, _noop_emit)
+
+
+# ---------------------------------------------------------------------------
+# validate_action
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAction:
+    def test_valid_action_unchanged(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=1.0, pref_vy=0.5, behavior="GO_TO")
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vx == 1.0
+        assert result.pref_vy == 0.5
+        assert result.behavior == "GO_TO"
+
+    def test_non_action_returns_stop(self):
+        ctrl = _StubController(cfg={})
+        result = ctrl.validate_action(1, "not_an_action")
+        assert result.pref_vx == 0.0
+        assert result.pref_vy == 0.0
+        assert result.behavior == "STOP"
+
+    def test_none_returns_stop(self):
+        ctrl = _StubController(cfg={})
+        result = ctrl.validate_action(1, None)
+        assert result.behavior == "STOP"
+
+    def test_dict_returns_stop(self):
+        ctrl = _StubController(cfg={})
+        result = ctrl.validate_action(1, {"vx": 1.0})
+        assert result.behavior == "STOP"
+
+    def test_clamps_excessive_positive_vx(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=10.0, pref_vy=0.0)
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vx == 5.0
+
+    def test_clamps_excessive_negative_vx(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=-10.0, pref_vy=0.0)
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vx == -5.0
+
+    def test_clamps_excessive_positive_vy(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=0.0, pref_vy=7.0)
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vy == 5.0
+
+    def test_clamps_excessive_negative_vy(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=0.0, pref_vy=-8.0)
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vy == -5.0
+
+    def test_within_bounds_not_clamped(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=3.0, pref_vy=-2.0)
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vx == 3.0
+        assert result.pref_vy == -2.0
+
+    def test_exactly_at_max_not_clamped(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=5.0, pref_vy=-5.0)
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vx == 5.0
+        assert result.pref_vy == -5.0
+
+    def test_zero_velocity_ok(self):
+        ctrl = _StubController(cfg={})
+        action = Action(pref_vx=0.0, pref_vy=0.0)
+        result = ctrl.validate_action(1, action)
+        assert result.pref_vx == 0.0
+        assert result.pref_vy == 0.0


### PR DESCRIPTION
## Summary
- Add 45 tests for `navirl/data/augmentation.py` (0% → covered): rotation, mirror, scale, noise, time warp, crop, and AugmentationPipeline
- Add 21 tests for `navirl/experiments/aggregator.py` (0% → covered): _compute_stats, RunRecord, BatchAggregator.summarize, BatchSummary.to_dict, JSON/Markdown output writers
- Add 29 tests for `navirl/humans/base.py` (27% → covered): reset() input validation (types, missing positions, format), step() input validation (bounds, types), and validate_action() clamping logic

All 3349 tests pass (95 new + 3254 existing), 102 skipped (PyTorch/gymnasium optional deps).

## Test plan
- [x] All new tests pass in isolation (`pytest tests/test_augmentation.py tests/test_aggregator.py tests/test_human_base.py`)
- [x] Full test suite passes (`3349 passed, 102 skipped`)
- [x] No existing tests modified or removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)