### PR TITLE
test: add 233 tests for loggers and env wrappers

### DIFF
--- a/tests/test_tensorboard_logger.py
+++ b/tests/test_tensorboard_logger.py
@@ -1,0 +1,783 @@
+"""Tests for navirl.logging.tensorboard_logger module.
+
+Covers is_tensorboard_available, StepTracker, MetricGroup, TBLogger,
+and create_tb_logger factory. TensorBoard dependency is mocked since it
+is not installed in the test environment.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# We import the module (not from it) so we can monkeypatch _TB_AVAILABLE
+import navirl.logging.tensorboard_logger as tb_mod
+from navirl.logging.tensorboard_logger import (
+    MetricGroup,
+    StepTracker,
+    TBLogger,
+    create_tb_logger,
+    is_tensorboard_available,
+)
+
+# ===================================================================
+# Helpers / Fixtures
+# ===================================================================
+
+
+@pytest.fixture()
+def mock_writer():
+    """Return a fresh MagicMock that stands in for SummaryWriter."""
+    writer = MagicMock(name="SummaryWriter")
+    return writer
+
+
+@pytest.fixture()
+def _enable_tb(monkeypatch):
+    """Monkeypatch _TB_AVAILABLE to True for the duration of a test."""
+    monkeypatch.setattr(tb_mod, "_TB_AVAILABLE", True)
+
+
+@pytest.fixture()
+def _disable_tb(monkeypatch):
+    """Monkeypatch _TB_AVAILABLE to False for the duration of a test."""
+    monkeypatch.setattr(tb_mod, "_TB_AVAILABLE", False)
+
+
+@pytest.fixture()
+def enabled_logger(tmp_path, mock_writer, _enable_tb, monkeypatch):
+    """Return an enabled TBLogger with a mocked SummaryWriter."""
+    monkeypatch.setattr(tb_mod, "SummaryWriter", lambda **kw: mock_writer)
+    logger = TBLogger(log_dir=tmp_path, enabled=True)
+    yield logger
+    if not logger.is_closed:
+        logger.close()
+
+
+@pytest.fixture()
+def disabled_logger(tmp_path, _disable_tb):
+    """Return a disabled TBLogger (no writer created)."""
+    logger = TBLogger(log_dir=tmp_path, enabled=False)
+    yield logger
+    if not logger.is_closed:
+        logger.close()
+
+
+# ===================================================================
+# is_tensorboard_available tests
+# ===================================================================
+
+
+class TestIsTensorboardAvailable:
+    def test_returns_true_when_available(self, _enable_tb):
+        assert is_tensorboard_available() is True
+
+    def test_returns_false_when_unavailable(self, _disable_tb):
+        assert is_tensorboard_available() is False
+
+
+# ===================================================================
+# StepTracker tests
+# ===================================================================
+
+
+class TestStepTracker:
+    def test_initial_step_default(self):
+        tracker = StepTracker()
+        assert tracker.global_step == 0
+
+    def test_initial_step_custom(self):
+        tracker = StepTracker(initial_step=42)
+        assert tracker.global_step == 42
+
+    def test_increment_default(self):
+        tracker = StepTracker()
+        result = tracker.increment()
+        assert result == 1
+        assert tracker.global_step == 1
+
+    def test_increment_by_n(self):
+        tracker = StepTracker(initial_step=10)
+        result = tracker.increment(5)
+        assert result == 15
+
+    def test_set(self):
+        tracker = StepTracker()
+        tracker.set(99)
+        assert tracker.global_step == 99
+
+    def test_get_global(self):
+        tracker = StepTracker(initial_step=7)
+        assert tracker.get() == 7
+        assert tracker.get(None) == 7
+
+    def test_get_tag_falls_back_to_global(self):
+        tracker = StepTracker(initial_step=5)
+        assert tracker.get("unknown_tag") == 5
+
+    def test_increment_tag(self):
+        tracker = StepTracker()
+        result = tracker.increment_tag("eval")
+        assert result == 1
+        result = tracker.increment_tag("eval", 3)
+        assert result == 4
+
+    def test_set_tag(self):
+        tracker = StepTracker()
+        tracker.set_tag("eval", 50)
+        assert tracker.get("eval") == 50
+
+    def test_tag_independent_of_global(self):
+        tracker = StepTracker(initial_step=100)
+        tracker.increment_tag("eval")
+        assert tracker.global_step == 100
+        assert tracker.get("eval") == 1
+
+
+# ===================================================================
+# MetricGroup tests
+# ===================================================================
+
+
+class TestMetricGroup:
+    def test_tag_prefixing(self, enabled_logger):
+        grp = MetricGroup(enabled_logger, "train/")
+        assert grp._tag("loss") == "train/loss"
+
+    def test_tag_prefix_strips_trailing_slash(self, enabled_logger):
+        grp = MetricGroup(enabled_logger, "train/")
+        assert grp._prefix == "train"
+
+    def test_scalar_delegates(self, enabled_logger, mock_writer):
+        grp = MetricGroup(enabled_logger, "train")
+        grp.scalar("loss", 0.5, step=10)
+        mock_writer.add_scalar.assert_called_once()
+        call_kw = mock_writer.add_scalar.call_args
+        assert call_kw.kwargs["tag"] == "train/loss"
+
+    def test_scalars_delegates(self, enabled_logger, mock_writer):
+        grp = MetricGroup(enabled_logger, "eval")
+        grp.scalars("rewards", {"mean": 1.0, "std": 0.1}, step=5)
+        mock_writer.add_scalars.assert_called_once()
+        call_kw = mock_writer.add_scalars.call_args
+        assert call_kw.kwargs["main_tag"] == "eval/rewards"
+
+    def test_histogram_delegates(self, enabled_logger, mock_writer):
+        grp = MetricGroup(enabled_logger, "debug")
+        grp.histogram("activations", np.array([1.0, 2.0, 3.0]), step=1)
+        mock_writer.add_histogram.assert_called_once()
+
+
+# ===================================================================
+# TBLogger construction tests
+# ===================================================================
+
+
+class TestTBLoggerConstruction:
+    def test_enabled_creates_writer(self, enabled_logger, mock_writer):
+        assert enabled_logger.enabled is True
+        assert enabled_logger._writer is mock_writer
+
+    def test_disabled_no_writer(self, disabled_logger):
+        assert disabled_logger.enabled is False
+        assert disabled_logger._writer is None
+
+    def test_experiment_name_subdir(self, tmp_path, mock_writer, _enable_tb, monkeypatch):
+        monkeypatch.setattr(tb_mod, "SummaryWriter", lambda **kw: mock_writer)
+        logger = TBLogger(log_dir=tmp_path, experiment_name="run_01")
+        assert (tmp_path / "run_01").is_dir()
+        logger.close()
+
+    def test_enabled_true_but_tb_unavailable_raises(self, tmp_path, _disable_tb):
+        with pytest.raises(ImportError, match="TensorBoard is not installed"):
+            TBLogger(log_dir=tmp_path, enabled=True)
+
+
+# ===================================================================
+# TBLogger properties tests
+# ===================================================================
+
+
+class TestTBLoggerProperties:
+    def test_global_step_getter_setter(self, enabled_logger):
+        assert enabled_logger.global_step == 0
+        enabled_logger.global_step = 42
+        assert enabled_logger.global_step == 42
+
+    def test_log_dir(self, enabled_logger, tmp_path):
+        assert enabled_logger.log_dir == tmp_path
+
+    def test_step_tracker(self, enabled_logger):
+        assert isinstance(enabled_logger.step_tracker, StepTracker)
+
+    def test_is_closed_initially_false(self, enabled_logger):
+        assert enabled_logger.is_closed is False
+
+
+# ===================================================================
+# Context manager tests
+# ===================================================================
+
+
+class TestTBLoggerContextManager:
+    def test_enter_returns_self(self, enabled_logger):
+        with enabled_logger as lg:
+            assert lg is enabled_logger
+
+    def test_exit_closes(self, tmp_path, mock_writer, _enable_tb, monkeypatch):
+        monkeypatch.setattr(tb_mod, "SummaryWriter", lambda **kw: mock_writer)
+        with TBLogger(log_dir=tmp_path) as lg:
+            pass
+        assert lg.is_closed is True
+        mock_writer.close.assert_called_once()
+
+
+# ===================================================================
+# add_scalar tests
+# ===================================================================
+
+
+class TestAddScalar:
+    def test_explicit_step(self, enabled_logger, mock_writer):
+        enabled_logger.add_scalar("train/loss", 0.5, step=10)
+        mock_writer.add_scalar.assert_called_once_with(
+            tag="train/loss", scalar_value=0.5, global_step=10
+        )
+
+    def test_default_step_uses_global(self, enabled_logger, mock_writer):
+        enabled_logger.global_step = 7
+        enabled_logger.add_scalar("train/loss", 0.3)
+        call_kw = mock_writer.add_scalar.call_args.kwargs
+        assert call_kw["global_step"] == 7
+
+    def test_wall_time(self, enabled_logger, mock_writer):
+        enabled_logger.add_scalar("x", 1.0, step=0, wall_time=123.0)
+        call_kw = mock_writer.add_scalar.call_args.kwargs
+        assert call_kw["walltime"] == 123.0
+
+    def test_disabled_noop(self, disabled_logger):
+        # Should not raise
+        disabled_logger.add_scalar("x", 1.0, step=0)
+
+    def test_caches_value(self, enabled_logger):
+        enabled_logger.add_scalar("m", 1.0, step=0)
+        enabled_logger.add_scalar("m", 2.0, step=1)
+        history = enabled_logger.get_scalar_history("m")
+        assert history == [(0, 1.0), (1, 2.0)]
+
+
+# ===================================================================
+# add_scalars tests
+# ===================================================================
+
+
+class TestAddScalars:
+    def test_basic(self, enabled_logger, mock_writer):
+        vals = {"a": 1.0, "b": 2.0}
+        enabled_logger.add_scalars("chart", vals, step=5)
+        mock_writer.add_scalars.assert_called_once()
+        kw = mock_writer.add_scalars.call_args.kwargs
+        assert kw["main_tag"] == "chart"
+        assert kw["tag_scalar_dict"] == vals
+        assert kw["global_step"] == 5
+
+    def test_with_wall_time(self, enabled_logger, mock_writer):
+        enabled_logger.add_scalars("c", {"x": 1.0}, step=0, wall_time=99.0)
+        kw = mock_writer.add_scalars.call_args.kwargs
+        assert kw["walltime"] == 99.0
+
+    def test_disabled_noop(self, disabled_logger):
+        disabled_logger.add_scalars("c", {"x": 1.0}, step=0)
+
+
+# ===================================================================
+# log_training_step tests
+# ===================================================================
+
+
+class TestLogTrainingStep:
+    def test_loss_only(self, enabled_logger, mock_writer):
+        enabled_logger.log_training_step(step=1, loss=0.5)
+        mock_writer.add_scalar.assert_called_once()
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "train/loss"
+
+    def test_all_optional_params(self, enabled_logger, mock_writer):
+        enabled_logger.log_training_step(
+            step=2, loss=0.4, lr=1e-3, grad_norm=0.1, extra={"acc": 0.9}
+        )
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "train/loss" in tags
+        assert "train/learning_rate" in tags
+        assert "train/grad_norm" in tags
+        assert "train/acc" in tags
+
+
+# ===================================================================
+# log_loss_components tests
+# ===================================================================
+
+
+class TestLogLossComponents:
+    def test_components_and_total(self, enabled_logger, mock_writer):
+        enabled_logger.log_loss_components(step=1, components={"ce": 0.3, "kl": 0.2})
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "loss/ce" in tags
+        assert "loss/kl" in tags
+        assert "loss/total" in tags
+        # Verify total value
+        total_call = next(
+            c for c in mock_writer.add_scalar.call_args_list if c.kwargs["tag"] == "loss/total"
+        )
+        assert total_call.kwargs["scalar_value"] == pytest.approx(0.5)
+
+    def test_custom_prefix(self, enabled_logger, mock_writer):
+        enabled_logger.log_loss_components(step=1, components={"a": 1.0}, prefix="my_loss")
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "my_loss/a" in tags
+        assert "my_loss/total" in tags
+
+
+# ===================================================================
+# log_learning_rate_schedule tests
+# ===================================================================
+
+
+class TestLogLearningRateSchedule:
+    def test_default_tag(self, enabled_logger, mock_writer):
+        enabled_logger.log_learning_rate_schedule(step=5, lr=0.001)
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "schedule/learning_rate"
+        assert kw["scalar_value"] == 0.001
+
+    def test_custom_tag(self, enabled_logger, mock_writer):
+        enabled_logger.log_learning_rate_schedule(step=5, lr=0.01, tag="lr/custom")
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "lr/custom"
+
+
+# ===================================================================
+# log_evaluation tests
+# ===================================================================
+
+
+class TestLogEvaluation:
+    def test_basic(self, enabled_logger, mock_writer):
+        enabled_logger.log_evaluation(step=10, metrics={"acc": 0.95, "f1": 0.9})
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "eval/acc" in tags
+        assert "eval/f1" in tags
+
+    def test_custom_prefix(self, enabled_logger, mock_writer):
+        enabled_logger.log_evaluation(step=1, metrics={"x": 1.0}, prefix="test")
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "test/x"
+
+
+# ===================================================================
+# log_episode_summary tests
+# ===================================================================
+
+
+class TestLogEpisodeSummary:
+    def test_basic(self, enabled_logger, mock_writer):
+        enabled_logger.log_episode_summary(episode=1, reward=10.0, length=100)
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "episode/reward" in tags
+        assert "episode/length" in tags
+        assert len(mock_writer.add_scalar.call_args_list) == 2
+
+    def test_with_success(self, enabled_logger, mock_writer):
+        enabled_logger.log_episode_summary(episode=1, reward=10.0, length=50, success=True)
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "episode/success" in tags
+        success_call = next(
+            c for c in mock_writer.add_scalar.call_args_list if c.kwargs["tag"] == "episode/success"
+        )
+        assert success_call.kwargs["scalar_value"] == 1.0
+
+    def test_with_extra(self, enabled_logger, mock_writer):
+        enabled_logger.log_episode_summary(
+            episode=2, reward=5.0, length=20, extra={"collision": 0.1}
+        )
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "episode/collision" in tags
+
+    def test_success_false(self, enabled_logger, mock_writer):
+        enabled_logger.log_episode_summary(episode=3, reward=0.0, length=10, success=False)
+        success_call = next(
+            c for c in mock_writer.add_scalar.call_args_list if c.kwargs["tag"] == "episode/success"
+        )
+        assert success_call.kwargs["scalar_value"] == 0.0
+
+
+# ===================================================================
+# add_histogram tests
+# ===================================================================
+
+
+class TestAddHistogram:
+    def test_basic(self, enabled_logger, mock_writer):
+        arr = np.array([1.0, 2.0, 3.0])
+        enabled_logger.add_histogram("hist", arr, step=5)
+        mock_writer.add_histogram.assert_called_once()
+        args = mock_writer.add_histogram.call_args
+        assert args.args[0] == "hist"
+        np.testing.assert_array_equal(args.args[1], arr)
+        assert args.kwargs["global_step"] == 5
+        assert args.kwargs["bins"] == "tensorflow"
+
+    def test_empty_array_skipped(self, enabled_logger, mock_writer):
+        enabled_logger.add_histogram("empty", np.array([]), step=1)
+        mock_writer.add_histogram.assert_not_called()
+
+    def test_sequence_input(self, enabled_logger, mock_writer):
+        enabled_logger.add_histogram("seq", [1.0, 2.0, 3.0], step=0)
+        mock_writer.add_histogram.assert_called_once()
+
+    def test_disabled_noop(self, disabled_logger):
+        disabled_logger.add_histogram("x", np.array([1.0]), step=0)
+
+
+# ===================================================================
+# log_reward_distribution tests
+# ===================================================================
+
+
+class TestLogRewardDistribution:
+    def test_delegates_to_add_histogram(self, enabled_logger, mock_writer):
+        rewards = np.array([1.0, 2.0, 3.0])
+        enabled_logger.log_reward_distribution(step=1, rewards=rewards)
+        mock_writer.add_histogram.assert_called_once()
+        assert mock_writer.add_histogram.call_args.args[0] == "reward/distribution"
+
+
+# ===================================================================
+# log_weight_histograms tests
+# ===================================================================
+
+
+class TestLogWeightHistograms:
+    def test_basic(self, enabled_logger, mock_writer):
+        params = {"layer.0.weight": np.ones(10), "layer.1.bias": np.zeros(5)}
+        enabled_logger.log_weight_histograms(step=1, named_params=params)
+        assert mock_writer.add_histogram.call_count == 2
+        tags = [c.args[0] for c in mock_writer.add_histogram.call_args_list]
+        assert "weights/layer/0/weight" in tags
+        assert "weights/layer/1/bias" in tags
+
+
+# ===================================================================
+# log_gradient_histograms tests
+# ===================================================================
+
+
+class TestLogGradientHistograms:
+    def test_basic(self, enabled_logger, mock_writer):
+        grads = {"layer.0.weight": np.ones(10)}
+        enabled_logger.log_gradient_histograms(step=1, named_gradients=grads)
+        assert mock_writer.add_histogram.call_count == 1
+        assert mock_writer.add_histogram.call_args.args[0] == "gradients/layer/0/weight"
+
+
+# ===================================================================
+# add_image / add_images tests
+# ===================================================================
+
+
+class TestAddImage:
+    def test_basic(self, enabled_logger, mock_writer):
+        img = np.zeros((64, 64, 3), dtype=np.uint8)
+        enabled_logger.add_image("img", img, step=1)
+        mock_writer.add_image.assert_called_once_with(
+            "img", img, global_step=1, dataformats="HWC"
+        )
+
+    def test_disabled_noop(self, disabled_logger):
+        disabled_logger.add_image("img", np.zeros((4, 4, 3)), step=0)
+
+
+class TestAddImages:
+    def test_basic(self, enabled_logger, mock_writer):
+        imgs = np.zeros((4, 64, 64, 3), dtype=np.uint8)
+        enabled_logger.add_images("batch", imgs, step=2)
+        mock_writer.add_images.assert_called_once_with(
+            "batch", imgs, global_step=2, dataformats="NHWC"
+        )
+
+    def test_disabled_noop(self, disabled_logger):
+        disabled_logger.add_images("batch", np.zeros((2, 4, 4, 3)), step=0)
+
+
+# ===================================================================
+# log_trajectory_image tests
+# ===================================================================
+
+
+class TestLogTrajectoryImage:
+    def test_with_positions(self, enabled_logger, mock_writer):
+        positions = {
+            0: np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]]),
+            1: np.array([[0.0, 2.0], [1.0, 1.0]]),
+        }
+        enabled_logger.log_trajectory_image(step=1, positions=positions)
+        mock_writer.add_image.assert_called_once()
+        call_args = mock_writer.add_image.call_args
+        assert call_args.kwargs.get("dataformats", call_args.args[3] if len(call_args.args) > 3 else None) or True
+        img = call_args.args[1]
+        assert img.shape == (256, 256, 3)
+
+    def test_empty_positions(self, enabled_logger, mock_writer):
+        enabled_logger.log_trajectory_image(step=1, positions={})
+        mock_writer.add_image.assert_called_once()
+        img = mock_writer.add_image.call_args.args[1]
+        # Should be a white image
+        assert img.shape == (256, 256, 3)
+        assert np.all(img == 255)
+
+    def test_with_world_bounds(self, enabled_logger, mock_writer):
+        positions = {0: np.array([[0.5, 0.5], [1.5, 1.5]])}
+        enabled_logger.log_trajectory_image(
+            step=1,
+            positions=positions,
+            world_bounds=(0.0, 2.0, 0.0, 2.0),
+            img_size=(128, 128),
+        )
+        mock_writer.add_image.assert_called_once()
+        img = mock_writer.add_image.call_args.args[1]
+        assert img.shape == (128, 128, 3)
+
+
+# ===================================================================
+# add_text tests
+# ===================================================================
+
+
+class TestAddText:
+    def test_basic(self, enabled_logger, mock_writer):
+        enabled_logger.add_text("note", "hello", step=1)
+        mock_writer.add_text.assert_called_once_with("note", "hello", global_step=1)
+
+    def test_disabled_noop(self, disabled_logger):
+        disabled_logger.add_text("note", "hello", step=0)
+
+
+# ===================================================================
+# add_hparams tests
+# ===================================================================
+
+
+class TestAddHparams:
+    def test_basic(self, enabled_logger, mock_writer):
+        enabled_logger.add_hparams({"lr": 1e-3, "bs": 32}, {"final_loss": 0.01})
+        mock_writer.add_hparams.assert_called_once_with(
+            {"lr": 1e-3, "bs": 32}, {"final_loss": 0.01}
+        )
+
+    def test_non_standard_types_stringified(self, enabled_logger, mock_writer):
+        enabled_logger.add_hparams(
+            {"lr": 1e-3, "schedule": [1, 2, 3], "config": {"a": 1}},
+            {"loss": 0.1},
+        )
+        hp_arg = mock_writer.add_hparams.call_args.args[0]
+        assert hp_arg["lr"] == 1e-3
+        assert hp_arg["schedule"] == "[1, 2, 3]"
+        assert hp_arg["config"] == "{'a': 1}"
+
+    def test_disabled_noop(self, disabled_logger):
+        disabled_logger.add_hparams({"lr": 1e-3}, {"loss": 0.1})
+
+
+# ===================================================================
+# log_config tests
+# ===================================================================
+
+
+class TestLogConfig:
+    def test_logs_json_text(self, enabled_logger, mock_writer):
+        enabled_logger.log_config({"lr": 0.001, "epochs": 10})
+        mock_writer.add_text.assert_called_once()
+        kw = mock_writer.add_text.call_args
+        assert kw.args[0] == "config"
+        assert '"lr": 0.001' in kw.args[1]
+        assert kw.kwargs["global_step"] == 0
+
+
+# ===================================================================
+# log_custom_metric, log_timing, log_throughput tests
+# ===================================================================
+
+
+class TestCustomMetrics:
+    def test_log_custom_metric(self, enabled_logger, mock_writer):
+        enabled_logger.log_custom_metric("accuracy", 0.95, step=10)
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "custom/accuracy"
+
+    def test_log_custom_metric_prefix(self, enabled_logger, mock_writer):
+        enabled_logger.log_custom_metric("x", 1.0, step=0, prefix="special")
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "special/x"
+
+    def test_log_timing(self, enabled_logger, mock_writer):
+        enabled_logger.log_timing("forward", 0.05, step=1)
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "timing/forward"
+        assert kw["scalar_value"] == pytest.approx(0.05)
+
+    def test_log_throughput(self, enabled_logger, mock_writer):
+        enabled_logger.log_throughput("samples", count=1000, duration_s=2.0, step=1)
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "throughput/samples"
+        assert kw["scalar_value"] == pytest.approx(500.0)
+
+    def test_log_throughput_near_zero_duration(self, enabled_logger, mock_writer):
+        enabled_logger.log_throughput("x", count=10, duration_s=0.0, step=0)
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["scalar_value"] > 0  # Should not be inf
+
+
+# ===================================================================
+# get_scalar_history tests
+# ===================================================================
+
+
+class TestGetScalarHistory:
+    def test_empty_tag(self, enabled_logger):
+        assert enabled_logger.get_scalar_history("nonexistent") == []
+
+    def test_returns_cached_values(self, enabled_logger):
+        enabled_logger.add_scalar("m", 1.0, step=0)
+        enabled_logger.add_scalar("m", 2.0, step=1)
+        enabled_logger.add_scalar("other", 9.0, step=0)
+        history = enabled_logger.get_scalar_history("m")
+        assert history == [(0, 1.0), (1, 2.0)]
+
+    def test_returns_copy(self, enabled_logger):
+        enabled_logger.add_scalar("m", 1.0, step=0)
+        h1 = enabled_logger.get_scalar_history("m")
+        h1.append((99, 99.0))
+        h2 = enabled_logger.get_scalar_history("m")
+        assert len(h2) == 1  # original unchanged
+
+
+# ===================================================================
+# timer context manager tests
+# ===================================================================
+
+
+class TestTimerContextManager:
+    def test_logs_elapsed_time(self, enabled_logger, mock_writer):
+        with enabled_logger.timer("test_op", step=5):
+            pass  # virtually zero time
+        mock_writer.add_scalar.assert_called_once()
+        kw = mock_writer.add_scalar.call_args.kwargs
+        assert kw["tag"] == "timing/test_op"
+        assert kw["global_step"] == 5
+        assert kw["scalar_value"] >= 0.0
+
+
+# ===================================================================
+# train_step_context tests
+# ===================================================================
+
+
+class TestTrainStepContext:
+    def test_collects_and_logs_metrics(self, enabled_logger, mock_writer):
+        with enabled_logger.train_step_context(step=10) as metrics:
+            metrics["loss"] = 0.5
+            metrics["acc"] = 0.9
+        tags = [c.kwargs["tag"] for c in mock_writer.add_scalar.call_args_list]
+        assert "train/loss" in tags
+        assert "train/acc" in tags
+        assert "train/step_time" in tags
+
+    def test_sets_global_step(self, enabled_logger):
+        with enabled_logger.train_step_context(step=42) as metrics:
+            metrics["loss"] = 0.1
+        assert enabled_logger.global_step == 42
+
+
+# ===================================================================
+# group() tests
+# ===================================================================
+
+
+class TestGroup:
+    def test_creates_metric_group(self, enabled_logger):
+        grp = enabled_logger.group("train")
+        assert isinstance(grp, MetricGroup)
+
+    def test_reuses_existing_group(self, enabled_logger):
+        grp1 = enabled_logger.group("train")
+        grp2 = enabled_logger.group("train")
+        assert grp1 is grp2
+
+    def test_different_prefixes_different_groups(self, enabled_logger):
+        grp1 = enabled_logger.group("train")
+        grp2 = enabled_logger.group("eval")
+        assert grp1 is not grp2
+
+
+# ===================================================================
+# flush / close tests
+# ===================================================================
+
+
+class TestFlushClose:
+    def test_flush(self, enabled_logger, mock_writer):
+        enabled_logger.flush()
+        mock_writer.flush.assert_called_once()
+
+    def test_flush_disabled(self, disabled_logger):
+        disabled_logger.flush()  # should not raise
+
+    def test_close(self, enabled_logger, mock_writer):
+        enabled_logger.close()
+        assert enabled_logger.is_closed is True
+        mock_writer.flush.assert_called_once()
+        mock_writer.close.assert_called_once()
+
+    def test_double_close_safe(self, enabled_logger, mock_writer):
+        enabled_logger.close()
+        enabled_logger.close()  # should not raise
+        mock_writer.close.assert_called_once()
+
+    def test_close_disabled(self, disabled_logger):
+        disabled_logger.close()
+        assert disabled_logger.is_closed is True
+
+
+# ===================================================================
+# create_tb_logger factory tests
+# ===================================================================
+
+
+class TestCreateTbLogger:
+    def test_creates_enabled_logger(self, tmp_path, mock_writer, _enable_tb, monkeypatch):
+        monkeypatch.setattr(tb_mod, "SummaryWriter", lambda **kw: mock_writer)
+        logger = create_tb_logger(tmp_path, experiment_name="exp1")
+        assert logger.enabled is True
+        logger.close()
+
+    def test_disabled_explicitly(self, tmp_path, _disable_tb):
+        logger = create_tb_logger(tmp_path, enabled=False)
+        assert logger.enabled is False
+        logger.close()
+
+    def test_falls_back_when_tb_unavailable(self, tmp_path, _disable_tb):
+        with pytest.warns(UserWarning, match="TensorBoard is not installed"):
+            logger = create_tb_logger(tmp_path, enabled=True)
+        assert logger.enabled is False
+        logger.close()
+
+    def test_passes_kwargs(self, tmp_path, mock_writer, _enable_tb, monkeypatch):
+        monkeypatch.setattr(tb_mod, "SummaryWriter", lambda **kw: mock_writer)
+        logger = create_tb_logger(tmp_path, initial_step=50, flush_secs=30)
+        assert logger.global_step == 50
+        logger.close()

--- a/tests/test_wandb_logger.py
+++ b/tests/test_wandb_logger.py
@@ -1,0 +1,949 @@
+"""Tests for navirl/logging/wandb_logger.py."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Build a fake wandb module so the real import succeeds with mocks
+# ---------------------------------------------------------------------------
+
+def _make_mock_wandb() -> types.ModuleType:
+    """Create a mock ``wandb`` module with the attributes the logger needs."""
+    mod = types.ModuleType("wandb")
+
+    # AlertLevel enum-like
+    alert_level = types.SimpleNamespace(INFO="info", WARN="warn", ERROR="error")
+    mod.AlertLevel = alert_level  # type: ignore[attr-defined]
+
+    # Classes
+    mod.Histogram = MagicMock(name="wandb.Histogram")  # type: ignore[attr-defined]
+    mod.Image = MagicMock(name="wandb.Image")  # type: ignore[attr-defined]
+    mod.Table = MagicMock(name="wandb.Table")  # type: ignore[attr-defined]
+    mod.Artifact = MagicMock(name="wandb.Artifact")  # type: ignore[attr-defined]
+
+    # Functions
+    mod.plot_table = MagicMock(name="wandb.plot_table")  # type: ignore[attr-defined]
+    mod.init = MagicMock(name="wandb.init")  # type: ignore[attr-defined]
+    mod.sweep = MagicMock(name="wandb.sweep", return_value="sweep-id-123")  # type: ignore[attr-defined]
+    mod.alert = MagicMock(name="wandb.alert")  # type: ignore[attr-defined]
+    mod.watch = MagicMock(name="wandb.watch")  # type: ignore[attr-defined]
+
+    return mod
+
+
+_mock_wandb = _make_mock_wandb()
+
+# Inject mock wandb into sys.modules BEFORE importing the logger module,
+# then remove it so other test modules that check for wandb availability
+# are not affected.
+_orig_wandb = sys.modules.get("wandb")
+sys.modules["wandb"] = _mock_wandb
+
+# Now import the logger -- it will see wandb as available
+from navirl.logging.wandb_logger import (
+    AlertManager,
+    SweepConfig,
+    WandbLogger,
+    create_wandb_logger,
+    is_wandb_available,
+)
+
+# Restore original sys.modules state to avoid polluting other tests
+if _orig_wandb is None:
+    sys.modules.pop("wandb", None)
+else:
+    sys.modules["wandb"] = _orig_wandb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_mock_run() -> MagicMock:
+    """Return a mock W&B run object."""
+    run = MagicMock(name="wandb_run")
+    run.id = "run-abc123"
+    run.get_url.return_value = "https://wandb.ai/test/run-abc123"
+    run.tags = ("baseline",)
+    run.config = {}
+    run.summary = {}
+    return run
+
+
+@pytest.fixture()
+def mock_run():
+    return _make_mock_run()
+
+
+@pytest.fixture()
+def enabled_logger(mock_run):
+    """Return a WandbLogger that believes it is enabled, with mocked wandb."""
+    with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+         patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        _mock_wandb.init.return_value = mock_run
+        lg = WandbLogger(project="test", run_name="unit", enabled=True)
+    # Ensure subsequent calls also see the mock
+    with patch("navirl.logging.wandb_logger.wandb", _mock_wandb), \
+         patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True):
+        yield lg
+
+
+@pytest.fixture()
+def disabled_logger():
+    """Return a disabled WandbLogger."""
+    with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+         patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        lg = WandbLogger(project="test", enabled=False)
+    yield lg
+
+
+# ---------------------------------------------------------------------------
+# is_wandb_available
+# ---------------------------------------------------------------------------
+
+class TestIsWandbAvailable:
+    def test_returns_true_when_available(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True):
+            assert is_wandb_available() is True
+
+    def test_returns_false_when_unavailable(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False):
+            assert is_wandb_available() is False
+
+
+# ---------------------------------------------------------------------------
+# SweepConfig
+# ---------------------------------------------------------------------------
+
+class TestSweepConfig:
+    def test_build_minimal(self):
+        cfg = SweepConfig().build()
+        assert cfg["method"] == "random"
+        assert cfg["metric"] == {"name": "val_loss", "goal": "minimize"}
+        assert cfg["parameters"] == {}
+        assert "name" not in cfg
+        assert "early_terminate" not in cfg
+
+    def test_build_with_name(self):
+        cfg = SweepConfig(name="my_sweep").build()
+        assert cfg["name"] == "my_sweep"
+
+    def test_add_uniform(self):
+        cfg = SweepConfig().add_uniform("lr", 1e-5, 1e-2).build()
+        assert cfg["parameters"]["lr"] == {
+            "distribution": "uniform",
+            "min": 1e-5,
+            "max": 1e-2,
+        }
+
+    def test_add_log_uniform(self):
+        cfg = SweepConfig().add_log_uniform("lr", 1e-6, 1e-1).build()
+        assert cfg["parameters"]["lr"]["distribution"] == "log_uniform_values"
+
+    def test_add_categorical(self):
+        cfg = SweepConfig().add_categorical("opt", ["adam", "sgd"]).build()
+        assert cfg["parameters"]["opt"] == {"values": ["adam", "sgd"]}
+
+    def test_add_int_uniform(self):
+        cfg = SweepConfig().add_int_uniform("layers", 1, 8).build()
+        p = cfg["parameters"]["layers"]
+        assert p["distribution"] == "int_uniform"
+        assert p["min"] == 1
+        assert p["max"] == 8
+
+    def test_add_constant(self):
+        cfg = SweepConfig().add_constant("seed", 42).build()
+        assert cfg["parameters"]["seed"] == {"value": 42}
+
+    def test_set_early_terminate(self):
+        cfg = SweepConfig().set_early_terminate(min_iter=5, eta=2, s=1).build()
+        et = cfg["early_terminate"]
+        assert et["type"] == "hyperband"
+        assert et["min_iter"] == 5
+        assert et["eta"] == 2
+        assert et["s"] == 1
+
+    def test_fluent_chaining(self):
+        sc = SweepConfig("bayes", "eval/reward", "maximize")
+        result = (
+            sc.add_uniform("lr", 1e-5, 1e-2)
+            .add_categorical("batch_size", [32, 64])
+            .add_constant("seed", 0)
+            .set_early_terminate()
+        )
+        # All chained methods return the same instance
+        assert result is sc
+        cfg = result.build()
+        assert len(cfg["parameters"]) == 3
+        assert "early_terminate" in cfg
+
+    def test_custom_method_and_metric(self):
+        cfg = SweepConfig("grid", "loss", "minimize").build()
+        assert cfg["method"] == "grid"
+        assert cfg["metric"]["name"] == "loss"
+        assert cfg["metric"]["goal"] == "minimize"
+
+
+# ---------------------------------------------------------------------------
+# AlertManager
+# ---------------------------------------------------------------------------
+
+class TestAlertManager:
+    def test_send_info(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="t", enabled=True)
+            _mock_wandb.alert.reset_mock()
+            lg.alerts.send("title", "body", level="INFO")
+            _mock_wandb.alert.assert_called_once_with(
+                title="title",
+                text="body",
+                level=_mock_wandb.AlertLevel.INFO,
+                wait_duration=0.0,
+            )
+
+    def test_send_warn(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="t", enabled=True)
+            _mock_wandb.alert.reset_mock()
+            lg.alerts.send("w", "warn text", level="WARN", wait_duration=5.0)
+            _mock_wandb.alert.assert_called_once()
+            call_kwargs = _mock_wandb.alert.call_args.kwargs
+            assert call_kwargs["level"] == _mock_wandb.AlertLevel.WARN
+            assert call_kwargs["wait_duration"] == 5.0
+
+    def test_send_error(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="t", enabled=True)
+            _mock_wandb.alert.reset_mock()
+            lg.alerts.send("e", "err", level="ERROR")
+            assert _mock_wandb.alert.call_args.kwargs["level"] == _mock_wandb.AlertLevel.ERROR
+
+    def test_send_disabled_is_noop(self):
+        lg = MagicMock()
+        lg.enabled = False
+        am = AlertManager(lg)
+        with patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.alert.reset_mock()
+            am.send("t", "b")
+            _mock_wandb.alert.assert_not_called()
+
+    def test_on_metric_threshold_above_triggered(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="t", enabled=True)
+            _mock_wandb.alert.reset_mock()
+            lg.alerts.on_metric_threshold("loss", 10.0, 5.0, direction="above")
+            _mock_wandb.alert.assert_called_once()
+            assert "loss" in _mock_wandb.alert.call_args.kwargs["title"]
+
+    def test_on_metric_threshold_above_not_triggered(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="t", enabled=True)
+            _mock_wandb.alert.reset_mock()
+            lg.alerts.on_metric_threshold("loss", 3.0, 5.0, direction="above")
+            _mock_wandb.alert.assert_not_called()
+
+    def test_on_metric_threshold_below_triggered(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="t", enabled=True)
+            _mock_wandb.alert.reset_mock()
+            lg.alerts.on_metric_threshold("acc", 0.1, 0.5, direction="below")
+            _mock_wandb.alert.assert_called_once()
+
+    def test_on_metric_threshold_below_not_triggered(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="t", enabled=True)
+            _mock_wandb.alert.reset_mock()
+            lg.alerts.on_metric_threshold("acc", 0.9, 0.5, direction="below")
+            _mock_wandb.alert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# WandbLogger
+# ---------------------------------------------------------------------------
+
+class TestWandbLoggerConstruction:
+    def test_enabled_construction(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            assert lg.enabled is True
+            assert lg.run is mock_run
+
+    def test_disabled_construction(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            lg = WandbLogger(project="p", enabled=False)
+            assert lg.enabled is False
+            assert lg.run is None
+
+    def test_raises_import_error_when_wandb_unavailable_and_not_disabled(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False), \
+             pytest.raises(ImportError, match="wandb is not installed"):
+            WandbLogger(project="p", enabled=True, mode="online")
+
+    def test_no_error_when_mode_disabled_and_wandb_unavailable(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False):
+            lg = WandbLogger(project="p", enabled=True, mode="disabled")
+            assert lg.enabled is False
+
+
+class TestWandbLoggerProperties:
+    def test_run_id(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            assert lg.run_id == "run-abc123"
+
+    def test_run_id_none_when_disabled(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            lg = WandbLogger(project="p", enabled=False)
+            assert lg.run_id is None
+
+    def test_run_url(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            assert lg.run_url == "https://wandb.ai/test/run-abc123"
+
+    def test_run_url_none_when_disabled(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            lg = WandbLogger(project="p", enabled=False)
+            assert lg.run_url is None
+
+    def test_alerts_property(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            assert isinstance(lg.alerts, AlertManager)
+
+    def test_is_closed_initially_false(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            assert lg.is_closed is False
+
+
+class TestWandbLoggerContextManager:
+    def test_context_manager_returns_self_and_finishes(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            with lg as ctx:
+                assert ctx is lg
+                assert lg.is_closed is False
+            assert lg.is_closed is True
+            mock_run.finish.assert_called_once()
+
+
+class TestWandbLoggerConfig:
+    def test_update_config(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            mock_run.config = MagicMock()
+            lg = WandbLogger(project="p", enabled=True)
+            lg.update_config({"lr": 0.001})
+            mock_run.config.update.assert_called_with({"lr": 0.001})
+
+    def test_update_config_disabled_is_noop(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            lg = WandbLogger(project="p", enabled=False)
+            # Should not raise
+            lg.update_config({"lr": 0.001})
+
+    def test_set_config(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            mock_run.config = {}
+            lg = WandbLogger(project="p", enabled=True)
+            lg.set_config({"a": 1, "b": 2})
+            assert mock_run.config["a"] == 1
+            assert mock_run.config["b"] == 2
+
+
+class TestWandbLoggerLog:
+    def test_log_with_step(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log({"loss": 0.5}, step=10)
+            mock_run.log.assert_called_with({"loss": 0.5}, step=10, commit=True)
+
+    def test_log_auto_step_increments(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log({"a": 1})  # step=0
+            lg.log({"b": 2})  # step=1
+            calls = mock_run.log.call_args_list
+            assert calls[0][1]["step"] == 0
+            assert calls[1][1]["step"] == 1
+
+    def test_log_commit_false_does_not_increment(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log({"a": 1}, commit=False)  # step=0, no increment
+            lg.log({"b": 2})  # step=0 still
+            calls = mock_run.log.call_args_list
+            assert calls[0][1]["step"] == 0
+            assert calls[1][1]["step"] == 0
+
+    def test_log_disabled_is_noop(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            lg = WandbLogger(project="p", enabled=False)
+            lg.log({"x": 1})  # should not raise
+
+    def test_log_scalar(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_scalar("metric", 3.14, step=5)
+            mock_run.log.assert_called_with({"metric": 3.14}, step=5, commit=True)
+
+    def test_log_scalars_with_prefix(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_scalars({"a": 1.0, "b": 2.0}, step=0, prefix="train")
+            call_data = mock_run.log.call_args[0][0]
+            assert "train/a" in call_data
+            assert "train/b" in call_data
+
+    def test_log_scalars_without_prefix(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_scalars({"x": 5.0}, step=0)
+            call_data = mock_run.log.call_args[0][0]
+            assert "x" in call_data
+
+
+class TestWandbLoggerTrainingHelpers:
+    def test_log_training_step_basic(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_training_step(step=1, loss=0.5)
+            call_data = mock_run.log.call_args[0][0]
+            assert call_data["train/loss"] == 0.5
+            assert "train/lr" not in call_data
+            assert "train/grad_norm" not in call_data
+
+    def test_log_training_step_with_optional_params(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_training_step(step=2, loss=0.3, lr=1e-4, grad_norm=0.1, extra={"entropy": 0.9})
+            call_data = mock_run.log.call_args[0][0]
+            assert call_data["train/loss"] == 0.3
+            assert call_data["train/lr"] == 1e-4
+            assert call_data["train/grad_norm"] == 0.1
+            assert call_data["train/entropy"] == 0.9
+
+    def test_log_evaluation(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_evaluation(step=10, metrics={"reward": 5.0, "success": 0.8})
+            call_data = mock_run.log.call_args[0][0]
+            assert "eval/reward" in call_data
+            assert "eval/success" in call_data
+
+    def test_log_episode_basic(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_episode(episode=5, reward=10.0, length=100)
+            call_data = mock_run.log.call_args[0][0]
+            assert call_data["episode/reward"] == 10.0
+            assert call_data["episode/length"] == 100
+            assert "episode/success" not in call_data
+
+    def test_log_episode_with_success_and_extra(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_episode(episode=5, reward=10.0, length=100, success=True, extra={"col": 3.0})
+            call_data = mock_run.log.call_args[0][0]
+            assert call_data["episode/success"] == 1.0
+            assert call_data["episode/col"] == 3.0
+
+
+class TestWandbLoggerHistogram:
+    def test_log_histogram(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Histogram.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_histogram("h", [1.0, 2.0, 3.0], step=0, num_bins=32)
+            _mock_wandb.Histogram.assert_called_once()
+            call_kwargs = _mock_wandb.Histogram.call_args
+            assert call_kwargs[1]["num_bins"] == 32
+
+    def test_log_reward_distribution(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Histogram.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_reward_distribution(step=0, rewards=np.array([1.0, 2.0]))
+            _mock_wandb.Histogram.assert_called_once()
+
+
+class TestWandbLoggerTable:
+    def test_log_table(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Table.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_table("t", ["a", "b"], [[1, 2], [3, 4]], step=0)
+            _mock_wandb.Table.assert_called_once_with(columns=["a", "b"], data=[[1, 2], [3, 4]])
+
+    def test_log_trajectory_table(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Table.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            positions = np.array([[0.0, 0.0], [3.0, 4.0]])
+            velocities = np.array([[1.0, 0.0], [0.6, 0.8]])
+            rewards = np.array([1.0, 2.0])
+            lg.log_trajectory_table(
+                step=0, agent_id=1, positions=positions,
+                velocities=velocities, rewards=rewards,
+            )
+            _mock_wandb.Table.assert_called_once()
+            call_kwargs = _mock_wandb.Table.call_args[1]
+            cols = call_kwargs["columns"]
+            assert "speed" in cols
+            assert "reward" in cols
+            rows = call_kwargs["data"]
+            assert len(rows) == 2
+            # Check speed computation for second row: sqrt(0.6^2 + 0.8^2) = 1.0
+            speed_idx = cols.index("speed")
+            assert rows[1][speed_idx] == pytest.approx(1.0)
+
+    def test_log_trajectory_table_positions_only(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Table.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            positions = np.array([[1.0, 2.0]])
+            lg.log_trajectory_table(step=0, agent_id=0, positions=positions)
+            call_kwargs = _mock_wandb.Table.call_args[1]
+            cols = call_kwargs["columns"]
+            assert cols == ["timestep", "agent_id", "x", "y"]
+
+
+class TestWandbLoggerImages:
+    def test_log_image(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Image.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            img = np.zeros((64, 64, 3), dtype=np.uint8)
+            lg.log_image("obs", img, step=0, caption="frame 0")
+            _mock_wandb.Image.assert_called_once_with(img, caption="frame 0")
+
+    def test_log_images_with_captions(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Image.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            imgs = [np.zeros((8, 8, 3)) for _ in range(3)]
+            lg.log_images("batch", imgs, step=0, captions=["a", "b", "c"])
+            assert _mock_wandb.Image.call_count == 3
+
+    def test_log_images_without_captions(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Image.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            imgs = [np.zeros((8, 8, 3))]
+            lg.log_images("batch", imgs, step=0)
+            _mock_wandb.Image.assert_called_once_with(imgs[0], caption=None)
+
+
+class TestWandbLoggerArtifacts:
+    def test_log_artifact_file(self, mock_run, tmp_path):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            art = MagicMock()
+            _mock_wandb.Artifact.return_value = art
+            lg = WandbLogger(project="p", enabled=True)
+
+            f = tmp_path / "data.csv"
+            f.write_text("a,b\n1,2\n")
+            lg.log_artifact(str(f), name="mydata", type="dataset")
+            _mock_wandb.Artifact.assert_called()
+            art.add_file.assert_called_once_with(str(f))
+            mock_run.log_artifact.assert_called_once()
+
+    def test_log_artifact_directory(self, mock_run, tmp_path):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            art = MagicMock()
+            _mock_wandb.Artifact.return_value = art
+            lg = WandbLogger(project="p", enabled=True)
+
+            d = tmp_path / "mydir"
+            d.mkdir()
+            (d / "f.txt").write_text("hi")
+            lg.log_artifact(str(d), name="dir_art")
+            art.add_dir.assert_called_once_with(str(d))
+
+    def test_log_model_checkpoint_adds_latest_alias(self, mock_run, tmp_path):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            art = MagicMock()
+            _mock_wandb.Artifact.return_value = art
+            lg = WandbLogger(project="p", enabled=True)
+
+            f = tmp_path / "model.pt"
+            f.write_text("weights")
+            lg.log_model_checkpoint(str(f), step=100)
+            call_kwargs = mock_run.log_artifact.call_args[1]
+            assert "latest" in call_kwargs["aliases"]
+
+    def test_log_model_checkpoint_preserves_existing_aliases(self, mock_run, tmp_path):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            art = MagicMock()
+            _mock_wandb.Artifact.return_value = art
+            lg = WandbLogger(project="p", enabled=True)
+
+            f = tmp_path / "model.pt"
+            f.write_text("weights")
+            lg.log_model_checkpoint(str(f), aliases=["best"])
+            call_kwargs = mock_run.log_artifact.call_args[1]
+            assert "best" in call_kwargs["aliases"]
+            assert "latest" in call_kwargs["aliases"]
+
+    def test_use_artifact(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            art_mock = MagicMock()
+            art_mock.download.return_value = "/tmp/artifacts/model"
+            mock_run.use_artifact.return_value = art_mock
+            lg = WandbLogger(project="p", enabled=True)
+
+            result = lg.use_artifact("model", type="model")
+            mock_run.use_artifact.assert_called_with("model:latest", type="model")
+            assert result == Path("/tmp/artifacts/model")
+
+    def test_use_artifact_with_version(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            art_mock = MagicMock()
+            art_mock.download.return_value = "/tmp/art"
+            mock_run.use_artifact.return_value = art_mock
+            lg = WandbLogger(project="p", enabled=True)
+
+            lg.use_artifact("model:v3")
+            mock_run.use_artifact.assert_called_with("model:v3", type=None)
+
+    def test_use_artifact_disabled_returns_none(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            lg = WandbLogger(project="p", enabled=False)
+            assert lg.use_artifact("x") is None
+
+
+class TestWandbLoggerSummary:
+    def test_set_summary(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            mock_run.summary = {}
+            lg = WandbLogger(project="p", enabled=True)
+            lg.set_summary("best_reward", 99.0)
+            assert mock_run.summary["best_reward"] == 99.0
+
+    def test_set_summaries(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            mock_run.summary = {}
+            lg = WandbLogger(project="p", enabled=True)
+            lg.set_summaries({"a": 1, "b": 2})
+            assert mock_run.summary["a"] == 1
+            assert mock_run.summary["b"] == 2
+
+
+class TestWandbLoggerTags:
+    def test_add_tags(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            mock_run.tags = ("existing",)
+            lg = WandbLogger(project="p", enabled=True)
+            lg.add_tags(["new1", "new2"])
+            assert set(mock_run.tags) == {"existing", "new1", "new2"}
+
+    def test_remove_tags(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            mock_run.tags = ("a", "b", "c")
+            lg = WandbLogger(project="p", enabled=True)
+            lg.remove_tags(["b"])
+            assert "b" not in set(mock_run.tags)
+            assert "a" in set(mock_run.tags)
+
+
+class TestWandbLoggerSweep:
+    def test_create_sweep_with_dict(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.sweep.reset_mock()
+            _mock_wandb.sweep.return_value = "sweep-id"
+            result = WandbLogger.create_sweep({"method": "random"}, project="p")
+            assert result == "sweep-id"
+            _mock_wandb.sweep.assert_called_once()
+
+    def test_create_sweep_with_sweep_config(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.sweep.reset_mock()
+            _mock_wandb.sweep.return_value = "sweep-id-2"
+            sc = SweepConfig("bayes", "loss", "minimize").add_uniform("lr", 0.0, 1.0)
+            result = WandbLogger.create_sweep(sc, project="p", entity="team")
+            assert result == "sweep-id-2"
+            call_kwargs = _mock_wandb.sweep.call_args[1]
+            assert call_kwargs["project"] == "p"
+            assert call_kwargs["entity"] == "team"
+            assert call_kwargs["sweep"]["method"] == "bayes"
+
+    def test_create_sweep_unavailable_returns_none(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False):
+            result = WandbLogger.create_sweep({"method": "random"})
+            assert result is None
+
+
+class TestWandbLoggerCustomCharts:
+    def test_define_and_log_custom_chart(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Table.reset_mock()
+            _mock_wandb.plot_table.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            lg.define_custom_chart("my_chart", {"$schema": "vega-lite"})
+            lg.log_custom_chart("my_chart", [{"x": 1, "y": 2}], step=0)
+            _mock_wandb.plot_table.assert_called_once()
+
+    def test_log_custom_chart_without_definition_falls_back_to_table(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.Table.reset_mock()
+            _mock_wandb.plot_table.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_custom_chart("undefined_chart", [{"a": 1}], step=0)
+            _mock_wandb.Table.assert_called_once()
+            _mock_wandb.plot_table.assert_not_called()
+
+    def test_log_custom_chart_empty_data_is_noop(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            mock_run.log.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            lg.log_custom_chart("chart", [], step=0)
+            mock_run.log.assert_not_called()
+
+
+class TestWandbLoggerContextManagers:
+    def test_train_step_context(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            with lg.train_step_context(step=5) as m:
+                m["loss"] = 0.1
+            call_data = mock_run.log.call_args[0][0]
+            assert "train/loss" in call_data
+            assert "train/step_time" in call_data
+            assert call_data["train/loss"] == 0.1
+
+    def test_eval_context(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            with lg.eval_context(step=10) as m:
+                m["reward"] = 42.0
+            call_data = mock_run.log.call_args[0][0]
+            assert "eval/reward" in call_data
+            assert "eval/eval_time" in call_data
+
+
+class TestWandbLoggerWatchModel:
+    def test_watch_model(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            _mock_wandb.watch.reset_mock()
+            lg = WandbLogger(project="p", enabled=True)
+            fake_model = MagicMock()
+            lg.watch_model(fake_model, log="gradients", log_freq=50, log_graph=True)
+            _mock_wandb.watch.assert_called_once_with(
+                fake_model, log="gradients", log_freq=50, log_graph=True,
+            )
+
+    def test_watch_model_disabled_is_noop(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.watch.reset_mock()
+            lg = WandbLogger(project="p", enabled=False)
+            lg.watch_model(MagicMock())
+            _mock_wandb.watch.assert_not_called()
+
+
+class TestWandbLoggerFinish:
+    def test_finish(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.finish(exit_code=0, quiet=True)
+            mock_run.finish.assert_called_once_with(exit_code=0, quiet=True)
+            assert lg.is_closed is True
+
+    def test_double_finish_is_safe(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.finish()
+            lg.finish()  # second call should be no-op
+            mock_run.finish.assert_called_once()
+
+    def test_finish_without_args(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = WandbLogger(project="p", enabled=True)
+            lg.finish()
+            mock_run.finish.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+class TestCreateWandbLogger:
+    def test_creates_enabled_logger(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.return_value = mock_run
+            lg = create_wandb_logger(project="test", enabled=True)
+            assert lg.enabled is True
+
+    def test_falls_back_to_disabled_when_unavailable(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False):
+            with pytest.warns(UserWarning, match="wandb is not installed"):
+                lg = create_wandb_logger(project="test", enabled=True)
+            assert lg.enabled is False
+
+    def test_disabled_explicitly(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            lg = create_wandb_logger(project="test", enabled=False, mode="disabled")
+            assert lg.enabled is False
+
+    def test_mode_defaults_to_disabled_when_unavailable(self):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False):
+            with pytest.warns(UserWarning):
+                lg = create_wandb_logger(project="test", enabled=True)
+            # Should not raise ImportError because mode defaults to "disabled"
+            assert lg.enabled is False
+
+
+class TestWandbLoggerInitKwargs:
+    """Verify that optional init kwargs (entity, dir, resume, run_id) are passed through."""
+
+    def test_entity_passed(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.reset_mock()
+            _mock_wandb.init.return_value = mock_run
+            WandbLogger(project="p", entity="myteam", enabled=True)
+            call_kwargs = _mock_wandb.init.call_args[1]
+            assert call_kwargs["entity"] == "myteam"
+
+    def test_dir_passed(self, mock_run, tmp_path):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.reset_mock()
+            _mock_wandb.init.return_value = mock_run
+            WandbLogger(project="p", dir=tmp_path, enabled=True)
+            call_kwargs = _mock_wandb.init.call_args[1]
+            assert call_kwargs["dir"] == str(tmp_path)
+
+    def test_resume_and_run_id_passed(self, mock_run):
+        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
+             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+            _mock_wandb.init.reset_mock()
+            _mock_wandb.init.return_value = mock_run
+            WandbLogger(project="p", resume="must", run_id="abc", enabled=True)
+            call_kwargs = _mock_wandb.init.call_args[1]
+            assert call_kwargs["resume"] == "must"
+            assert call_kwargs["id"] == "abc"

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,862 @@
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Build a mock gymnasium module so the wrappers can import cleanly.
+# ---------------------------------------------------------------------------
+
+
+def _build_mock_gym() -> types.ModuleType:
+    """Create a minimal gymnasium mock with Env, Wrapper, spaces, etc."""
+
+    gym_mod = types.ModuleType("gymnasium")
+    spaces_mod = types.ModuleType("gymnasium.spaces")
+    utils_mod = types.ModuleType("gymnasium.spaces.utils")
+
+    # --- spaces.Box ---
+    class Box:
+        def __init__(self, low=-np.inf, high=np.inf, shape=None, dtype=np.float32):
+            if shape is not None:
+                self.low = np.full(shape, low, dtype=dtype)
+                self.high = np.full(shape, high, dtype=dtype)
+                self.shape = shape
+            else:
+                self.low = np.asarray(low, dtype=dtype)
+                self.high = np.asarray(high, dtype=dtype)
+                self.shape = self.low.shape
+            self.dtype = np.dtype(dtype)
+
+        def sample(self):
+            return np.random.uniform(self.low, self.high).astype(self.dtype)
+
+    class Dict(dict):
+        """Minimal gymnasium.spaces.Dict."""
+
+        def __init__(self, spaces_dict=None, **kwargs):
+            super().__init__(spaces_dict or {}, **kwargs)
+
+        def sample(self):
+            return {k: v.sample() for k, v in self.items()}
+
+    class Discrete:
+        def __init__(self, n):
+            self.n = n
+            self.shape = ()
+            self.dtype = np.int64
+
+        def sample(self):
+            return np.random.randint(self.n)
+
+    def flatten_space(space):
+        if isinstance(space, Dict):
+            total = sum(int(np.prod(s.shape)) for s in space.values())
+            return Box(low=-np.inf, high=np.inf, shape=(total,), dtype=np.float32)
+        return space
+
+    def flatten(space, obs):
+        if isinstance(obs, dict):
+            return np.concatenate([np.asarray(v).flatten() for v in obs.values()])
+        return np.asarray(obs).flatten()
+
+    spaces_mod.Box = Box
+    spaces_mod.Dict = Dict
+    spaces_mod.Discrete = Discrete
+    utils_mod.flatten_space = flatten_space
+    utils_mod.flatten = flatten
+    spaces_mod.utils = utils_mod
+
+    # --- Base classes ---
+    class Env:
+        observation_space: Box
+        action_space: Box
+
+        def step(self, action):
+            raise NotImplementedError
+
+        def reset(self, **kwargs):
+            raise NotImplementedError
+
+        def close(self):
+            pass
+
+        @property
+        def unwrapped(self):
+            return self
+
+    class Wrapper(Env):
+        def __init__(self, env):
+            self.env = env
+            self.observation_space = getattr(env, "observation_space", None)
+            self.action_space = getattr(env, "action_space", None)
+
+        def step(self, action):
+            return self.env.step(action)
+
+        def reset(self, **kwargs):
+            return self.env.reset(**kwargs)
+
+        def close(self):
+            return self.env.close()
+
+        @property
+        def unwrapped(self):
+            return self.env.unwrapped
+
+    class ObservationWrapper(Wrapper):
+        def step(self, action):
+            obs, rew, term, trunc, info = self.env.step(action)
+            return self.observation(obs), rew, term, trunc, info
+
+        def reset(self, **kwargs):
+            obs, info = self.env.reset(**kwargs)
+            return self.observation(obs), info
+
+        def observation(self, observation):
+            raise NotImplementedError
+
+    class ActionWrapper(Wrapper):
+        def step(self, action):
+            return self.env.step(self.action(action))
+
+        def action(self, action):
+            raise NotImplementedError
+
+    class RewardWrapper(Wrapper):
+        def step(self, action):
+            obs, rew, term, trunc, info = self.env.step(action)
+            return obs, self.reward(rew), term, trunc, info
+
+        def reward(self, reward):
+            raise NotImplementedError
+
+    gym_mod.Env = Env
+    gym_mod.Wrapper = Wrapper
+    gym_mod.ObservationWrapper = ObservationWrapper
+    gym_mod.ActionWrapper = ActionWrapper
+    gym_mod.RewardWrapper = RewardWrapper
+    gym_mod.spaces = spaces_mod
+
+    return gym_mod, spaces_mod, utils_mod
+
+
+_gym_mod, _spaces_mod, _utils_mod = _build_mock_gym()
+
+# Inject into sys.modules BEFORE importing wrappers
+sys.modules["gymnasium"] = _gym_mod
+sys.modules["gymnasium.spaces"] = _spaces_mod
+sys.modules["gymnasium.spaces.utils"] = _utils_mod
+
+# Now import the wrappers module (it will find our mock gymnasium)
+# Remove any cached import of the wrappers module first
+sys.modules.pop("navirl.envs.wrappers", None)
+
+from navirl.envs.wrappers import (
+    ActionRepeat,
+    ClipAction,
+    CurriculumWrapper,
+    DomainRandomization,
+    FlattenObservation,
+    FrameStack,
+    GoalConditioned,
+    MonitorWrapper,
+    NormalizeObservation,
+    NormalizeReward,
+    RecordEpisode,
+    RelativeObservation,
+    RewardShaping,
+    TimeLimit,
+    VecEnvWrapper,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers: a simple mock environment
+# ---------------------------------------------------------------------------
+
+class MockEnv(_gym_mod.Env):
+    """Deterministic environment for testing wrappers."""
+
+    def __init__(
+        self,
+        obs_shape=(4,),
+        obs_low=-1.0,
+        obs_high=1.0,
+        act_shape=(2,),
+        act_low=-1.0,
+        act_high=1.0,
+    ):
+        self.observation_space = _spaces_mod.Box(
+            low=obs_low, high=obs_high, shape=obs_shape, dtype=np.float32
+        )
+        self.action_space = _spaces_mod.Box(
+            low=act_low, high=act_high, shape=act_shape, dtype=np.float32
+        )
+        self._step_count = 0
+        self._obs = np.zeros(obs_shape, dtype=np.float32)
+        self._terminated = False
+        self._truncated = False
+        self._reward = 1.0
+        self._info: dict = {}
+        self.difficulty = 0.0  # for CurriculumWrapper / DomainRandomization
+
+    def reset(self, **kwargs):
+        self._step_count = 0
+        self._obs = np.zeros(self.observation_space.shape, dtype=np.float32)
+        return self._obs.copy(), {}
+
+    def step(self, action):
+        self._step_count += 1
+        self._obs = np.full(self.observation_space.shape, self._step_count * 0.1, dtype=np.float32)
+        return (
+            self._obs.copy(),
+            self._reward,
+            self._terminated,
+            self._truncated,
+            dict(self._info),
+        )
+
+    def close(self):
+        pass
+
+    @property
+    def unwrapped(self):
+        return self
+
+
+# ============================================================================
+# Tests: FrameStack
+# ============================================================================
+
+
+class TestFrameStack:
+    def test_observation_shape_after_reset(self):
+        env = MockEnv(obs_shape=(3,))
+        wrapped = FrameStack(env, num_stack=4)
+        obs, _ = wrapped.reset()
+        assert obs.shape == (4, 3)
+
+    def test_reset_fills_all_frames_with_initial_obs(self):
+        env = MockEnv(obs_shape=(2,))
+        wrapped = FrameStack(env, num_stack=3)
+        obs, _ = wrapped.reset()
+        # All frames should be identical (the reset observation is zeros)
+        for i in range(3):
+            np.testing.assert_array_equal(obs[i], np.zeros(2))
+
+    def test_step_shifts_frames(self):
+        env = MockEnv(obs_shape=(2,))
+        wrapped = FrameStack(env, num_stack=3)
+        wrapped.reset()
+        obs1, *_ = wrapped.step(np.zeros(2))
+        # Frame 0,1 = reset obs (zeros), frame 2 = step obs (0.1, 0.1)
+        np.testing.assert_allclose(obs1[0], np.zeros(2))
+        np.testing.assert_allclose(obs1[2], np.full(2, 0.1), atol=1e-6)
+
+    def test_observation_space_bounds(self):
+        env = MockEnv(obs_shape=(3,), obs_low=-2.0, obs_high=2.0)
+        wrapped = FrameStack(env, num_stack=2)
+        assert wrapped.observation_space.shape == (2, 3)
+        np.testing.assert_allclose(wrapped.observation_space.low, -2.0)
+        np.testing.assert_allclose(wrapped.observation_space.high, 2.0)
+
+
+# ============================================================================
+# Tests: NormalizeObservation
+# ============================================================================
+
+
+class TestNormalizeObservation:
+    def test_first_observation_is_zero(self):
+        env = MockEnv(obs_shape=(2,))
+        wrapped = NormalizeObservation(env)
+        wrapped.reset()
+        # After reset the observation method sees a zero-vector. With count=1,
+        # mean=0, var ~1, normalised should be ~0.
+        obs, _ = wrapped.reset()
+        np.testing.assert_allclose(obs, 0.0, atol=1e-5)
+
+    def test_clipping(self):
+        env = MockEnv(obs_shape=(1,))
+        wrapped = NormalizeObservation(env, clip=2.0)
+        wrapped.reset()
+        # Feed a huge observation value through the observation method
+        result = wrapped.observation(np.array([1e6], dtype=np.float32))
+        assert np.all(result <= 2.0)
+        assert np.all(result >= -2.0)
+
+    def test_running_stats_converge(self):
+        env = MockEnv(obs_shape=(1,))
+        wrapped = NormalizeObservation(env)
+        wrapped.reset()
+        for val in np.random.randn(200):
+            wrapped.observation(np.array([val], dtype=np.float32))
+        # After many observations, _mean and _var should be reasonable
+        assert wrapped._count == 201  # 1 from reset + 200
+
+
+# ============================================================================
+# Tests: FlattenObservation
+# ============================================================================
+
+
+class TestFlattenObservation:
+    def test_flattens_dict_observation(self):
+        env = MockEnv(obs_shape=(4,))
+        # Replace observation_space with a Dict space
+        env.observation_space = _spaces_mod.Dict({
+            "pos": _spaces_mod.Box(low=-1, high=1, shape=(2,)),
+            "vel": _spaces_mod.Box(low=-1, high=1, shape=(3,)),
+        })
+        wrapped = FlattenObservation(env)
+        assert wrapped.observation_space.shape == (5,)
+
+    def test_observation_returns_flat_array(self):
+        env = MockEnv(obs_shape=(4,))
+        env.observation_space = _spaces_mod.Dict({
+            "a": _spaces_mod.Box(low=0, high=1, shape=(2,)),
+            "b": _spaces_mod.Box(low=0, high=1, shape=(2,)),
+        })
+        wrapped = FlattenObservation(env)
+        obs_dict = {"a": np.array([1.0, 2.0]), "b": np.array([3.0, 4.0])}
+        result = wrapped.observation(obs_dict)
+        np.testing.assert_array_equal(result, [1.0, 2.0, 3.0, 4.0])
+
+
+# ============================================================================
+# Tests: RelativeObservation
+# ============================================================================
+
+
+class TestRelativeObservation:
+    def test_translation_puts_robot_at_origin(self):
+        env = MockEnv(obs_shape=(6,))
+        wrapped = RelativeObservation(env, robot_pos_indices=(0, 1))
+        obs = np.array([3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=np.float32)
+        result = wrapped.observation(obs)
+        # Robot x,y should be at origin
+        assert result[0] == pytest.approx(0.0)
+        assert result[1] == pytest.approx(0.0)
+        # Other positions shifted
+        assert result[2] == pytest.approx(2.0)
+        assert result[3] == pytest.approx(2.0)
+
+    def test_rotation_with_heading(self):
+        # Use 6-element obs so even/odd slicing produces equal-length arrays
+        # obs: [rx, ry, heading, pad, other_x, other_y]
+        env = MockEnv(obs_shape=(6,))
+        wrapped = RelativeObservation(env, robot_pos_indices=(0, 1), robot_heading_index=2)
+        heading = np.pi / 2
+        obs = np.array([1.0, 1.0, heading, 0.0, 2.0, 1.0], dtype=np.float32)
+        result = wrapped.observation(obs)
+        # After translation: [0, 0, heading-heading, -1, 1, 0]
+        # Robot position should be at origin
+        assert result[0] == pytest.approx(0.0, abs=1e-5)
+        assert result[1] == pytest.approx(0.0, abs=1e-5)
+
+    def test_no_rotation_when_heading_is_none(self):
+        env = MockEnv(obs_shape=(4,))
+        wrapped = RelativeObservation(env, robot_pos_indices=(0, 1), robot_heading_index=None)
+        obs = np.array([2.0, 3.0, 4.0, 5.0], dtype=np.float32)
+        result = wrapped.observation(obs)
+        np.testing.assert_allclose(result, [0.0, 0.0, 2.0, 2.0])
+
+
+# ============================================================================
+# Tests: GoalConditioned
+# ============================================================================
+
+
+class TestGoalConditioned:
+    def test_observation_is_dict_with_required_keys(self):
+        env = MockEnv(obs_shape=(6,))
+        wrapped = GoalConditioned(env)
+        obs_raw = np.arange(6, dtype=np.float32)
+        result = wrapped.observation(obs_raw)
+        assert "observation" in result
+        assert "achieved_goal" in result
+        assert "desired_goal" in result
+
+    def test_default_goal_fns_use_first_and_second_pairs(self):
+        env = MockEnv(obs_shape=(6,))
+        wrapped = GoalConditioned(env)
+        obs = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float32)
+        result = wrapped.observation(obs)
+        np.testing.assert_array_equal(result["achieved_goal"], [1.0, 2.0])
+        np.testing.assert_array_equal(result["desired_goal"], [3.0, 4.0])
+
+    def test_custom_goal_fns(self):
+        env = MockEnv(obs_shape=(6,))
+        wrapped = GoalConditioned(
+            env,
+            achieved_goal_fn=lambda o: o[-2:],
+            desired_goal_fn=lambda o: o[0:1],
+        )
+        obs = np.arange(6, dtype=np.float32)
+        result = wrapped.observation(obs)
+        np.testing.assert_array_equal(result["achieved_goal"], [4.0, 5.0])
+        np.testing.assert_array_equal(result["desired_goal"], [0.0])
+
+    def test_observation_space_is_dict(self):
+        env = MockEnv(obs_shape=(6,))
+        wrapped = GoalConditioned(env)
+        assert isinstance(wrapped.observation_space, _spaces_mod.Dict)
+        assert "observation" in wrapped.observation_space
+        assert "achieved_goal" in wrapped.observation_space
+
+
+# ============================================================================
+# Tests: ClipAction
+# ============================================================================
+
+
+class TestClipAction:
+    def test_clips_action_to_bounds(self):
+        env = MockEnv(act_shape=(2,), act_low=-0.5, act_high=0.5)
+        wrapped = ClipAction(env)
+        clipped = wrapped.action(np.array([2.0, -3.0]))
+        np.testing.assert_allclose(clipped, [0.5, -0.5])
+
+    def test_action_within_bounds_unchanged(self):
+        env = MockEnv(act_shape=(2,), act_low=-1.0, act_high=1.0)
+        wrapped = ClipAction(env)
+        action = np.array([0.3, -0.7])
+        clipped = wrapped.action(action)
+        np.testing.assert_allclose(clipped, action)
+
+
+# ============================================================================
+# Tests: RewardShaping
+# ============================================================================
+
+
+class TestRewardShaping:
+    def test_progress_weight(self):
+        env = MockEnv()
+        # Make reset return distance_to_goal in its info
+        original_reset = env.reset
+
+        def reset_with_dist(**kwargs):
+            obs, info = original_reset(**kwargs)
+            info["distance_to_goal"] = 10.0
+            return obs, info
+
+        env.reset = reset_with_dist
+        wrapped = RewardShaping(env, progress_weight=1.0)
+        wrapped.reset()
+        # After reset, _prev_dist = 10.0
+        env._info = {"distance_to_goal": 8.0}
+        _, reward, *_ = wrapped.step(np.zeros(2))
+        # shaped = base(1.0) + 1.0*(10.0 - 8.0) = 3.0
+        assert reward == pytest.approx(3.0)
+
+    def test_collision_penalty(self):
+        env = MockEnv()
+        env._info = {"collision": True}
+        wrapped = RewardShaping(env, collision_penalty=5.0)
+        wrapped.reset()
+        _, reward, *_ = wrapped.step(np.zeros(2))
+        # shaped = 1.0 - 5.0 = -4.0
+        assert reward == pytest.approx(-4.0)
+
+    def test_custom_shaping_fn_6_args(self):
+        def shaper(obs, action, reward, terminated, truncated, info):
+            return 100.0
+
+        env = MockEnv()
+        wrapped = RewardShaping(env, shaping_fn=shaper)
+        wrapped.reset()
+        _, reward, *_ = wrapped.step(np.zeros(2))
+        # shaped = base(1.0) + 100.0 = 101.0
+        assert reward == pytest.approx(101.0)
+
+    def test_custom_shaping_fn_4_args(self):
+        def shaper(reward, obs, action, info):
+            return float(reward) * 2
+
+        env = MockEnv()
+        wrapped = RewardShaping(env, shaping_fn=shaper)
+        wrapped.reset()
+        _, reward, *_ = wrapped.step(np.zeros(2))
+        # For arity<=4, shaped = shaping_fn(reward, obs, action, info)
+        assert reward == pytest.approx(2.0)
+
+    def test_custom_shaping_fn_with_varargs(self):
+        def shaper(*args):
+            return 50.0
+
+        env = MockEnv()
+        wrapped = RewardShaping(env, shaping_fn=shaper)
+        # VAR_POSITIONAL => arity=6 => added to base
+        wrapped.reset()
+        _, reward, *_ = wrapped.step(np.zeros(2))
+        assert reward == pytest.approx(51.0)
+
+
+class TestInferShapingFnArity:
+    """Test _infer_shaping_fn_arity independently (no gym needed)."""
+
+    def test_none_returns_zero(self):
+        assert RewardShaping._infer_shaping_fn_arity(None) == 0
+
+    def test_lambda_no_args(self):
+        assert RewardShaping._infer_shaping_fn_arity(lambda: 0) == 0
+
+    def test_lambda_one_arg(self):
+        assert RewardShaping._infer_shaping_fn_arity(lambda x: x) == 1
+
+    def test_lambda_four_args(self):
+        assert RewardShaping._infer_shaping_fn_arity(lambda a, b, c, d: 0) == 4
+
+    def test_lambda_six_args(self):
+        assert RewardShaping._infer_shaping_fn_arity(lambda a, b, c, d, e, f: 0) == 6
+
+    def test_varargs_returns_six(self):
+        assert RewardShaping._infer_shaping_fn_arity(lambda *args: 0) == 6
+
+    def test_mixed_args_and_varargs(self):
+        assert RewardShaping._infer_shaping_fn_arity(lambda a, b, *args: 0) == 6
+
+    def test_regular_function(self):
+        def my_fn(obs, action, reward):
+            return 0.0
+
+        assert RewardShaping._infer_shaping_fn_arity(my_fn) == 3
+
+    def test_uninspectable_callable_returns_six(self):
+        # Create a callable whose signature raises TypeError
+        class Opaque:
+            def __call__(self, *args):
+                return 0.0
+            # Make inspect.signature fail
+            __signature__ = None
+        opaque = Opaque()
+        # inspect.signature raises TypeError for __signature__=None in some versions;
+        # if it doesn't, the VAR_POSITIONAL path gives 6 anyway
+        result = RewardShaping._infer_shaping_fn_arity(opaque)
+        assert result == 6
+
+
+# ============================================================================
+# Tests: NormalizeReward
+# ============================================================================
+
+
+class TestNormalizeReward:
+    def test_normalizes_constant_reward(self):
+        env = MockEnv()
+        wrapped = NormalizeReward(env, gamma=0.99, clip=10.0)
+        wrapped.reset()
+        rewards = []
+        for _ in range(50):
+            _, r, *_ = wrapped.step(np.zeros(2))
+            rewards.append(r)
+        # Should produce finite rewards
+        assert all(np.isfinite(r) for r in rewards)
+
+    def test_clipping(self):
+        env = MockEnv()
+        env._reward = 1e6
+        wrapped = NormalizeReward(env, clip=5.0)
+        wrapped.reset()
+        _, r, *_ = wrapped.step(np.zeros(2))
+        assert -5.0 <= r <= 5.0
+
+    def test_reset_clears_return(self):
+        env = MockEnv()
+        wrapped = NormalizeReward(env)
+        wrapped.reset()
+        wrapped.step(np.zeros(2))
+        wrapped.step(np.zeros(2))
+        wrapped.reset()
+        assert wrapped._return == 0.0
+
+
+# ============================================================================
+# Tests: ActionRepeat
+# ============================================================================
+
+
+class TestActionRepeat:
+    def test_reward_summing(self):
+        env = MockEnv()
+        env._reward = 2.0
+        wrapped = ActionRepeat(env, num_repeat=3)
+        wrapped.reset()
+        _, reward, *_ = wrapped.step(np.zeros(2))
+        assert reward == pytest.approx(6.0)
+
+    def test_early_termination(self):
+        env = MockEnv()
+        env._reward = 1.0
+        call_count = 0
+        original_step = env.step
+
+        def terminating_step(action):
+            nonlocal call_count
+            call_count += 1
+            obs, r, term, trunc, info = original_step(action)
+            if call_count >= 2:
+                term = True
+            return obs, r, term, trunc, info
+
+        env.step = terminating_step
+        wrapped = ActionRepeat(env, num_repeat=5)
+        wrapped.reset()
+        _, reward, terminated, *_ = wrapped.step(np.zeros(2))
+        # Should stop after 2 steps
+        assert call_count == 2
+        assert reward == pytest.approx(2.0)
+        assert terminated is True
+
+
+# ============================================================================
+# Tests: TimeLimit
+# ============================================================================
+
+
+class TestTimeLimit:
+    def test_truncation_at_max_steps(self):
+        env = MockEnv()
+        wrapped = TimeLimit(env, max_steps=3)
+        wrapped.reset()
+        for _i in range(2):
+            _, _, _, truncated, info = wrapped.step(np.zeros(2))
+            assert truncated is False
+        _, _, _, truncated, info = wrapped.step(np.zeros(2))
+        assert truncated is True
+        assert info.get("TimeLimit.truncated") is True
+
+    def test_reset_clears_counter(self):
+        env = MockEnv()
+        wrapped = TimeLimit(env, max_steps=5)
+        wrapped.reset()
+        wrapped.step(np.zeros(2))
+        wrapped.step(np.zeros(2))
+        wrapped.reset()
+        assert wrapped._elapsed_steps == 0
+
+
+# ============================================================================
+# Tests: RecordEpisode
+# ============================================================================
+
+
+class TestRecordEpisode:
+    def test_episode_stored_on_termination(self):
+        env = MockEnv()
+        wrapped = RecordEpisode(env)
+        wrapped.reset()
+        env._terminated = True
+        wrapped.step(np.zeros(2))
+        assert len(wrapped.episodes) == 1
+        assert len(wrapped.episode_rewards) == 1
+
+    def test_episode_rewards_tracking(self):
+        env = MockEnv()
+        env._reward = 3.0
+        wrapped = RecordEpisode(env)
+        wrapped.reset()
+        wrapped.step(np.zeros(2))
+        wrapped.step(np.zeros(2))
+        env._terminated = True
+        wrapped.step(np.zeros(2))
+        assert wrapped.episode_rewards[-1] == pytest.approx(9.0)
+
+    def test_fifo_buffer(self):
+        env = MockEnv()
+        wrapped = RecordEpisode(env, max_episodes=2)
+        for _ in range(3):
+            wrapped.reset()
+            env._terminated = True
+            wrapped.step(np.zeros(2))
+        assert len(wrapped.episodes) == 2
+
+    def test_episode_data_structure(self):
+        env = MockEnv()
+        wrapped = RecordEpisode(env)
+        wrapped.reset()
+        wrapped.step(np.zeros(2))
+        env._terminated = True
+        wrapped.step(np.zeros(2))
+        ep = wrapped.episodes[0]
+        assert "observations" in ep
+        assert "actions" in ep
+        assert "rewards" in ep
+        assert "infos" in ep
+        # 1 from reset + 2 from steps
+        assert len(ep["observations"]) == 3
+        assert len(ep["actions"]) == 2
+
+
+# ============================================================================
+# Tests: MonitorWrapper
+# ============================================================================
+
+
+class TestMonitorWrapper:
+    def test_episode_stats_recorded(self):
+        env = MockEnv()
+        env._reward = 2.0
+        wrapped = MonitorWrapper(env)
+        wrapped.reset()
+        wrapped.step(np.zeros(2))
+        env._terminated = True
+        _, _, _, _, info = wrapped.step(np.zeros(2))
+        assert len(wrapped.episode_returns) == 1
+        assert wrapped.episode_returns[0] == pytest.approx(4.0)
+        assert wrapped.episode_lengths[0] == 2
+        assert len(wrapped.episode_times) == 1
+
+    def test_info_contains_episode_on_done(self):
+        env = MockEnv()
+        env._terminated = True
+        wrapped = MonitorWrapper(env)
+        wrapped.reset()
+        _, _, _, _, info = wrapped.step(np.zeros(2))
+        assert "episode" in info
+        assert "r" in info["episode"]
+        assert "l" in info["episode"]
+        assert "t" in info["episode"]
+
+    def test_reset_clears_accumulators(self):
+        env = MockEnv()
+        wrapped = MonitorWrapper(env)
+        wrapped.reset()
+        wrapped.step(np.zeros(2))
+        wrapped.reset()
+        assert wrapped._episode_return == 0.0
+        assert wrapped._episode_length == 0
+
+
+# ============================================================================
+# Tests: CurriculumWrapper
+# ============================================================================
+
+
+class TestCurriculumWrapper:
+    def test_scheduler_sets_difficulty(self):
+        env = MockEnv()
+        def scheduler(steps):
+            return min(steps / 100, 1.0)
+        wrapped = CurriculumWrapper(env, scheduler=scheduler)
+        wrapped.reset()
+        assert env.difficulty == 0.0  # 0 steps so far
+        for _ in range(50):
+            wrapped.step(np.zeros(2))
+        wrapped.reset()
+        assert env.difficulty == pytest.approx(0.5)
+
+    def test_curriculum_manager_with_get_env_config(self):
+        env = MockEnv()
+        manager = MagicMock()
+        manager.get_env_config.return_value = {"difficulty": 0.75}
+        wrapped = CurriculumWrapper(env, curriculum_manager=manager)
+        wrapped.reset()
+        assert env.difficulty == pytest.approx(0.75)
+
+    def test_curriculum_manager_with_difficulty_attr(self):
+        env = MockEnv()
+        manager = MagicMock(spec=[])  # no get_env_config
+        manager.difficulty = 0.3
+        wrapped = CurriculumWrapper(env, curriculum_manager=manager)
+        wrapped.reset()
+        assert env.difficulty == pytest.approx(0.3)
+
+    def test_error_when_neither_scheduler_nor_manager(self):
+        env = MockEnv()
+        with pytest.raises(TypeError, match="requires either"):
+            CurriculumWrapper(env)
+
+    def test_error_when_manager_has_no_difficulty(self):
+        env = MockEnv()
+        manager = MagicMock(spec=[])  # no attributes
+        del manager.difficulty  # make sure it doesn't exist
+        wrapped = CurriculumWrapper(env, curriculum_manager=manager)
+        with pytest.raises(AttributeError, match="curriculum_manager must define"):
+            wrapped.reset()
+
+
+# ============================================================================
+# Tests: DomainRandomization
+# ============================================================================
+
+
+class TestDomainRandomization:
+    def test_attributes_randomized_on_reset(self):
+        env = MockEnv()
+        env.friction = 0.5  # add attribute
+        config = {"friction": (0.1, 0.9), "difficulty": (0.0, 1.0)}
+        wrapped = DomainRandomization(env, randomization_config=config, seed=42)
+        wrapped.reset()
+        # The attributes should have changed from defaults
+        assert 0.1 <= env.friction <= 0.9
+        assert 0.0 <= env.difficulty <= 1.0
+
+    def test_seeded_rng_is_deterministic(self):
+        env1 = MockEnv()
+        env1.param = 0.0
+        env2 = MockEnv()
+        env2.param = 0.0
+        config = {"param": (0.0, 10.0)}
+        w1 = DomainRandomization(env1, randomization_config=config, seed=123)
+        w2 = DomainRandomization(env2, randomization_config=config, seed=123)
+        w1.reset()
+        w2.reset()
+        assert env1.param == pytest.approx(env2.param)
+
+    def test_missing_attribute_is_skipped(self):
+        env = MockEnv()
+        config = {"nonexistent_attr": (0.0, 1.0)}
+        wrapped = DomainRandomization(env, randomization_config=config, seed=0)
+        # Should not raise; attribute doesn't exist so it won't be set
+        wrapped.reset()
+        assert not hasattr(env, "nonexistent_attr")
+
+
+# ============================================================================
+# Tests: VecEnvWrapper
+# ============================================================================
+
+
+class TestVecEnvWrapper:
+    def test_batched_reset(self):
+        vec = VecEnvWrapper([lambda: MockEnv(obs_shape=(3,)) for _ in range(4)])
+        obs, infos = vec.reset()
+        assert obs.shape == (4, 3)
+        assert len(infos) == 4
+
+    def test_batched_step(self):
+        vec = VecEnvWrapper([lambda: MockEnv(obs_shape=(2,), act_shape=(1,)) for _ in range(3)])
+        vec.reset()
+        actions = np.zeros((3, 1))
+        obs, rewards, terminateds, truncateds, infos = vec.step(actions)
+        assert obs.shape == (3, 2)
+        assert rewards.shape == (3,)
+        assert terminateds.shape == (3,)
+        assert truncateds.shape == (3,)
+        assert len(infos) == 3
+
+    def test_close(self):
+        envs_closed = []
+
+        def make_env():
+            e = MockEnv()
+            original_close = e.close
+            def tracked_close():
+                envs_closed.append(True)
+                original_close()
+            e.close = tracked_close
+            return e
+
+        vec = VecEnvWrapper([make_env for _ in range(2)])
+        vec.close()
+        assert len(envs_closed) == 2
+
+    def test_num_envs(self):
+        vec = VecEnvWrapper([lambda: MockEnv() for _ in range(5)])
+        assert vec.num_envs == 5


### PR DESCRIPTION
## Summary
- Add 90 tests for `navirl/logging/tensorboard_logger.py` (0% → 99% coverage)
- Add 85 tests for `navirl/logging/wandb_logger.py` (0% → 96% coverage)
- Add 58 tests for `navirl/envs/wrappers.py` (0% → 98% coverage)

All tests use mocked external dependencies (TensorBoard, wandb, gymnasium) to run without optional packages. Full suite: 3802 passed, 98 skipped, 0 failures.

## Test plan
- [x] All 233 new tests pass
- [x] Full test suite passes (3802 passed, 98 skipped)
- [x] Ruff lint checks pass
- [x] No test-ordering pollution (wandb mock properly cleaned up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)