### PR TITLE
ci: add lint/format quality gates and coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,21 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: python -m pip install ruff>=0.3
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -31,9 +46,15 @@ jobs:
             echo "Retry $i: pip install failed, retrying in 5s..."
             sleep 5
           done
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         run: |
-          python -m pytest -m "not e2e"
+          python -m pytest -m "not e2e" --cov=navirl --cov-report=term-missing --cov-report=xml
       - name: Run E2E regression tests
         run: |
           python -m pytest -m e2e
+      - name: Upload coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/navirl/backends/continuous/adapter.py
+++ b/navirl/backends/continuous/adapter.py
@@ -126,9 +126,7 @@ class ContinuousSceneBackend(SceneBackend):
         self._preferred_velocities[agent_id] = (0.0, 0.0)
         self._needs_reset = True
 
-    def set_preferred_velocity(
-        self, agent_id: int, velocity: tuple[float, float]
-    ) -> None:
+    def set_preferred_velocity(self, agent_id: int, velocity: tuple[float, float]) -> None:
         self._preferred_velocities[agent_id] = (float(velocity[0]), float(velocity[1]))
 
     def step(self) -> None:
@@ -192,12 +190,8 @@ class ContinuousSceneBackend(SceneBackend):
         # Fallback – centre of the world.
         return (self._width / 2, self._height / 2)
 
-    def check_obstacle_collision(
-        self, position: tuple[float, float], radius: float
-    ) -> bool:
-        return self._env.obstacles.check_collision(
-            np.array(position, dtype=float), radius
-        )
+    def check_obstacle_collision(self, position: tuple[float, float], radius: float) -> bool:
+        return self._env.obstacles.check_collision(np.array(position, dtype=float), radius)
 
     def world_to_map(self, position: tuple[float, float]) -> tuple[int, int]:
         res = self._map_resolution

--- a/navirl/backends/grid2d/orca.py
+++ b/navirl/backends/grid2d/orca.py
@@ -24,8 +24,7 @@ class IndoorORCASim:
     def __init__(self, config: IndoorORCASimConfig):
         if rvo2 is None:
             raise ImportError(
-                "rvo2 is required for IndoorORCASim. "
-                "Install it with: pip install rvo2"
+                "rvo2 is required for IndoorORCASim. Install it with: pip install rvo2"
             )
         self.config = config
         self.sim = rvo2.PyRVOSimulator(

--- a/navirl/experiments/aggregator.py
+++ b/navirl/experiments/aggregator.py
@@ -91,7 +91,13 @@ def _compute_stats(values: list[float]) -> dict[str, float]:
     """Compute summary statistics for a list of finite values."""
     finite = [v for v in values if math.isfinite(v)]
     if not finite:
-        return {"mean": float("nan"), "std": float("nan"), "min": float("nan"), "max": float("nan"), "median": float("nan")}
+        return {
+            "mean": float("nan"),
+            "std": float("nan"),
+            "min": float("nan"),
+            "max": float("nan"),
+            "median": float("nan"),
+        }
     arr = np.asarray(finite, dtype=np.float64)
     return {
         "mean": float(arr.mean()),

--- a/navirl/orchestration/executor.py
+++ b/navirl/orchestration/executor.py
@@ -180,9 +180,7 @@ class LocalExecutor(TaskExecutor):
         else:
             # Parallel execution
             num_procs = min(self.max_workers, len(tasks))
-            logger.info(
-                "Launching %d workers for %d tasks", num_procs, len(tasks)
-            )
+            logger.info("Launching %d workers for %d tasks", num_procs, len(tasks))
             with mp.Pool(processes=num_procs) as pool:
                 for i, result_dict in enumerate(
                     pool.imap(  # preserves order

--- a/navirl/orchestration/manifest.py
+++ b/navirl/orchestration/manifest.py
@@ -104,10 +104,7 @@ class ShardManifest:
         for i, task in enumerate(tasks):
             shard_lists[i % num_shards].append(task)
 
-        shards = [
-            TaskShard(shard_id=i, tasks=shard_lists[i])
-            for i in range(num_shards)
-        ]
+        shards = [TaskShard(shard_id=i, tasks=shard_lists[i]) for i in range(num_shards)]
 
         manifest = cls(template_name=template_name, shards=shards)
         manifest.manifest_id = manifest._compute_id()

--- a/navirl/orchestration/orchestrator.py
+++ b/navirl/orchestration/orchestrator.py
@@ -167,10 +167,7 @@ class Orchestrator:
         )
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {
-                executor.submit(self._run_shard, shard_id): shard_id
-                for shard_id in pending
-            }
+            futures = {executor.submit(self._run_shard, shard_id): shard_id for shard_id in pending}
             for future in concurrent.futures.as_completed(futures):
                 shard_id = futures[future]
                 try:
@@ -217,10 +214,7 @@ class Orchestrator:
         max_workers = self.config.max_workers or len(pending)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {
-                executor.submit(self._run_shard, shard_id): shard_id
-                for shard_id in pending
-            }
+            futures = {executor.submit(self._run_shard, shard_id): shard_id for shard_id in pending}
             for future in concurrent.futures.as_completed(futures):
                 shard_id = futures[future]
                 try:

--- a/navirl/packs/loader.py
+++ b/navirl/packs/loader.py
@@ -117,6 +117,5 @@ def _resolve_scenario_path(entry_path: str, pack_dir: Path) -> Path:
                 return candidate.resolve()
 
     raise FileNotFoundError(
-        f"Cannot resolve scenario path '{entry_path}': "
-        f"checked {pack_dir}, {_LIBRARY_DIR}"
+        f"Cannot resolve scenario path '{entry_path}': checked {pack_dir}, {_LIBRARY_DIR}"
     )

--- a/navirl/packs/runner.py
+++ b/navirl/packs/runner.py
@@ -60,7 +60,10 @@ def run_pack(
             task_num += 1
             logger.info(
                 "Pack run %d/%d: %s seed=%d",
-                task_num, total, entry.id, seed,
+                task_num,
+                total,
+                entry.id,
+                seed,
             )
 
             try:

--- a/navirl/packs/schema.py
+++ b/navirl/packs/schema.py
@@ -73,10 +73,7 @@ class PackManifest:
         obj = {
             "name": self.name,
             "version": self.version,
-            "scenarios": [
-                {"id": e.id, "path": e.path, "seeds": e.seeds}
-                for e in self.scenarios
-            ],
+            "scenarios": [{"id": e.id, "path": e.path, "seeds": e.seeds} for e in self.scenarios],
             "metrics": self.metrics,
         }
         blob = json.dumps(obj, sort_keys=True, separators=(",", ":"))
@@ -120,7 +117,8 @@ class PackResult:
             vals = [
                 float(r.metrics[key])
                 for r in completed
-                if key in r.metrics and isinstance(r.metrics[key], (int, float))
+                if key in r.metrics
+                and isinstance(r.metrics[key], (int, float))
                 and math.isfinite(float(r.metrics[key]))
             ]
             if vals:

--- a/navirl/robots/baselines/astar.py
+++ b/navirl/robots/baselines/astar.py
@@ -122,8 +122,11 @@ class BaselineAStarRobotController(RobotController):
                 self._grace_steps = self.stuck_window  # grace period before re-checking
                 # Replan after waiting — humans likely moved
                 self._plan((st.x, st.y))
-                emit_event("robot_replan", self.robot_id,
-                           {"reason": "post_wait", "wait_cycle": self._wait_cycles})
+                emit_event(
+                    "robot_replan",
+                    self.robot_id,
+                    {"reason": "post_wait", "wait_cycle": self._wait_cycles},
+                )
             # Emit tiny velocity toward goal so deadlock detector doesn't
             # flag a full stop, but ORCA will override to near-zero anyway
             dx = self.goal[0] - st.x
@@ -146,8 +149,9 @@ class BaselineAStarRobotController(RobotController):
             self._is_waiting = True
             self._wait_counter = self.wait_duration
             self._wait_cycles += 1
-            emit_event("robot_yield", self.robot_id,
-                       {"wait_cycle": self._wait_cycles, "pos": (st.x, st.y)})
+            emit_event(
+                "robot_yield", self.robot_id, {"wait_cycle": self._wait_cycles, "pos": (st.x, st.y)}
+            )
             return Action(pref_vx=0.0, pref_vy=0.0, behavior="YIELD")
 
         # --- Normal path following ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dev = [
   "build>=1.0",
   "twine>=4.0",
 ]
+agents = [
+  "torch>=2.0",
+]
 notebooks = [
   "jupyter>=1.0",
   "jupytext>=1.15",

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -95,17 +95,29 @@ class TestBatchAggregator:
             RunRecord(
                 scenario="hallway",
                 seed=1,
-                metrics={"success_rate": 1.0, "collisions_agent_agent": 0, "path_length_robot": 5.0},
+                metrics={
+                    "success_rate": 1.0,
+                    "collisions_agent_agent": 0,
+                    "path_length_robot": 5.0,
+                },
             ),
             RunRecord(
                 scenario="hallway",
                 seed=2,
-                metrics={"success_rate": 1.0, "collisions_agent_agent": 2, "path_length_robot": 6.0},
+                metrics={
+                    "success_rate": 1.0,
+                    "collisions_agent_agent": 2,
+                    "path_length_robot": 6.0,
+                },
             ),
             RunRecord(
                 scenario="crossing",
                 seed=1,
-                metrics={"success_rate": 0.0, "collisions_agent_agent": 5, "path_length_robot": 10.0},
+                metrics={
+                    "success_rate": 0.0,
+                    "collisions_agent_agent": 5,
+                    "path_length_robot": 10.0,
+                },
             ),
             RunRecord(
                 scenario="crossing",
@@ -217,10 +229,20 @@ class TestBatchSummaryToDict:
                     scenario="hallway",
                     num_runs=2,
                     num_successes=2,
-                    metrics={"success_rate": {"mean": 1.0, "std": 0.0, "min": 1.0, "max": 1.0, "median": 1.0}},
+                    metrics={
+                        "success_rate": {
+                            "mean": 1.0,
+                            "std": 0.0,
+                            "min": 1.0,
+                            "max": 1.0,
+                            "median": 1.0,
+                        }
+                    },
                 )
             ],
-            global_metrics={"success_rate": {"mean": 1.0, "std": 0.0, "min": 1.0, "max": 1.0, "median": 1.0}},
+            global_metrics={
+                "success_rate": {"mean": 1.0, "std": 0.0, "min": 1.0, "max": 1.0, "median": 1.0}
+            },
             timestamp="2026-01-01T00:00:00",
         )
         d = summary.to_dict()
@@ -248,10 +270,20 @@ class TestWriters:
                     scenario="hallway",
                     num_runs=2,
                     num_successes=1,
-                    metrics={"success_rate": {"mean": 0.5, "std": 0.5, "min": 0.0, "max": 1.0, "median": 0.5}},
+                    metrics={
+                        "success_rate": {
+                            "mean": 0.5,
+                            "std": 0.5,
+                            "min": 0.0,
+                            "max": 1.0,
+                            "median": 0.5,
+                        }
+                    },
                 )
             ],
-            global_metrics={"success_rate": {"mean": 0.5, "std": 0.5, "min": 0.0, "max": 1.0, "median": 0.5}},
+            global_metrics={
+                "success_rate": {"mean": 0.5, "std": 0.5, "min": 0.0, "max": 1.0, "median": 0.5}
+            },
             timestamp="2026-01-01T00:00:00",
         )
 

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -22,6 +22,7 @@ from navirl.data.trajectory import Trajectory
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_trajectory(n: int = 10, with_velocities: bool = True) -> Trajectory:
     """Create a simple straight-line trajectory for testing."""
     ts = np.linspace(0.0, 1.0, n)

--- a/tests/test_batch_experiments.py
+++ b/tests/test_batch_experiments.py
@@ -151,9 +151,7 @@ class TestBatchAggregator:
 
     def test_single_run(self, sample_metrics):
         agg = BatchAggregator(template_name="single")
-        agg.add_record(
-            RunRecord(scenario="hallway_pass", seed=42, metrics=sample_metrics)
-        )
+        agg.add_record(RunRecord(scenario="hallway_pass", seed=42, metrics=sample_metrics))
         summary = agg.summarize()
         assert summary.total_runs == 1
         assert summary.completed_runs == 1
@@ -193,9 +191,7 @@ class TestBatchAggregator:
     def test_failed_runs_tracked(self, sample_metrics):
         agg = BatchAggregator(template_name="with_failures")
         agg.add_record(RunRecord(scenario="hallway_pass", seed=42, metrics=sample_metrics))
-        agg.add_record(
-            RunRecord(scenario="hallway_pass", seed=99, status="failed", error="boom")
-        )
+        agg.add_record(RunRecord(scenario="hallway_pass", seed=99, status="failed", error="boom"))
 
         summary = agg.summarize()
         assert summary.total_runs == 2
@@ -204,9 +200,7 @@ class TestBatchAggregator:
 
     def test_global_metrics_aggregated(self, sample_metrics):
         agg = BatchAggregator(template_name="global")
-        agg.add_record(
-            RunRecord(scenario="hallway_pass", seed=42, metrics=sample_metrics)
-        )
+        agg.add_record(RunRecord(scenario="hallway_pass", seed=42, metrics=sample_metrics))
         agg.add_record(
             RunRecord(
                 scenario="kitchen_congestion",
@@ -305,7 +299,10 @@ class TestResearchTemplates:
 
     def test_orca_param_study_loads(self):
         path = (
-            Path(__file__).resolve().parent.parent / "research" / "templates" / "orca_param_study.yaml"
+            Path(__file__).resolve().parent.parent
+            / "research"
+            / "templates"
+            / "orca_param_study.yaml"
         )
         if not path.exists():
             pytest.skip("orca_param_study.yaml not found")

--- a/tests/test_behavior_tree.py
+++ b/tests/test_behavior_tree.py
@@ -50,9 +50,12 @@ def _make_agent(
     return AgentState(
         agent_id=agent_id,
         kind="human",
-        x=x, y=y,
-        vx=vx, vy=vy,
-        goal_x=goal_x, goal_y=goal_y,
+        x=x,
+        y=y,
+        vx=vx,
+        vy=vy,
+        goal_x=goal_x,
+        goal_y=goal_y,
         radius=0.3,
         max_speed=max_speed,
     )

--- a/tests/test_communication_extended.py
+++ b/tests/test_communication_extended.py
@@ -33,9 +33,7 @@ class TestMessageProtocol:
         assert msg.receiver is None
 
     def test_metadata(self):
-        msg = MessageProtocol(
-            sender="a", receiver="b", content=42, metadata={"priority": "high"}
-        )
+        msg = MessageProtocol(sender="a", receiver="b", content=42, metadata={"priority": "high"})
         assert msg.metadata["priority"] == "high"
 
     def test_default_metadata_empty(self):

--- a/tests/test_continuous_backend.py
+++ b/tests/test_continuous_backend.py
@@ -23,6 +23,7 @@ from navirl.backends.continuous.physics import AgentState
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_backend_with_agents() -> ContinuousBackend:
     """Create a backend with one robot and one pedestrian for reuse."""
     cfg = EnvironmentConfig(width=20.0, height=20.0, dt=0.1, max_steps=50)
@@ -35,6 +36,7 @@ def _make_backend_with_agents() -> ContinuousBackend:
 # ---------------------------------------------------------------------------
 # ContinuousBackend — construction & agent management
 # ---------------------------------------------------------------------------
+
 
 class TestContinuousBackendConstruction:
     def test_default_construction(self):
@@ -90,6 +92,7 @@ class TestContinuousBackendConstruction:
 # ContinuousBackend — from_scenario
 # ---------------------------------------------------------------------------
 
+
 class TestContinuousBackendFromScenario:
     def test_from_scenario_robots_and_pedestrians(self):
         scenario = ScenarioConfig(
@@ -142,6 +145,7 @@ class TestContinuousBackendFromScenario:
 # ContinuousBackend — pedestrian circle and flow
 # ---------------------------------------------------------------------------
 
+
 class TestPedestrianPatterns:
     def test_pedestrian_circle(self):
         backend = ContinuousBackend()
@@ -187,6 +191,7 @@ class TestPedestrianPatterns:
 # ---------------------------------------------------------------------------
 # ContinuousBackend — reset / step loop
 # ---------------------------------------------------------------------------
+
 
 class TestContinuousBackendSimulation:
     def test_step_before_reset_raises(self):
@@ -240,6 +245,7 @@ class TestContinuousBackendSimulation:
 # ---------------------------------------------------------------------------
 # ContinuousBackend — query methods
 # ---------------------------------------------------------------------------
+
 
 class TestContinuousBackendQueries:
     def test_get_robot_observation(self):
@@ -299,6 +305,7 @@ class TestContinuousBackendQueries:
 # ContinuousBackend — run_episode
 # ---------------------------------------------------------------------------
 
+
 class TestRunEpisode:
     def test_run_episode_no_policy(self):
         backend = _make_backend_with_agents()
@@ -332,6 +339,7 @@ class TestRunEpisode:
 # ---------------------------------------------------------------------------
 # ContinuousBackend — _compute_pedestrian_action
 # ---------------------------------------------------------------------------
+
 
 class TestComputePedestrianAction:
     def test_at_goal_returns_zero(self):
@@ -369,23 +377,28 @@ class TestComputePedestrianAction:
 # ContinuousEnvironment — core operations
 # ---------------------------------------------------------------------------
 
+
 class TestContinuousEnvironment:
     def test_add_agent(self):
         env = ContinuousEnvironment()
-        aid = env.add_agent(AgentConfig(
-            position=np.array([1.0, 1.0]),
-            goal=np.array([10.0, 10.0]),
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([1.0, 1.0]),
+                goal=np.array([10.0, 10.0]),
+            )
+        )
         assert isinstance(aid, int)
 
     def test_add_multiple_agents_unique_ids(self):
         env = ContinuousEnvironment()
         ids = []
         for i in range(5):
-            aid = env.add_agent(AgentConfig(
-                position=np.array([float(i), 0.0]),
-                goal=np.array([float(i), 10.0]),
-            ))
+            aid = env.add_agent(
+                AgentConfig(
+                    position=np.array([float(i), 0.0]),
+                    goal=np.array([float(i), 10.0]),
+                )
+            )
             ids.append(aid)
         assert len(set(ids)) == 5
 
@@ -408,20 +421,24 @@ class TestContinuousEnvironment:
 
     def test_reset_initializes_states(self):
         env = ContinuousEnvironment()
-        env.add_agent(AgentConfig(
-            position=np.array([1.0, 1.0]),
-            goal=np.array([10.0, 10.0]),
-        ))
+        env.add_agent(
+            AgentConfig(
+                position=np.array([1.0, 1.0]),
+                goal=np.array([10.0, 10.0]),
+            )
+        )
         obs = env.reset()
         assert len(obs) == 1
         assert "position" in next(iter(obs.values()))
 
     def test_step_updates_state(self):
         env = ContinuousEnvironment()
-        aid = env.add_agent(AgentConfig(
-            position=np.array([1.0, 1.0]),
-            goal=np.array([10.0, 10.0]),
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([1.0, 1.0]),
+                goal=np.array([10.0, 10.0]),
+            )
+        )
         env.reset()
         obs, rewards, dones, info = env.step({aid: np.array([1.0, 0.5])})
         assert aid in obs
@@ -431,10 +448,12 @@ class TestContinuousEnvironment:
 
     def test_get_agent_state(self):
         env = ContinuousEnvironment()
-        aid = env.add_agent(AgentConfig(
-            position=np.array([3.0, 4.0]),
-            goal=np.array([10.0, 10.0]),
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([3.0, 4.0]),
+                goal=np.array([10.0, 10.0]),
+            )
+        )
         env.reset()
         state = env.get_agent_state(aid)
         assert state is not None
@@ -447,10 +466,12 @@ class TestContinuousEnvironment:
 
     def test_get_agent_goal(self):
         env = ContinuousEnvironment()
-        aid = env.add_agent(AgentConfig(
-            position=np.array([0.0, 0.0]),
-            goal=np.array([8.0, 8.0]),
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([0.0, 0.0]),
+                goal=np.array([8.0, 8.0]),
+            )
+        )
         env.reset()
         goal = env.get_agent_goal(aid)
         assert goal is not None
@@ -463,10 +484,12 @@ class TestContinuousEnvironment:
 
     def test_set_agent_goal(self):
         env = ContinuousEnvironment()
-        aid = env.add_agent(AgentConfig(
-            position=np.array([0.0, 0.0]),
-            goal=np.array([5.0, 5.0]),
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([0.0, 0.0]),
+                goal=np.array([5.0, 5.0]),
+            )
+        )
         env.reset()
         env.set_agent_goal(aid, np.array([15.0, 15.0]))
         new_goal = env.get_agent_goal(aid)
@@ -528,16 +551,19 @@ class TestContinuousEnvironment:
 # ContinuousEnvironment — rewards and dones
 # ---------------------------------------------------------------------------
 
+
 class TestEnvironmentRewardsAndDones:
     def test_goal_reached_gives_bonus(self):
         """Agent placed very close to goal should get goal bonus."""
         cfg = EnvironmentConfig(dt=0.1, goal_radius=2.0, max_steps=100)
         env = ContinuousEnvironment(cfg)
-        aid = env.add_agent(AgentConfig(
-            position=np.array([9.0, 9.0]),
-            goal=np.array([10.0, 10.0]),
-            max_speed=5.0,
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([9.0, 9.0]),
+                goal=np.array([10.0, 10.0]),
+                max_speed=5.0,
+            )
+        )
         env.reset()
         # Move toward goal
         _, rewards, dones, _ = env.step({aid: np.array([2.0, 2.0])})
@@ -549,10 +575,12 @@ class TestEnvironmentRewardsAndDones:
     def test_timeout_done(self):
         cfg = EnvironmentConfig(dt=0.1, max_steps=3)
         env = ContinuousEnvironment(cfg)
-        aid = env.add_agent(AgentConfig(
-            position=np.array([0.0, 0.0]),
-            goal=np.array([100.0, 100.0]),
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([0.0, 0.0]),
+                goal=np.array([100.0, 100.0]),
+            )
+        )
         env.reset()
         for _ in range(3):
             _, _, dones, _ = env.step({aid: np.array([0.1, 0.0])})
@@ -561,11 +589,13 @@ class TestEnvironmentRewardsAndDones:
     def test_progress_reward_positive_when_approaching_goal(self):
         cfg = EnvironmentConfig(dt=0.1, max_steps=100, goal_radius=0.5)
         env = ContinuousEnvironment(cfg)
-        aid = env.add_agent(AgentConfig(
-            position=np.array([0.0, 0.0]),
-            goal=np.array([10.0, 0.0]),
-            max_speed=5.0,
-        ))
+        aid = env.add_agent(
+            AgentConfig(
+                position=np.array([0.0, 0.0]),
+                goal=np.array([10.0, 0.0]),
+                max_speed=5.0,
+            )
+        )
         env.reset()
         _, rewards, _, _ = env.step({aid: np.array([2.0, 0.0])})
         # Moving toward goal should give positive progress reward (minus time penalty)
@@ -575,6 +605,7 @@ class TestEnvironmentRewardsAndDones:
 # ---------------------------------------------------------------------------
 # ContinuousEnvironment — statistics and snapshots
 # ---------------------------------------------------------------------------
+
 
 class TestEnvironmentStatisticsAndSnapshots:
     def test_get_statistics(self):
@@ -624,7 +655,9 @@ class TestEnvironmentStatisticsAndSnapshots:
         env.load_snapshot(snap)
         state = env.get_agent_state(0)
         np.testing.assert_allclose(
-            state.position, snap["agents"][0]["position"], atol=1e-6,
+            state.position,
+            snap["agents"][0]["position"],
+            atol=1e-6,
         )
 
     def test_load_snapshot_string_keys(self):
@@ -693,6 +726,7 @@ class TestEnvironmentStatisticsAndSnapshots:
 # ---------------------------------------------------------------------------
 # ScenarioConfig
 # ---------------------------------------------------------------------------
+
 
 class TestScenarioConfig:
     def test_defaults(self):

--- a/tests/test_continuous_obstacles.py
+++ b/tests/test_continuous_obstacles.py
@@ -34,9 +34,7 @@ def _unit_circle() -> CircleObstacle:
 
 def _triangle() -> PolygonObstacle:
     """CCW triangle centred near origin."""
-    return PolygonObstacle(
-        vertices=np.array([[0.0, 2.0], [-1.0, 0.0], [1.0, 0.0]])
-    )
+    return PolygonObstacle(vertices=np.array([[0.0, 2.0], [-1.0, 0.0], [1.0, 0.0]]))
 
 
 def _horizontal_wall() -> LineObstacle:
@@ -460,9 +458,7 @@ class TestPolygonObstacle:
 
     def test_polygon_square(self):
         """Test polygon with a square shape for more predictable geometry."""
-        sq = PolygonObstacle(
-            vertices=np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=float)
-        )
+        sq = PolygonObstacle(vertices=np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=float))
         assert sq.contains_point(np.array([1.0, 1.0]))
         assert not sq.contains_point(np.array([3.0, 1.0]))
 
@@ -475,16 +471,32 @@ class TestPolygonObstacle:
 class TestObstacleABC:
     def test_inflate_raises(self):
         """Default inflate raises NotImplementedError on a subclass that doesn't override it."""
+
         # Create a minimal concrete subclass without inflate
         class _BareObstacle(Obstacle):
-            def contains_point(self, p): return False
-            def distance_to_point(self, p): return 0.0
-            def intersects_circle(self, c, r): return False
-            def ray_cast(self, o, d): return None
-            def closest_point(self, p): return np.zeros(2)
-            def normal_at(self, p): return np.array([1.0, 0.0])
-            def get_bounding_box(self): return np.zeros(2), np.ones(2)
-            def get_vertices(self): return None
+            def contains_point(self, p):
+                return False
+
+            def distance_to_point(self, p):
+                return 0.0
+
+            def intersects_circle(self, c, r):
+                return False
+
+            def ray_cast(self, o, d):
+                return None
+
+            def closest_point(self, p):
+                return np.zeros(2)
+
+            def normal_at(self, p):
+                return np.array([1.0, 0.0])
+
+            def get_bounding_box(self):
+                return np.zeros(2), np.ones(2)
+
+            def get_vertices(self):
+                return None
 
         with pytest.raises(NotImplementedError):
             _BareObstacle().inflate(1.0)

--- a/tests/test_continuous_physics.py
+++ b/tests/test_continuous_physics.py
@@ -279,7 +279,8 @@ class TestCollisionResolution:
     def test_boundary_collision_restitution(self):
         engine = PhysicsEngine(
             config=PhysicsConfig(
-                damping=0.0, restitution=1.0,
+                damping=0.0,
+                restitution=1.0,
                 enable_collision_response=True,
                 integration_method=IntegrationMethod.EULER,
             ),

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -78,9 +78,7 @@ class TestMessageProtocol:
         assert msg.receiver is None
 
     def test_metadata(self):
-        msg = MessageProtocol(
-            sender="a1", receiver="a2", content="x", metadata={"priority": 5}
-        )
+        msg = MessageProtocol(sender="a1", receiver="a2", content="x", metadata={"priority": 5})
         assert msg.metadata["priority"] == 5
 
 
@@ -722,9 +720,7 @@ class TestVelocityObstaclePlanner:
         assert new_pos[0] > 0.0
 
     def test_two_agents_avoid_collision(self):
-        planner = VelocityObstaclePlanner(
-            time_horizon=5.0, max_speed=1.5, agent_radius=0.3
-        )
+        planner = VelocityObstaclePlanner(time_horizon=5.0, max_speed=1.5, agent_radius=0.3)
         # Two agents heading toward each other
         positions = np.array([[0.0, 0.0], [5.0, 0.0]])
         velocities = np.array([[1.0, 0.0], [-1.0, 0.0]])

--- a/tests/test_coordination_coverage.py
+++ b/tests/test_coordination_coverage.py
@@ -211,16 +211,11 @@ class TestDirectChannelExtended:
         def writer(sender, receiver, count):
             try:
                 for i in range(count):
-                    ch.send(
-                        MessageProtocol(sender=sender, receiver=receiver, content=i)
-                    )
+                    ch.send(MessageProtocol(sender=sender, receiver=receiver, content=i))
             except Exception as e:
                 errors.append(e)
 
-        threads = [
-            threading.Thread(target=writer, args=(f"s{i}", "target", 50))
-            for i in range(5)
-        ]
+        threads = [threading.Thread(target=writer, args=(f"s{i}", "target", 50)) for i in range(5)]
         for t in threads:
             t.start()
         for t in threads:
@@ -295,9 +290,7 @@ class TestSharedMemoryExtended:
             except Exception as e:
                 errors.append(e)
 
-        threads = [
-            threading.Thread(target=writer, args=(f"t{i}", 50)) for i in range(5)
-        ]
+        threads = [threading.Thread(target=writer, args=(f"t{i}", 50)) for i in range(5)]
         for t in threads:
             t.start()
         for t in threads:

--- a/tests/test_core_registry_validation.py
+++ b/tests/test_core_registry_validation.py
@@ -66,8 +66,7 @@ def _clean_registries():
 
 class _DummyBase(ABC):
     @abstractmethod
-    def step(self):
-        ...
+    def step(self): ...
 
 
 class _GoodPlugin(_DummyBase):
@@ -255,9 +254,7 @@ class TestSafePluginCall:
         assert result == 42
 
     def test_call_with_args(self):
-        result = safe_plugin_call(
-            lambda x, y: x + y, 3, 4, plugin_name="test", method_name="fn"
-        )
+        result = safe_plugin_call(lambda x, y: x + y, 3, 4, plugin_name="test", method_name="fn")
         assert result == 7
 
     def test_exception_wrapped(self):
@@ -273,9 +270,7 @@ class TestSafePluginCall:
             return "done"
 
         # This tests the timeout check after execution
-        result = safe_plugin_call(
-            slow, plugin_name="test", method_name="fn", timeout_s=10.0
-        )
+        result = safe_plugin_call(slow, plugin_name="test", method_name="fn", timeout_s=10.0)
         assert result == "done"
 
 
@@ -340,9 +335,7 @@ class TestHumanControllerRegistry:
         assert callable(factory)
 
     def test_register_class(self):
-        register_human_controller(
-            "hc_class", _GoodPlugin, enable_security_validation=True
-        )
+        register_human_controller("hc_class", _GoodPlugin, enable_security_validation=True)
         factory = get_human_controller("hc_class")
         assert callable(factory)
 
@@ -355,9 +348,7 @@ class TestHumanControllerRegistry:
             get_human_controller("nonexistent")
 
     def test_skip_security_validation(self):
-        register_human_controller(
-            "hc_nosec", _GoodPlugin, enable_security_validation=False
-        )
+        register_human_controller("hc_nosec", _GoodPlugin, enable_security_validation=False)
         assert "hc_nosec" in registry_snapshot()["human_controllers"]
 
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -26,14 +26,18 @@ class TestResolveRetentionHoursEdgeCases:
             resolve_retention_hours(-1.0, env_var="X", default_hours=24.0)
 
     def test_env_var_non_numeric_raises(self):
-        with mock.patch.dict(os.environ, {"TEST_RET": "abc"}):
-            with pytest.raises(ValueError, match="must be a number of hours"):
-                resolve_retention_hours(None, env_var="TEST_RET", default_hours=24.0)
+        with (
+            mock.patch.dict(os.environ, {"TEST_RET": "abc"}),
+            pytest.raises(ValueError, match="must be a number of hours"),
+        ):
+            resolve_retention_hours(None, env_var="TEST_RET", default_hours=24.0)
 
     def test_env_var_negative_raises(self):
-        with mock.patch.dict(os.environ, {"TEST_RET": "-5"}):
-            with pytest.raises(ValueError, match="must be >= 0"):
-                resolve_retention_hours(None, env_var="TEST_RET", default_hours=24.0)
+        with (
+            mock.patch.dict(os.environ, {"TEST_RET": "-5"}),
+            pytest.raises(ValueError, match="must be >= 0"),
+        ):
+            resolve_retention_hours(None, env_var="TEST_RET", default_hours=24.0)
 
     def test_env_var_valid(self):
         with mock.patch.dict(os.environ, {"TEST_RET": "48"}):
@@ -331,7 +335,6 @@ class TestRobotControllerPerformance:
             # Should get both warning (> max) and info (consistently slow)
             # Actually 0.9 * max < max, so no warning; check info
             # 0.9 * 0.1 = 0.09, which is < 0.1, so no warning
-            pass
         # Force consistently slow condition: step_count=20, comp_time > 0.8*max
         r._step_count = 20
         with mock.patch("navirl.robots.base.logger") as mock_logger:
@@ -341,12 +344,14 @@ class TestRobotControllerPerformance:
     def test_config_validation_error(self):
         from navirl.core.plugin_validation import ConfigValidationError
 
-        with mock.patch(
-            "navirl.robots.base.validate_controller_config",
-            side_effect=ConfigValidationError("bad config"),
+        with (
+            mock.patch(
+                "navirl.robots.base.validate_controller_config",
+                side_effect=ConfigValidationError("bad config"),
+            ),
+            pytest.raises(ConfigValidationError),
         ):
-            with pytest.raises(ConfigValidationError):
-                DummyRobot()
+            DummyRobot()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_crowd_dynamics.py
+++ b/tests/test_crowd_dynamics.py
@@ -51,9 +51,7 @@ class TestComputeDensity:
 
 class TestComputeFlowField:
     def test_empty(self):
-        flow = CrowdAnalyzer.compute_flow_field(
-            np.empty((0, 2)), np.empty((0, 2)), (0, 0, 10, 10)
-        )
+        flow = CrowdAnalyzer.compute_flow_field(np.empty((0, 2)), np.empty((0, 2)), (0, 0, 10, 10))
         assert flow.sum() == 0.0
 
     def test_single_agent(self):

--- a/tests/test_demonstration_dataset.py
+++ b/tests/test_demonstration_dataset.py
@@ -27,6 +27,7 @@ FeatureStatistics = _mod.FeatureStatistics
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def sample_data():
     """Return arrays for 50 transitions with obs_dim=4, act_dim=2."""
@@ -158,7 +159,10 @@ class TestLoadFromNavirlLogs:
         assert len(ds) == 30  # 3 episodes * 10
 
     def test_empty_dir_raises(self):
-        with tempfile.TemporaryDirectory() as td, pytest.raises(FileNotFoundError, match="No episode"):
+        with (
+            tempfile.TemporaryDirectory() as td,
+            pytest.raises(FileNotFoundError, match="No episode"),
+        ):
             DemonstrationDataset.load_from_navirl_logs(td)
 
     def test_with_optional_fields(self):
@@ -279,7 +283,10 @@ class TestFilterByReward:
         dones = np.zeros(n, dtype=np.float32)
         dones[9] = 1.0  # episode boundary at 9, then 10-19 is trailing
         ds = DemonstrationDataset(
-            observations=obs, actions=actions, rewards=rewards, dones=dones,
+            observations=obs,
+            actions=actions,
+            rewards=rewards,
+            dones=dones,
         )
         filtered = ds.filter_by_reward(min_return=1.0)
         assert len(filtered) == 20  # both chunks pass

--- a/tests/test_e2e_regression.py
+++ b/tests/test_e2e_regression.py
@@ -82,9 +82,7 @@ def test_canonical_scenario_invariants_pass(scenario_name: str, tmp_path: Path) 
     """Run *scenario_name* through the full pipeline and verify all invariants."""
     invariants = _run_and_validate(scenario_name, tmp_path)
 
-    failed_checks = [
-        c["name"] for c in invariants.get("checks", []) if not c.get("pass", False)
-    ]
+    failed_checks = [c["name"] for c in invariants.get("checks", []) if not c.get("pass", False)]
     assert invariants["overall_pass"], (
         f"Scenario {scenario_name!r} failed invariant checks: {failed_checks}"
     )
@@ -106,9 +104,7 @@ def test_complex_scenario_invariants_pass(scenario_name: str, tmp_path: Path) ->
             pytest.xfail(f"Scenario {scenario_name!r} hit deadlock: {exc}")
         raise
 
-    failed_checks = [
-        c["name"] for c in invariants.get("checks", []) if not c.get("pass", False)
-    ]
+    failed_checks = [c["name"] for c in invariants.get("checks", []) if not c.get("pass", False)]
     if not invariants["overall_pass"]:
         pytest.xfail(
             f"Scenario {scenario_name!r} failed invariant checks "
@@ -125,9 +121,7 @@ def test_complex_scenario_invariants_pass(scenario_name: str, tmp_path: Path) ->
 def test_hallway_pass_no_teleport(tmp_path: Path) -> None:
     """Hallway scenario must not produce any teleportation violations."""
     invariants = _run_and_validate("hallway_pass.yaml", tmp_path)
-    teleport = next(
-        (c for c in invariants["checks"] if c["name"] == "no_teleport"), None
-    )
+    teleport = next((c for c in invariants["checks"] if c["name"] == "no_teleport"), None)
     assert teleport is not None, "no_teleport check missing"
     assert teleport["pass"], f"Teleport violations: {teleport.get('violations', [])}"
 
@@ -136,9 +130,7 @@ def test_hallway_pass_no_teleport(tmp_path: Path) -> None:
 def test_doorway_token_exclusivity(tmp_path: Path) -> None:
     """Doorway scenario must enforce token-based exclusivity if check is present."""
     invariants = _run_and_validate("doorway_token_yield.yaml", tmp_path)
-    token_check = next(
-        (c for c in invariants["checks"] if c["name"] == "token_exclusivity"), None
-    )
+    token_check = next((c for c in invariants["checks"] if c["name"] == "token_exclusivity"), None)
     if token_check is not None:
         assert token_check["pass"], (
             f"Token exclusivity violated: {token_check.get('violations', [])}"
@@ -149,13 +141,10 @@ def test_doorway_token_exclusivity(tmp_path: Path) -> None:
 def test_hallway_no_wall_penetration(tmp_path: Path) -> None:
     """Hallway scenario must have zero wall penetration."""
     invariants = _run_and_validate("hallway_pass.yaml", tmp_path)
-    wall_check = next(
-        (c for c in invariants["checks"] if c["name"] == "no_wall_penetration"), None
-    )
+    wall_check = next((c for c in invariants["checks"] if c["name"] == "no_wall_penetration"), None)
     assert wall_check is not None, "no_wall_penetration check missing"
     assert wall_check["pass"], (
-        f"Wall penetration in hallway_pass: "
-        f"{wall_check.get('num_violations', '?')} violations"
+        f"Wall penetration in hallway_pass: {wall_check.get('num_violations', '?')} violations"
     )
 
 
@@ -176,9 +165,7 @@ def test_all_reliable_scenarios_produce_events_file(tmp_path: Path) -> None:
             video_override=False,
         )
         bundle_dir = Path(episode.bundle_dir)
-        assert (bundle_dir / "events.jsonl").exists(), (
-            f"{name}: events.jsonl not produced"
-        )
+        assert (bundle_dir / "events.jsonl").exists(), f"{name}: events.jsonl not produced"
 
 
 @pytest.mark.e2e

--- a/tests/test_env_scenarios.py
+++ b/tests/test_env_scenarios.py
@@ -26,7 +26,14 @@ from navirl.envs.scenarios import (
 # ---------------------------------------------------------------------------
 
 SEED = 42
-REQUIRED_KEYS = {"map_name", "robot_start", "robot_goal", "human_starts", "human_goals", "num_humans"}
+REQUIRED_KEYS = {
+    "map_name",
+    "robot_start",
+    "robot_goal",
+    "human_starts",
+    "human_goals",
+    "num_humans",
+}
 
 
 def _rng(seed: int = SEED) -> np.random.Generator:
@@ -156,7 +163,9 @@ class TestRandomGoal:
     def test_positions_within_world(self):
         sc = RandomGoal(world_size=4.0)
         cfg = sc.generate(_rng())
-        for pos in [cfg["robot_start"], cfg["robot_goal"]] + cfg["human_starts"] + cfg["human_goals"]:
+        for pos in (
+            [cfg["robot_start"], cfg["robot_goal"]] + cfg["human_starts"] + cfg["human_goals"]
+        ):
             assert -4.0 <= pos[0] <= 4.0
             assert -4.0 <= pos[1] <= 4.0
 
@@ -358,9 +367,7 @@ class TestOpenField:
         sc = OpenField(field_size=10.0, num_humans=5)
         cfg = sc.generate(_rng())
         for pos in (
-            [cfg["robot_start"], cfg["robot_goal"]]
-            + cfg["human_starts"]
-            + cfg["human_goals"]
+            [cfg["robot_start"], cfg["robot_goal"]] + cfg["human_starts"] + cfg["human_goals"]
         ):
             assert -10.0 <= pos[0] <= 10.0
             assert -10.0 <= pos[1] <= 10.0
@@ -483,4 +490,7 @@ class TestProceduralScenarioGenerator:
         cfg1 = gen.generate(_rng(1))
         cfg2 = gen.generate(_rng(2))
         # Very unlikely to be identical
-        assert cfg1["robot_start"] != cfg2["robot_start"] or cfg1["scenario_index"] != cfg2["scenario_index"]
+        assert (
+            cfg1["robot_start"] != cfg2["robot_start"]
+            or cfg1["scenario_index"] != cfg2["scenario_index"]
+        )

--- a/tests/test_episode_log.py
+++ b/tests/test_episode_log.py
@@ -23,6 +23,7 @@ from navirl.logging.episode_log import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_agent_state(agent_id=0, kind="robot", x=1.0, y=2.0, vx=0.5, vy=0.3):
     return AgentState(
         agent_id=agent_id,
@@ -74,9 +75,12 @@ class TestAgentTrajectory:
         traj = AgentTrajectory(agent_id=0, kind="robot")
         for i in range(n):
             pt = TrajectoryPoint(
-                step=i, time_s=float(i) * 0.1,
-                x=float(i), y=float(i) * 0.5,
-                vx=1.0, vy=0.5,
+                step=i,
+                time_s=float(i) * 0.1,
+                x=float(i),
+                y=float(i) * 0.5,
+                vx=1.0,
+                vy=0.5,
                 speed=math.sqrt(1.0 + 0.25),
                 heading=math.atan2(0.5, 1.0),
             )
@@ -281,7 +285,9 @@ class TestEpisodeLogger:
 
     def test_write_reward(self, tmp_path):
         with EpisodeLogger(tmp_path / "ep") as logger:
-            logger.write_reward(0, 0.0, agent_id=1, reward=1.5, components={"goal": 1.0, "time": 0.5})
+            logger.write_reward(
+                0, 0.0, agent_id=1, reward=1.5, components={"goal": 1.0, "time": 0.5}
+            )
             history = logger.get_reward_history(agent_id=1)
             assert len(history) == 1
             assert history[0]["reward"] == 1.5

--- a/tests/test_experiment_packs.py
+++ b/tests/test_experiment_packs.py
@@ -174,21 +174,15 @@ class TestPackResult:
         assert agg["intrusion_rate"]["std"] == pytest.approx(0.0)
 
     def test_aggregate_with_nan_values(self):
-        result = PackResult(
-            manifest_name="t", manifest_version="1", manifest_checksum="x"
-        )
+        result = PackResult(manifest_name="t", manifest_version="1", manifest_checksum="x")
         result.runs.append(
-            PackRunResult(
-                entry_id="a", seed=1, metrics={"m": float("inf")}, status="completed"
-            )
+            PackRunResult(entry_id="a", seed=1, metrics={"m": float("inf")}, status="completed")
         )
         agg = result.aggregate(["m"])
         assert math.isnan(agg["m"]["mean"])
 
     def test_aggregate_missing_metric(self):
-        result = PackResult(
-            manifest_name="t", manifest_version="1", manifest_checksum="x"
-        )
+        result = PackResult(manifest_name="t", manifest_version="1", manifest_checksum="x")
         result.runs.append(
             PackRunResult(entry_id="a", seed=1, metrics={"other": 1.0}, status="completed")
         )
@@ -196,15 +190,11 @@ class TestPackResult:
         assert math.isnan(agg["missing_metric"]["mean"])
 
     def test_aggregate_skips_failed_runs(self, sample_metrics):
-        result = PackResult(
-            manifest_name="t", manifest_version="1", manifest_checksum="x"
-        )
+        result = PackResult(manifest_name="t", manifest_version="1", manifest_checksum="x")
         result.runs.append(
             PackRunResult(entry_id="a", seed=1, metrics=sample_metrics, status="completed")
         )
-        result.runs.append(
-            PackRunResult(entry_id="a", seed=2, status="failed", error="boom")
-        )
+        result.runs.append(PackRunResult(entry_id="a", seed=2, status="failed", error="boom"))
         agg = result.aggregate(["success_rate"])
         assert agg["success_rate"]["mean"] == pytest.approx(1.0)
 
@@ -415,9 +405,7 @@ class TestMarkdownReporter:
         assert out.exists()
 
     def test_markdown_empty_result(self, tmp_path):
-        result = PackResult(
-            manifest_name="empty", manifest_version="1.0", manifest_checksum="x"
-        )
+        result = PackResult(manifest_name="empty", manifest_version="1.0", manifest_checksum="x")
         out = tmp_path / "report.md"
         write_pack_markdown(result, out, ["success_rate"])
         content = out.read_text()

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -41,11 +41,14 @@ class TestApplyOverrides:
             "horizon": {"dt": 0.1, "max_steps": 100},
             "scene": {"map": {"id": "hallway"}},
         }
-        result = _apply_overrides(scenario, {
-            "horizon.dt": 0.05,
-            "horizon.max_steps": 200,
-            "scene.map.id": "doorway",
-        })
+        result = _apply_overrides(
+            scenario,
+            {
+                "horizon.dt": 0.05,
+                "horizon.max_steps": 200,
+                "scene.map.id": "doorway",
+            },
+        )
         assert result["horizon"]["dt"] == 0.05
         assert result["horizon"]["max_steps"] == 200
         assert result["scene"]["map"]["id"] == "doorway"

--- a/tests/test_file_logger.py
+++ b/tests/test_file_logger.py
@@ -41,7 +41,9 @@ class TestLogLevel:
         assert LogLevel.CRITICAL == 50
 
     def test_ordering(self):
-        assert LogLevel.DEBUG < LogLevel.INFO < LogLevel.WARNING < LogLevel.ERROR < LogLevel.CRITICAL
+        assert (
+            LogLevel.DEBUG < LogLevel.INFO < LogLevel.WARNING < LogLevel.ERROR < LogLevel.CRITICAL
+        )
 
     def test_from_string_valid(self):
         assert LogLevel.from_string("INFO") is LogLevel.INFO

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -26,11 +26,21 @@ from navirl.robots.fleet import (
 # Helper to create AgentState instances
 # ---------------------------------------------------------------------------
 
-def _state(agent_id: int, x: float, y: float, vx: float = 0.0, vy: float = 0.0,
-           radius: float = 0.3) -> AgentState:
+
+def _state(
+    agent_id: int, x: float, y: float, vx: float = 0.0, vy: float = 0.0, radius: float = 0.3
+) -> AgentState:
     return AgentState(
-        agent_id=agent_id, kind="robot", x=x, y=y, vx=vx, vy=vy,
-        goal_x=0.0, goal_y=0.0, radius=radius, max_speed=1.0,
+        agent_id=agent_id,
+        kind="robot",
+        x=x,
+        y=y,
+        vx=vx,
+        vy=vy,
+        goal_x=0.0,
+        goal_y=0.0,
+        radius=radius,
+        max_speed=1.0,
     )
 
 
@@ -336,9 +346,12 @@ class TestFleetPlanner:
         assert result[1] == 1
 
     def test_compute_formation_targets(self):
-        planner = FleetPlanner(FormationConfig(
-            formation_type=FormationType.LINE, spacing=2.0,
-        ))
+        planner = FleetPlanner(
+            FormationConfig(
+                formation_type=FormationType.LINE,
+                spacing=2.0,
+            )
+        )
         centroid = np.array([5.0, 5.0])
         targets = planner.compute_formation_targets(centroid, 0.0, 3)
         assert targets.shape == (3, 2)
@@ -487,7 +500,8 @@ class TestRobotFleet:
         fleet = RobotFleet(
             controllers={0: ctrl0, 1: ctrl1},
             formation_config=FormationConfig(
-                formation_type=FormationType.LINE, spacing=2.0,
+                formation_type=FormationType.LINE,
+                spacing=2.0,
             ),
         )
         # Place robots at ideal formation positions

--- a/tests/test_geometry_extended.py
+++ b/tests/test_geometry_extended.py
@@ -77,37 +77,47 @@ class TestNormalizeVector:
 class TestCircleCircleIntersection:
     def test_no_intersection_far_apart(self):
         pts = circle_circle_intersection(
-            np.array([0.0, 0.0]), 1.0,
-            np.array([10.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
+            np.array([10.0, 0.0]),
+            1.0,
         )
         assert pts == []
 
     def test_no_intersection_concentric(self):
         pts = circle_circle_intersection(
-            np.array([0.0, 0.0]), 1.0,
-            np.array([0.0, 0.0]), 2.0,
+            np.array([0.0, 0.0]),
+            1.0,
+            np.array([0.0, 0.0]),
+            2.0,
         )
         assert pts == []
 
     def test_no_intersection_one_inside_other(self):
         pts = circle_circle_intersection(
-            np.array([0.0, 0.0]), 5.0,
-            np.array([1.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            5.0,
+            np.array([1.0, 0.0]),
+            1.0,
         )
         assert pts == []
 
     def test_tangent_externally(self):
         pts = circle_circle_intersection(
-            np.array([0.0, 0.0]), 1.0,
-            np.array([2.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
+            np.array([2.0, 0.0]),
+            1.0,
         )
         assert len(pts) == 1
         np.testing.assert_allclose(pts[0], [1.0, 0.0], atol=1e-10)
 
     def test_two_intersections(self):
         pts = circle_circle_intersection(
-            np.array([0.0, 0.0]), 1.0,
-            np.array([1.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
+            np.array([1.0, 0.0]),
+            1.0,
         )
         assert len(pts) == 2
         # Both points should be at distance 1 from each center
@@ -118,8 +128,10 @@ class TestCircleCircleIntersection:
     def test_identical_circles(self):
         # Same center, same radius -> concentric check returns empty
         pts = circle_circle_intersection(
-            np.array([1.0, 1.0]), 2.0,
-            np.array([1.0, 1.0]), 2.0,
+            np.array([1.0, 1.0]),
+            2.0,
+            np.array([1.0, 1.0]),
+            2.0,
         )
         assert pts == []
 
@@ -132,7 +144,8 @@ class TestCircleCircleIntersection:
 class TestCircleLineIntersection:
     def test_line_through_center(self):
         pts = circle_line_intersection(
-            np.array([0.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
             np.array([-2.0, 0.0]),
             np.array([2.0, 0.0]),
         )
@@ -143,7 +156,8 @@ class TestCircleLineIntersection:
 
     def test_line_tangent(self):
         pts = circle_line_intersection(
-            np.array([0.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
             np.array([-2.0, 1.0]),
             np.array([2.0, 1.0]),
         )
@@ -155,7 +169,8 @@ class TestCircleLineIntersection:
 
     def test_line_misses(self):
         pts = circle_line_intersection(
-            np.array([0.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
             np.array([-2.0, 5.0]),
             np.array([2.0, 5.0]),
         )
@@ -164,7 +179,8 @@ class TestCircleLineIntersection:
     def test_segment_partially_inside(self):
         # Segment from center to outside — one intersection
         pts = circle_line_intersection(
-            np.array([0.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
             np.array([0.0, 0.0]),
             np.array([2.0, 0.0]),
         )
@@ -174,7 +190,8 @@ class TestCircleLineIntersection:
     def test_degenerate_segment(self):
         # Zero-length segment
         pts = circle_line_intersection(
-            np.array([0.0, 0.0]), 1.0,
+            np.array([0.0, 0.0]),
+            1.0,
             np.array([0.5, 0.0]),
             np.array([0.5, 0.0]),
         )
@@ -188,9 +205,16 @@ class TestCircleLineIntersection:
 
 class TestConvexHull:
     def test_square(self):
-        points = np.array([
-            [0, 0], [1, 0], [1, 1], [0, 1], [0.5, 0.5],
-        ], dtype=float)
+        points = np.array(
+            [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+                [0.5, 0.5],
+            ],
+            dtype=float,
+        )
         hull = convex_hull(points)
         # Interior point should be excluded
         assert len(hull) == 4
@@ -242,9 +266,15 @@ class TestMinimumBoundingRectangle:
         assert height == 0.0
 
     def test_rectangle_axis_aligned(self):
-        points = np.array([
-            [0, 0], [4, 0], [4, 2], [0, 2],
-        ], dtype=float)
+        points = np.array(
+            [
+                [0, 0],
+                [4, 0],
+                [4, 2],
+                [0, 2],
+            ],
+            dtype=float,
+        )
         corners, width, height, angle = minimum_bounding_rectangle(points)
         dims = sorted([width, height])
         assert dims[0] == pytest.approx(2.0, abs=1e-6)
@@ -280,7 +310,10 @@ class TestTransform2D:
     def test_combined(self):
         pt = np.array([1.0, 0.0])
         result = transform_2d(
-            pt, translation=np.array([5.0, 0.0]), rotation=math.pi / 2, scale=2.0,
+            pt,
+            translation=np.array([5.0, 0.0]),
+            rotation=math.pi / 2,
+            scale=2.0,
         )
         # scale(1,0)*2 = (2,0), rotate 90° -> (0,2), translate -> (5,2)
         np.testing.assert_allclose(result, [5.0, 2.0], atol=1e-10)
@@ -400,18 +433,32 @@ class TestComputeArcLength:
 class TestSimplifyTrajectory:
     def test_straight_line(self):
         # Points on a line should simplify to just endpoints
-        positions = np.array([
-            [0, 0], [1, 0], [2, 0], [3, 0], [4, 0],
-        ], dtype=float)
+        positions = np.array(
+            [
+                [0, 0],
+                [1, 0],
+                [2, 0],
+                [3, 0],
+                [4, 0],
+            ],
+            dtype=float,
+        )
         simplified = simplify_trajectory(positions, epsilon=0.1)
         assert len(simplified) == 2
         np.testing.assert_allclose(simplified[0], [0, 0])
         np.testing.assert_allclose(simplified[-1], [4, 0])
 
     def test_l_shape(self):
-        positions = np.array([
-            [0, 0], [1, 0], [2, 0], [2, 1], [2, 2],
-        ], dtype=float)
+        positions = np.array(
+            [
+                [0, 0],
+                [1, 0],
+                [2, 0],
+                [2, 1],
+                [2, 2],
+            ],
+            dtype=float,
+        )
         simplified = simplify_trajectory(positions, epsilon=0.1)
         # Should keep the corner point
         assert len(simplified) >= 3
@@ -427,9 +474,16 @@ class TestSimplifyTrajectory:
 
     def test_large_epsilon(self):
         # Very large epsilon should reduce to endpoints
-        positions = np.array([
-            [0, 0], [1, 1], [2, 0], [3, 1], [4, 0],
-        ], dtype=float)
+        positions = np.array(
+            [
+                [0, 0],
+                [1, 1],
+                [2, 0],
+                [3, 1],
+                [4, 0],
+            ],
+            dtype=float,
+        )
         simplified = simplify_trajectory(positions, epsilon=100.0)
         assert len(simplified) == 2
 

--- a/tests/test_global_planners_extended.py
+++ b/tests/test_global_planners_extended.py
@@ -181,9 +181,7 @@ class TestRRTPlanner:
         assert idx == 1
 
     def test_collision_free_no_obstacles(self):
-        assert RRTPlanner._collision_free(
-            np.array([0.0, 0.0]), np.array([1.0, 1.0]), None
-        ) is True
+        assert RRTPlanner._collision_free(np.array([0.0, 0.0]), np.array([1.0, 1.0]), None) is True
 
     def test_collision_free_with_obstacle(self):
         obstacles = np.array([[0.5, 0.0, 0.2]])
@@ -194,9 +192,7 @@ class TestRRTPlanner:
 
     def test_collision_free_clear_path(self):
         obstacles = np.array([[5.0, 5.0, 0.2]])
-        result = RRTPlanner._collision_free(
-            np.array([0.0, 0.0]), np.array([1.0, 0.0]), obstacles
-        )
+        result = RRTPlanner._collision_free(np.array([0.0, 0.0]), np.array([1.0, 0.0]), obstacles)
         assert result is True
 
     def test_sample_goal_bias(self):
@@ -285,9 +281,7 @@ class TestRRTStarPlanner:
 class TestPRMPlanner:
     def test_plan_open_space(self, config_sampling):
         np.random.seed(42)
-        planner = PRMPlanner(
-            config=config_sampling, num_samples=200, k_neighbors=10
-        )
+        planner = PRMPlanner(config=config_sampling, num_samples=200, k_neighbors=10)
         start = np.array([0.0, 0.0])
         goal = np.array([3.0, 3.0])
         path = planner.plan(start, goal)

--- a/tests/test_goal_conditioned_prediction.py
+++ b/tests/test_goal_conditioned_prediction.py
@@ -23,6 +23,7 @@ from navirl.prediction.goal_conditioned import (
 # GoalConditionedPredictor — construction
 # ---------------------------------------------------------------------------
 
+
 class TestGoalConditionedPredictorConstruction:
     def test_default_params(self):
         p = GoalConditionedPredictor()
@@ -49,15 +50,18 @@ class TestGoalConditionedPredictorConstruction:
 # GoalConditionedPredictor — _estimate_goals
 # ---------------------------------------------------------------------------
 
+
 class TestEstimateGoals:
     def test_velocity_extrapolation(self):
         """With 2+ observations, goals should be extrapolated from velocity."""
         p = GoalConditionedPredictor(num_goals=5)
-        observed = np.array([
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [2.0, 0.0],
-        ])
+        observed = np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [2.0, 0.0],
+            ]
+        )
         goals = p._estimate_goals(observed)
         assert len(goals) >= 1
         # Goals should be ahead in the x direction
@@ -112,6 +116,7 @@ class TestEstimateGoals:
 # GoalConditionedPredictor — _plan_path_to_goal
 # ---------------------------------------------------------------------------
 
+
 class TestPlanPathToGoal:
     def test_output_shape(self):
         p = GoalConditionedPredictor(horizon=12, dt=0.4)
@@ -152,6 +157,7 @@ class TestPlanPathToGoal:
 # GoalConditionedPredictor — predict
 # ---------------------------------------------------------------------------
 
+
 class TestGoalConditionedPredict:
     def test_predict_output_type(self):
         p = GoalConditionedPredictor(horizon=8, num_goals=3, num_samples_per_goal=2)
@@ -164,7 +170,9 @@ class TestGoalConditionedPredict:
         num_goals = 3
         samples_per = 2
         p = GoalConditionedPredictor(
-            horizon=horizon, num_goals=num_goals, num_samples_per_goal=samples_per,
+            horizon=horizon,
+            num_goals=num_goals,
+            num_samples_per_goal=samples_per,
         )
         observed = np.array([[0.0, 0.0], [1.0, 0.5], [2.0, 1.0]])
         result = p.predict(observed)
@@ -212,6 +220,7 @@ class TestGoalConditionedPredict:
 # IntentPredictor — construction
 # ---------------------------------------------------------------------------
 
+
 class TestIntentPredictorConstruction:
     def test_default_params(self):
         ip = IntentPredictor()
@@ -233,6 +242,7 @@ class TestIntentPredictorConstruction:
 # IntentPredictor — classify
 # ---------------------------------------------------------------------------
 
+
 class TestIntentClassify:
     def test_too_few_observations_returns_unknown(self):
         ip = IntentPredictor()
@@ -245,13 +255,15 @@ class TestIntentClassify:
         """Agent moving in a straight line at constant speed."""
         ip = IntentPredictor(dt=0.1)
         # Constant velocity to the right
-        obs = np.array([
-            [0.0, 0.0],
-            [0.5, 0.0],
-            [1.0, 0.0],
-            [1.5, 0.0],
-            [2.0, 0.0],
-        ])
+        obs = np.array(
+            [
+                [0.0, 0.0],
+                [0.5, 0.0],
+                [1.0, 0.0],
+                [1.5, 0.0],
+                [2.0, 0.0],
+            ]
+        )
         intent, probs = ip.classify(obs)
         assert intent == PedestrianIntent.WALKING_STRAIGHT
         assert probs[PedestrianIntent.WALKING_STRAIGHT.value] > 0
@@ -260,25 +272,29 @@ class TestIntentClassify:
         """Agent decelerating to a stop."""
         ip = IntentPredictor(dt=0.1, stop_speed_threshold=0.5)
         # Decelerating
-        obs = np.array([
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [1.5, 0.0],
-            [1.7, 0.0],
-            [1.72, 0.0],  # Nearly stopped, decelerating
-        ])
+        obs = np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [1.5, 0.0],
+                [1.7, 0.0],
+                [1.72, 0.0],  # Nearly stopped, decelerating
+            ]
+        )
         intent, probs = ip.classify(obs)
         assert intent in (PedestrianIntent.STOPPING, PedestrianIntent.WAITING)
 
     def test_waiting(self):
         """Agent that is stationary (not decelerating, just standing)."""
         ip = IntentPredictor(dt=0.1, stop_speed_threshold=0.5)
-        obs = np.array([
-            [5.0, 5.0],
-            [5.0, 5.0],
-            [5.0, 5.0],
-            [5.0, 5.0],
-        ])
+        obs = np.array(
+            [
+                [5.0, 5.0],
+                [5.0, 5.0],
+                [5.0, 5.0],
+                [5.0, 5.0],
+            ]
+        )
         intent, probs = ip.classify(obs)
         assert intent == PedestrianIntent.WAITING
 
@@ -306,24 +322,28 @@ class TestIntentClassify:
         """Agent crossing laterally relative to road direction."""
         ip = IntentPredictor(dt=0.1, crossing_lateral_threshold=0.3)
         # Road goes in x direction, agent crosses in y direction
-        obs = np.array([
-            [5.0, 0.0],
-            [5.0, 1.0],
-            [5.0, 2.0],
-            [5.0, 3.0],
-        ])
+        obs = np.array(
+            [
+                [5.0, 0.0],
+                [5.0, 1.0],
+                [5.0, 2.0],
+                [5.0, 3.0],
+            ]
+        )
         context = {"road_direction": np.array([1.0, 0.0])}
         intent, probs = ip.classify(obs, context)
         assert intent == PedestrianIntent.CROSSING
 
     def test_classify_probabilities_sum_to_one(self):
         ip = IntentPredictor(dt=0.1)
-        obs = np.array([
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [2.0, 0.0],
-            [3.0, 0.0],
-        ])
+        obs = np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [2.0, 0.0],
+                [3.0, 0.0],
+            ]
+        )
         _, probs = ip.classify(obs)
         total = sum(probs.values())
         assert total == pytest.approx(1.0, abs=1e-6)
@@ -348,11 +368,17 @@ class TestIntentClassify:
 # PedestrianIntent enum
 # ---------------------------------------------------------------------------
 
+
 class TestPedestrianIntentEnum:
     def test_all_intents(self):
         expected = {
-            "crossing", "waiting", "turning_left", "turning_right",
-            "stopping", "walking_straight", "unknown",
+            "crossing",
+            "waiting",
+            "turning_left",
+            "turning_right",
+            "stopping",
+            "walking_straight",
+            "unknown",
         }
         actual = {i.value for i in PedestrianIntent}
         assert actual == expected
@@ -365,6 +391,7 @@ class TestPedestrianIntentEnum:
 # ---------------------------------------------------------------------------
 # _CandidateGoal
 # ---------------------------------------------------------------------------
+
 
 class TestCandidateGoal:
     def test_default_probability(self):

--- a/tests/test_group_behavior.py
+++ b/tests/test_group_behavior.py
@@ -24,8 +24,16 @@ from navirl.models.group_behavior import (
 
 def _state(aid: int, x: float, y: float, vx: float = 0.0, vy: float = 0.0, **kw) -> AgentState:
     defaults = {
-        "agent_id": aid, "kind": "human", "x": x, "y": y, "vx": vx, "vy": vy,
-        "goal_x": 0.0, "goal_y": 0.0, "radius": 0.25, "max_speed": 1.5,
+        "agent_id": aid,
+        "kind": "human",
+        "x": x,
+        "y": y,
+        "vx": vx,
+        "vy": vy,
+        "goal_x": 0.0,
+        "goal_y": 0.0,
+        "radius": 0.25,
+        "max_speed": 1.5,
     }
     defaults.update(kw)
     return AgentState(**defaults)

--- a/tests/test_human_controllers.py
+++ b/tests/test_human_controllers.py
@@ -279,12 +279,14 @@ class TestReplayHumanController:
         """Only 'human' agents should be loaded from replay."""
         replay_file = tmp_path / "replay.jsonl"
         lines = [
-            json.dumps({
-                "agents": [
-                    {"id": 1, "kind": "human", "x": 1.0, "y": 0.0},
-                    {"id": 2, "kind": "robot", "x": 99.0, "y": 99.0},
-                ]
-            }),
+            json.dumps(
+                {
+                    "agents": [
+                        {"id": 1, "kind": "human", "x": 1.0, "y": 0.0},
+                        {"id": 2, "kind": "robot", "x": 99.0, "y": 99.0},
+                    ]
+                }
+            ),
         ]
         replay_file.write_text("\n".join(lines) + "\n")
 
@@ -298,7 +300,9 @@ class TestReplayHumanController:
 
     def test_replay_empty_lines_skipped(self, tmp_path):
         replay_file = tmp_path / "replay.jsonl"
-        content = "\n" + json.dumps({"agents": [{"id": 1, "kind": "human", "x": 1.0, "y": 2.0}]}) + "\n\n"
+        content = (
+            "\n" + json.dumps({"agents": [{"id": 1, "kind": "human", "x": 1.0, "y": 2.0}]}) + "\n\n"
+        )
         replay_file.write_text(content)
 
         ctrl = ReplayHumanController({"path": str(replay_file)})
@@ -308,18 +312,22 @@ class TestReplayHumanController:
     def test_multiple_humans_replay(self, tmp_path):
         replay_file = tmp_path / "replay.jsonl"
         lines = [
-            json.dumps({
-                "agents": [
-                    {"id": 1, "kind": "human", "x": 0.0, "y": 0.0},
-                    {"id": 2, "kind": "human", "x": 5.0, "y": 5.0},
-                ]
-            }),
-            json.dumps({
-                "agents": [
-                    {"id": 1, "kind": "human", "x": 1.0, "y": 0.0},
-                    {"id": 2, "kind": "human", "x": 6.0, "y": 5.0},
-                ]
-            }),
+            json.dumps(
+                {
+                    "agents": [
+                        {"id": 1, "kind": "human", "x": 0.0, "y": 0.0},
+                        {"id": 2, "kind": "human", "x": 5.0, "y": 5.0},
+                    ]
+                }
+            ),
+            json.dumps(
+                {
+                    "agents": [
+                        {"id": 1, "kind": "human", "x": 1.0, "y": 0.0},
+                        {"id": 2, "kind": "human", "x": 6.0, "y": 5.0},
+                    ]
+                }
+            ),
         ]
         replay_file.write_text("\n".join(lines) + "\n")
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -231,7 +231,9 @@ class TestHeuristicJudgeIntrusion:
         summary["metrics"]["intrusion_rate"] = 0.85
         result = _heuristic_judge(summary, [], 0.6, False)
         # 0.85 < 0.92 major threshold for high interaction
-        intrusion_violations = [v for v in result["violations"] if v["type"] == "high_intrusion_rate"]
+        intrusion_violations = [
+            v for v in result["violations"] if v["type"] == "high_intrusion_rate"
+        ]
         assert not any(v["severity"] in ("blocker", "major") for v in intrusion_violations)
 
 

--- a/tests/test_monitoring_extended.py
+++ b/tests/test_monitoring_extended.py
@@ -196,11 +196,15 @@ class TestGetStatistics:
 class TestReset:
     def test_reset_clears_everything(self, monitor):
         alert = SafetyAlert(timestamp=1.0, severity=Severity.CRITICAL, constraint_name="c")
-        monitor.record_step(np.zeros(2), np.array([1.0, 0.0]), {
-            "violation": alert,
-            "shield_intervened": True,
-            "min_obstacle_dist": 0.3,
-        })
+        monitor.record_step(
+            np.zeros(2),
+            np.array([1.0, 0.0]),
+            {
+                "violation": alert,
+                "shield_intervened": True,
+                "min_obstacle_dist": 0.3,
+            },
+        )
         monitor.reset()
 
         stats = monitor.get_statistics()
@@ -227,18 +231,14 @@ class TestReset:
 
 class TestSafetyLogger:
     def test_log_alert_info(self, logger, caplog):
-        alert = SafetyAlert(
-            timestamp=1.0, severity=Severity.INFO, constraint_name="speed_check"
-        )
+        alert = SafetyAlert(timestamp=1.0, severity=Severity.INFO, constraint_name="speed_check")
         with caplog.at_level(logging.DEBUG, logger="navirl.safety"):
             logger.log_alert(alert)
         assert "speed_check" in caplog.text
         assert "INFO" in caplog.text
 
     def test_log_alert_warning(self, logger, caplog):
-        alert = SafetyAlert(
-            timestamp=1.0, severity=Severity.WARNING, constraint_name="distance"
-        )
+        alert = SafetyAlert(timestamp=1.0, severity=Severity.WARNING, constraint_name="distance")
         with caplog.at_level(logging.DEBUG, logger="navirl.safety"):
             logger.log_alert(alert)
         assert "distance" in caplog.text
@@ -246,7 +246,9 @@ class TestSafetyLogger:
 
     def test_log_alert_critical(self, logger, caplog):
         alert = SafetyAlert(
-            timestamp=1.0, severity=Severity.CRITICAL, constraint_name="collision",
+            timestamp=1.0,
+            severity=Severity.CRITICAL,
+            constraint_name="collision",
             details={"agent": "robot_1"},
         )
         with caplog.at_level(logging.DEBUG, logger="navirl.safety"):

--- a/tests/test_multi_backend.py
+++ b/tests/test_multi_backend.py
@@ -90,9 +90,7 @@ class TestSceneBackendContract:
         # Agent should have moved in +x direction
         assert pos[0] > 5.0
 
-    def test_get_velocity_returns_tuple(
-        self, continuous_backend: ContinuousSceneBackend
-    ) -> None:
+    def test_get_velocity_returns_tuple(self, continuous_backend: ContinuousSceneBackend) -> None:
         continuous_backend.add_agent(0, (5.0, 5.0), 0.3, 1.5, "robot")
         continuous_backend.set_preferred_velocity(0, (1.0, 0.5))
         continuous_backend.step()
@@ -100,9 +98,7 @@ class TestSceneBackendContract:
         assert isinstance(vel, tuple)
         assert len(vel) == 2
 
-    def test_step_updates_position(
-        self, continuous_backend: ContinuousSceneBackend
-    ) -> None:
+    def test_step_updates_position(self, continuous_backend: ContinuousSceneBackend) -> None:
         continuous_backend.add_agent(0, (5.0, 5.0), 0.3, 1.5, "robot")
         continuous_backend.set_preferred_velocity(0, (0.0, 1.0))
         pos_before = continuous_backend.get_position(0)
@@ -130,9 +126,7 @@ class TestSceneBackendContract:
         assert math.isclose(path[-1][0], goal[0], abs_tol=0.5)
         assert math.isclose(path[-1][1], goal[1], abs_tol=0.5)
 
-    def test_sample_free_point(
-        self, continuous_backend: ContinuousSceneBackend
-    ) -> None:
+    def test_sample_free_point(self, continuous_backend: ContinuousSceneBackend) -> None:
         pt = continuous_backend.sample_free_point()
         assert isinstance(pt, tuple)
         assert len(pt) == 2
@@ -156,17 +150,13 @@ class TestSceneBackendContract:
         self, continuous_backend_with_obstacles: ContinuousSceneBackend
     ) -> None:
         # Circle obstacle at (10, 10) r=2 → point (10, 10) should collide
-        assert continuous_backend_with_obstacles.check_obstacle_collision(
-            (10.0, 10.0), 0.3
-        )
+        assert continuous_backend_with_obstacles.check_obstacle_collision((10.0, 10.0), 0.3)
 
     def test_check_obstacle_collision_outside(
         self, continuous_backend_with_obstacles: ContinuousSceneBackend
     ) -> None:
         # Well outside any obstacle
-        assert not continuous_backend_with_obstacles.check_obstacle_collision(
-            (18.0, 18.0), 0.3
-        )
+        assert not continuous_backend_with_obstacles.check_obstacle_collision((18.0, 18.0), 0.3)
 
     def test_world_to_map(self, continuous_backend: ContinuousSceneBackend) -> None:
         result = continuous_backend.world_to_map((10.0, 10.0))
@@ -295,7 +285,9 @@ class TestContinuousAdapterSpecific:
         assert len(path) >= 2
         # Path should go around the obstacle (y > ~15 or different route)
         # At minimum, it should not be a straight line through the wall
-        assert any(pt[1] > 10.0 or pt[0] < 9.0 or pt[0] > 11.0 for pt in path[1:-1]) or len(path) > 2
+        assert (
+            any(pt[1] > 10.0 or pt[0] < 9.0 or pt[0] > 11.0 for pt in path[1:-1]) or len(path) > 2
+        )
 
     def test_shortest_path_direct_line_of_sight(self) -> None:
         backend = ContinuousSceneBackend({}, {"dt": 0.1})
@@ -304,9 +296,7 @@ class TestContinuousAdapterSpecific:
         assert len(path) == 2
 
     def test_world_to_map_corners(self) -> None:
-        backend = ContinuousSceneBackend(
-            {"width": 10.0, "height": 10.0}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 10.0, "height": 10.0}, {"dt": 0.1})
         # Origin should map to bottom-left of the image
         r, c = backend.world_to_map((0.0, 0.0))
         assert r >= 0 and c >= 0
@@ -383,9 +373,7 @@ class TestCrossBackendCompatibility:
 
     def test_both_backends_add_agent_and_query(self) -> None:
         """Both backends support the same add_agent → get_position flow."""
-        backend = ContinuousSceneBackend(
-            {"width": 20, "height": 20}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 20, "height": 20}, {"dt": 0.1})
         backend.add_agent(0, (5.0, 5.0), 0.3, 1.5, "robot")
         backend.add_agent(1, (15.0, 15.0), 0.3, 1.2, "human")
 
@@ -397,9 +385,7 @@ class TestCrossBackendCompatibility:
 
     def test_step_velocity_movement(self) -> None:
         """Setting preferred velocity and stepping produces motion."""
-        backend = ContinuousSceneBackend(
-            {"width": 20, "height": 20}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 20, "height": 20}, {"dt": 0.1})
         backend.add_agent(0, (5.0, 5.0), 0.3, 1.5, "robot")
         backend.set_preferred_velocity(0, (1.0, 0.0))
         backend.step()
@@ -408,9 +394,7 @@ class TestCrossBackendCompatibility:
 
     def test_shortest_path_contract(self) -> None:
         """shortest_path returns a valid path for both backends."""
-        backend = ContinuousSceneBackend(
-            {"width": 20, "height": 20}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 20, "height": 20}, {"dt": 0.1})
         path = backend.shortest_path((1.0, 1.0), (19.0, 19.0))
         assert len(path) >= 2
         # First and last points should be near start/goal
@@ -419,9 +403,7 @@ class TestCrossBackendCompatibility:
 
     def test_sample_free_point_returns_valid(self) -> None:
         """sample_free_point returns a point inside the world."""
-        backend = ContinuousSceneBackend(
-            {"width": 20, "height": 20}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 20, "height": 20}, {"dt": 0.1})
         for _ in range(10):
             pt = backend.sample_free_point()
             assert 0 <= pt[0] <= 20.0
@@ -443,26 +425,20 @@ class TestCrossBackendCompatibility:
 
     def test_map_image_valid_format(self) -> None:
         """map_image returns a 2D uint8 ndarray for both backends."""
-        backend = ContinuousSceneBackend(
-            {"width": 10, "height": 10}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 10, "height": 10}, {"dt": 0.1})
         img = backend.map_image()
         assert isinstance(img, np.ndarray)
         assert img.ndim == 2
         assert img.dtype == np.uint8
 
     def test_world_to_map_valid_format(self) -> None:
-        backend = ContinuousSceneBackend(
-            {"width": 20, "height": 20}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 20, "height": 20}, {"dt": 0.1})
         r, c = backend.world_to_map((10.0, 10.0))
         assert isinstance(r, int)
         assert isinstance(c, int)
 
     def test_map_metadata_valid_format(self) -> None:
-        backend = ContinuousSceneBackend(
-            {"width": 20, "height": 20}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 20, "height": 20}, {"dt": 0.1})
         meta = backend.map_metadata()
         assert isinstance(meta, dict)
 
@@ -517,9 +493,7 @@ class TestScenarioPortability:
     """Document which scenario features are portable and which are not."""
 
     def test_empty_world_works(self) -> None:
-        backend = ContinuousSceneBackend(
-            {"width": 10, "height": 10}, {"dt": 0.1}
-        )
+        backend = ContinuousSceneBackend({"width": 10, "height": 10}, {"dt": 0.1})
         backend.add_agent(0, (5.0, 5.0), 0.3, 1.5, "robot")
         backend.step()
         pos = backend.get_position(0)

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -74,8 +74,12 @@ def sample_shard_result():
         shard_id=0,
         manifest_id="abc123",
         records=[
-            RunRecord(scenario="hallway", seed=42, metrics={"success_rate": 1.0}, status="completed"),
-            RunRecord(scenario="kitchen", seed=42, metrics={"success_rate": 0.5}, status="completed"),
+            RunRecord(
+                scenario="hallway", seed=42, metrics={"success_rate": 1.0}, status="completed"
+            ),
+            RunRecord(
+                scenario="kitchen", seed=42, metrics={"success_rate": 0.5}, status="completed"
+            ),
         ],
         status="completed",
         attempts=1,
@@ -200,7 +204,9 @@ class TestTaskStatus:
 
 class TestTaskShard:
     def test_creation(self):
-        shard = TaskShard(shard_id=0, tasks=[{"scenario": Path("a.yaml"), "seed": 1, "overrides": {}}])
+        shard = TaskShard(
+            shard_id=0, tasks=[{"scenario": Path("a.yaml"), "seed": 1, "overrides": {}}]
+        )
         assert shard.shard_id == 0
         assert shard.num_tasks == 1
 
@@ -209,14 +215,18 @@ class TestTaskShard:
         assert shard.num_tasks == 0
 
     def test_to_dict(self):
-        shard = TaskShard(shard_id=0, tasks=[{"scenario": Path("a.yaml"), "seed": 1, "overrides": {}}])
+        shard = TaskShard(
+            shard_id=0, tasks=[{"scenario": Path("a.yaml"), "seed": 1, "overrides": {}}]
+        )
         d = shard.to_dict()
         assert d["shard_id"] == 0
         assert len(d["tasks"]) == 1
         assert d["tasks"][0]["scenario"] == "a.yaml"
 
     def test_from_dict_roundtrip(self):
-        shard = TaskShard(shard_id=3, tasks=[{"scenario": Path("b.yaml"), "seed": 7, "overrides": {"x": 1}}])
+        shard = TaskShard(
+            shard_id=3, tasks=[{"scenario": Path("b.yaml"), "seed": 7, "overrides": {"x": 1}}]
+        )
         d = shard.to_dict()
         restored = TaskShard.from_dict(d)
         assert restored.shard_id == 3
@@ -385,16 +395,28 @@ class TestResultStore:
 
     def test_merge_results(self, tmp_path):
         store = ResultStore(tmp_path / "results")
-        store.save(ShardResult(
-            shard_id=0,
-            records=[RunRecord(scenario="a", seed=1, metrics={"success_rate": 1.0}, status="completed")],
-            status="completed",
-        ))
-        store.save(ShardResult(
-            shard_id=1,
-            records=[RunRecord(scenario="b", seed=2, metrics={"success_rate": 0.5}, status="completed")],
-            status="completed",
-        ))
+        store.save(
+            ShardResult(
+                shard_id=0,
+                records=[
+                    RunRecord(
+                        scenario="a", seed=1, metrics={"success_rate": 1.0}, status="completed"
+                    )
+                ],
+                status="completed",
+            )
+        )
+        store.save(
+            ShardResult(
+                shard_id=1,
+                records=[
+                    RunRecord(
+                        scenario="b", seed=2, metrics={"success_rate": 0.5}, status="completed"
+                    )
+                ],
+                status="completed",
+            )
+        )
         summary = store.merge_results(num_shards=2, template_name="test")
         assert isinstance(summary, BatchSummary)
         assert summary.total_runs == 2
@@ -402,11 +424,13 @@ class TestResultStore:
 
     def test_merge_with_missing_shard(self, tmp_path):
         store = ResultStore(tmp_path / "results")
-        store.save(ShardResult(
-            shard_id=0,
-            records=[RunRecord(scenario="a", seed=1, metrics={}, status="completed")],
-            status="completed",
-        ))
+        store.save(
+            ShardResult(
+                shard_id=0,
+                records=[RunRecord(scenario="a", seed=1, metrics={}, status="completed")],
+                status="completed",
+            )
+        )
         # Shard 1 is missing
         summary = store.merge_results(num_shards=2, template_name="test")
         assert summary.total_runs == 1
@@ -438,7 +462,9 @@ class TestOrchestratorConfig:
         assert cfg.video is False
 
     def test_custom_values(self):
-        cfg = OrchestratorConfig(num_shards=8, max_retries=5, max_workers=2, render=True, video=True)
+        cfg = OrchestratorConfig(
+            num_shards=8, max_retries=5, max_workers=2, render=True, video=True
+        )
         assert cfg.num_shards == 8
         assert cfg.max_retries == 5
         assert cfg.max_workers == 2
@@ -584,14 +610,18 @@ class TestLocalExecutor:
     @patch("navirl.orchestration.executor._worker_entry")
     def test_multiple_tasks_sequential(self, mock_worker, tmp_path):
         mock_worker.side_effect = [
-            {"task_id": f"t{i}", "status": "completed", "metrics": {}, "bundle_dir": "", "error": "", "wall_time_s": 0.1}
+            {
+                "task_id": f"t{i}",
+                "status": "completed",
+                "metrics": {},
+                "bundle_dir": "",
+                "error": "",
+                "wall_time_s": 0.1,
+            }
             for i in range(3)
         ]
         executor = LocalExecutor(max_workers=1)
-        tasks = [
-            SimulationTask(task_id=f"t{i}", scenario_path="s.yaml", seed=i)
-            for i in range(3)
-        ]
+        tasks = [SimulationTask(task_id=f"t{i}", scenario_path="s.yaml", seed=i) for i in range(3)]
         results = executor.execute_batch(tasks, str(tmp_path))
         assert len(results) == 3
         assert all(r.status == TaskStatus.COMPLETED for r in results)
@@ -624,7 +654,9 @@ class TestShardWorker:
 
             from navirl.orchestration.worker import ShardWorker
 
-            shard = TaskShard(shard_id=0, tasks=[{"scenario": Path("a.yaml"), "seed": 1, "overrides": {}}])
+            shard = TaskShard(
+                shard_id=0, tasks=[{"scenario": Path("a.yaml"), "seed": 1, "overrides": {}}]
+            )
             worker = ShardWorker(shard=shard, out_root=str(tmp_path))
             result = worker.run()
 
@@ -633,10 +665,14 @@ class TestShardWorker:
         assert result.records[0].status == "completed"
 
     def test_all_tasks_fail(self, tmp_path):
-        with patch("navirl.orchestration.worker.load_scenario", side_effect=FileNotFoundError("nope")):
+        with patch(
+            "navirl.orchestration.worker.load_scenario", side_effect=FileNotFoundError("nope")
+        ):
             from navirl.orchestration.worker import ShardWorker
 
-            shard = TaskShard(shard_id=0, tasks=[{"scenario": Path("bad.yaml"), "seed": 1, "overrides": {}}])
+            shard = TaskShard(
+                shard_id=0, tasks=[{"scenario": Path("bad.yaml"), "seed": 1, "overrides": {}}]
+            )
             worker = ShardWorker(shard=shard, out_root=str(tmp_path))
             result = worker.run()
 
@@ -647,10 +683,14 @@ class TestShardWorker:
     def test_saves_to_result_store(self, tmp_path):
         store = ResultStore(tmp_path / "results")
 
-        with patch("navirl.orchestration.worker.load_scenario", side_effect=FileNotFoundError("nope")):
+        with patch(
+            "navirl.orchestration.worker.load_scenario", side_effect=FileNotFoundError("nope")
+        ):
             from navirl.orchestration.worker import ShardWorker
 
-            shard = TaskShard(shard_id=0, tasks=[{"scenario": Path("x.yaml"), "seed": 1, "overrides": {}}])
+            shard = TaskShard(
+                shard_id=0, tasks=[{"scenario": Path("x.yaml"), "seed": 1, "overrides": {}}]
+            )
             worker = ShardWorker(shard=shard, out_root=str(tmp_path), result_store=store)
             worker.run()
 
@@ -692,7 +732,9 @@ class TestExecuteSingleTask:
         assert result.wall_time_s > 0
 
     def test_failed_execution_returns_error(self, tmp_path):
-        with patch("navirl.orchestration.executor.load_scenario", side_effect=FileNotFoundError("nope")):
+        with patch(
+            "navirl.orchestration.executor.load_scenario", side_effect=FileNotFoundError("nope")
+        ):
             task = SimulationTask(task_id="t1", scenario_path="nonexistent.yaml", seed=1)
             result = _execute_single_task(task, str(tmp_path))
 
@@ -723,14 +765,21 @@ class TestCLIOrchestrate:
         from navirl.cli import build_parser
 
         parser = build_parser()
-        args = parser.parse_args([
-            "orchestrate", "t.yaml",
-            "--shards", "8",
-            "--workers", "4",
-            "--retries", "3",
-            "--resume",
-            "--out", "/tmp/custom",
-        ])
+        args = parser.parse_args(
+            [
+                "orchestrate",
+                "t.yaml",
+                "--shards",
+                "8",
+                "--workers",
+                "4",
+                "--retries",
+                "3",
+                "--resume",
+                "--out",
+                "/tmp/custom",
+            ]
+        )
         assert args.shards == 8
         assert args.workers == 4
         assert args.retries == 3

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -25,9 +25,7 @@ from navirl.orchestration.result_store import ResultStore, ShardResult
 def _make_template(name: str = "test_template", num_tasks: int = 4) -> MagicMock:
     template = MagicMock(spec=BatchTemplate)
     template.name = name
-    template.expand_tasks.return_value = [
-        MagicMock(task_id=f"task_{i}") for i in range(num_tasks)
-    ]
+    template.expand_tasks.return_value = [MagicMock(task_id=f"task_{i}") for i in range(num_tasks)]
     return template
 
 

--- a/tests/test_overseer_provider.py
+++ b/tests/test_overseer_provider.py
@@ -32,6 +32,7 @@ from navirl.overseer.provider import (
 # ProviderConfig
 # ---------------------------------------------------------------------------
 
+
 class TestProviderConfig:
     def test_defaults(self):
         cfg = ProviderConfig()
@@ -44,7 +45,10 @@ class TestProviderConfig:
     def test_normalized_provider(self):
         assert ProviderConfig(provider="Codex").normalized_provider() == "codex"
         assert ProviderConfig(provider="  Claude  ").normalized_provider() == "claude"
-        assert ProviderConfig(provider="OPENAI_COMPATIBLE").normalized_provider() == "openai_compatible"
+        assert (
+            ProviderConfig(provider="OPENAI_COMPATIBLE").normalized_provider()
+            == "openai_compatible"
+        )
 
     def test_normalized_provider_none(self):
         cfg = ProviderConfig(provider=None)
@@ -54,6 +58,7 @@ class TestProviderConfig:
 # ---------------------------------------------------------------------------
 # _validate_file_path
 # ---------------------------------------------------------------------------
+
 
 class TestValidateFilePath:
     def test_valid_file(self, tmp_path):
@@ -74,19 +79,31 @@ class TestValidateFilePath:
         f = tmp_path / "big.bin"
         f.write_bytes(b"\0")
         real_stat = f.stat()
-        fake_stat = os.stat_result((
-            real_stat.st_mode, real_stat.st_ino, real_stat.st_dev,
-            real_stat.st_nlink, real_stat.st_uid, real_stat.st_gid,
-            MAX_FILE_SIZE + 1,  # st_size
-            real_stat.st_atime, real_stat.st_mtime, real_stat.st_ctime,
-        ))
-        with mock.patch("navirl.overseer.provider.Path.stat", return_value=fake_stat), pytest.raises(ProviderCallError, match="too large"):
+        fake_stat = os.stat_result(
+            (
+                real_stat.st_mode,
+                real_stat.st_ino,
+                real_stat.st_dev,
+                real_stat.st_nlink,
+                real_stat.st_uid,
+                real_stat.st_gid,
+                MAX_FILE_SIZE + 1,  # st_size
+                real_stat.st_atime,
+                real_stat.st_mtime,
+                real_stat.st_ctime,
+            )
+        )
+        with (
+            mock.patch("navirl.overseer.provider.Path.stat", return_value=fake_stat),
+            pytest.raises(ProviderCallError, match="too large"),
+        ):
             _validate_file_path(str(f))
 
 
 # ---------------------------------------------------------------------------
 # _extract_json_text
 # ---------------------------------------------------------------------------
+
 
 class TestExtractJsonText:
     def test_plain_json_object(self):
@@ -124,6 +141,7 @@ class TestExtractJsonText:
 # _parse_json_object
 # ---------------------------------------------------------------------------
 
+
 class TestParseJsonObject:
     def test_valid_json(self):
         result = _parse_json_object('{"a": 1, "b": [2, 3]}')
@@ -144,6 +162,7 @@ class TestParseJsonObject:
 # ---------------------------------------------------------------------------
 # _strict_json_schema_for_codex
 # ---------------------------------------------------------------------------
+
 
 class TestStrictJsonSchema:
     def test_adds_additional_properties_false(self):
@@ -214,6 +233,7 @@ class TestStrictJsonSchema:
 # _resolve_native_command
 # ---------------------------------------------------------------------------
 
+
 class TestResolveNativeCommand:
     def test_explicit_native_cmd(self):
         cfg = ProviderConfig(native_cmd="/usr/bin/my-tool")
@@ -274,6 +294,7 @@ class TestResolveNativeCommand:
 # run_structured_vlm — dispatch
 # ---------------------------------------------------------------------------
 
+
 class TestRunStructuredVlm:
     def test_unsupported_provider_raises(self):
         cfg = ProviderConfig(provider="nonexistent_provider")
@@ -287,7 +308,10 @@ class TestRunStructuredVlm:
 
     def test_native_provider_no_cmd_raises(self):
         cfg = ProviderConfig(provider="codex", native_cmd=None)
-        with mock.patch.dict(os.environ, {"NAVIRL_CODEX_CMD": ""}, clear=False), pytest.raises(ProviderUnavailableError, match="No native command"):
+        with (
+            mock.patch.dict(os.environ, {"NAVIRL_CODEX_CMD": ""}, clear=False),
+            pytest.raises(ProviderUnavailableError, match="No native command"),
+        ):
             run_structured_vlm(
                 prompt="test",
                 image_paths=[],
@@ -311,17 +335,29 @@ class TestRunStructuredVlm:
     def test_codex_routes_to_native(self):
         """Codex provider should route to _run_native_json."""
         cfg = ProviderConfig(provider="codex", native_cmd=None)
-        with mock.patch.dict(os.environ, {"NAVIRL_CODEX_CMD": ""}, clear=False), pytest.raises(ProviderUnavailableError, match="No native command"):
+        with (
+            mock.patch.dict(os.environ, {"NAVIRL_CODEX_CMD": ""}, clear=False),
+            pytest.raises(ProviderUnavailableError, match="No native command"),
+        ):
             run_structured_vlm(
-                prompt="test", image_paths=[], schema={}, config=cfg,
+                prompt="test",
+                image_paths=[],
+                schema={},
+                config=cfg,
             )
 
     def test_claude_routes_to_native(self):
         """Claude provider should route to _run_native_json."""
         cfg = ProviderConfig(provider="claude", native_cmd=None)
-        with mock.patch.dict(os.environ, {"NAVIRL_CLAUDE_CMD": ""}, clear=False), pytest.raises(ProviderUnavailableError, match="No native command"):
+        with (
+            mock.patch.dict(os.environ, {"NAVIRL_CLAUDE_CMD": ""}, clear=False),
+            pytest.raises(ProviderUnavailableError, match="No native command"),
+        ):
             run_structured_vlm(
-                prompt="test", image_paths=[], schema={}, config=cfg,
+                prompt="test",
+                image_paths=[],
+                schema={},
+                config=cfg,
             )
 
     def test_kimi_routes_to_openai_compatible(self):
@@ -330,13 +366,17 @@ class TestRunStructuredVlm:
         os.environ.pop("NONEXISTENT_KEY_12345", None)
         with pytest.raises(ProviderUnavailableError, match="Missing API key"):
             run_structured_vlm(
-                prompt="test", image_paths=[], schema={}, config=cfg,
+                prompt="test",
+                image_paths=[],
+                schema={},
+                config=cfg,
             )
 
 
 # ---------------------------------------------------------------------------
 # ProviderCallError and ProviderUnavailableError
 # ---------------------------------------------------------------------------
+
 
 class TestExceptions:
     def test_provider_call_error_is_runtime_error(self):

--- a/tests/test_pedestrian_models.py
+++ b/tests/test_pedestrian_models.py
@@ -459,9 +459,7 @@ class TestCrowdAnalyzer:
         assert grid[0, 1] == 0.0
 
     def test_flow_field_empty(self):
-        flow = CrowdAnalyzer.compute_flow_field(
-            np.empty((0, 2)), np.empty((0, 2)), (0, 0, 10, 10)
-        )
+        flow = CrowdAnalyzer.compute_flow_field(np.empty((0, 2)), np.empty((0, 2)), (0, 0, 10, 10))
         assert np.all(flow == 0.0)
 
     def test_flow_field_single_agent(self):

--- a/tests/test_plugin_registry_extended.py
+++ b/tests/test_plugin_registry_extended.py
@@ -68,12 +68,10 @@ def _clean_registries():
 
 class _Base(ABC):
     @abstractmethod
-    def step(self):
-        ...
+    def step(self): ...
 
     @abstractmethod
-    def reset(self):
-        ...
+    def reset(self): ...
 
 
 class _FullImpl(_Base):
@@ -260,7 +258,10 @@ class TestSafePluginCallExtended:
 
         with pytest.raises(PluginPerformanceError, match="exceeded timeout"):
             safe_plugin_call(
-                slow, plugin_name="test", method_name="fn", timeout_s=0.001,
+                slow,
+                plugin_name="test",
+                method_name="fn",
+                timeout_s=0.001,
             )
 
     def test_performance_error_passthrough(self):
@@ -269,7 +270,9 @@ class TestSafePluginCallExtended:
 
         with pytest.raises(PluginPerformanceError, match="custom perf error"):
             safe_plugin_call(
-                raises_perf, plugin_name="test", method_name="fn",
+                raises_perf,
+                plugin_name="test",
+                method_name="fn",
             )
 
     def test_kwargs_forwarded(self):
@@ -277,7 +280,11 @@ class TestSafePluginCallExtended:
             return a + b
 
         result = safe_plugin_call(
-            fn, 5, plugin_name="test", method_name="fn", b=20,
+            fn,
+            5,
+            plugin_name="test",
+            method_name="fn",
+            b=20,
         )
         assert result == 25
 
@@ -444,7 +451,9 @@ class TestGetPluginInfoExtended:
                 pass
 
         register_robot_controller(
-            "doc_rc", DocPlugin, enable_security_validation=False,
+            "doc_rc",
+            DocPlugin,
+            enable_security_validation=False,
         )
         info = get_plugin_info("robot_controller", "doc_rc")
         assert "A documented plugin" in info["doc"]
@@ -453,7 +462,9 @@ class TestGetPluginInfoExtended:
 
     def test_class_without_docstring(self):
         register_human_controller(
-            "nodoc_hc", _FullImpl, enable_security_validation=False,
+            "nodoc_hc",
+            _FullImpl,
+            enable_security_validation=False,
         )
         info = get_plugin_info("human_controller", "nodoc_hc")
         assert "init_parameters" in info

--- a/tests/test_policy_controllers.py
+++ b/tests/test_policy_controllers.py
@@ -26,6 +26,7 @@ from navirl.models.learned_robot_policy import (
 #  Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_state(
     agent_id: int,
     kind: str = "human",
@@ -60,6 +61,7 @@ def _noop_emit(event_type, agent_id, payload):
 #  Observation builder tests
 # ---------------------------------------------------------------------------
 
+
 class TestHumanObservationBuilder:
     def test_shape_no_neighbours(self):
         agent = _make_state(0)
@@ -76,12 +78,12 @@ class TestHumanObservationBuilder:
     def test_ego_encoding(self):
         agent = _make_state(0, x=1.0, y=2.0, vx=0.3, vy=0.4, goal_x=4.0, goal_y=6.0, radius=0.2)
         obs = _build_observation(agent, [], max_neighbours=4)
-        assert obs[0] == pytest.approx(3.0)   # dx_goal
-        assert obs[1] == pytest.approx(4.0)   # dy_goal
-        assert obs[2] == pytest.approx(0.3)   # vx
-        assert obs[3] == pytest.approx(0.4)   # vy
-        assert obs[4] == pytest.approx(0.5)   # speed
-        assert obs[5] == pytest.approx(0.2)   # radius
+        assert obs[0] == pytest.approx(3.0)  # dx_goal
+        assert obs[1] == pytest.approx(4.0)  # dy_goal
+        assert obs[2] == pytest.approx(0.3)  # vx
+        assert obs[3] == pytest.approx(0.4)  # vy
+        assert obs[4] == pytest.approx(0.5)  # speed
+        assert obs[5] == pytest.approx(0.2)  # radius
 
     def test_neighbours_sorted_by_distance(self):
         agent = _make_state(0, x=0.0, y=0.0)
@@ -104,7 +106,7 @@ class TestHumanObservationBuilder:
         agent = _make_state(0)
         obs = _build_observation(agent, [_make_state(1, x=2.0)], max_neighbours=4)
         # Slots 2 and 3 should be zero
-        assert obs[6 + 2 * 5: 6 + 4 * 5].sum() == 0.0
+        assert obs[6 + 2 * 5 : 6 + 4 * 5].sum() == 0.0
 
 
 class TestRobotObservationBuilder:
@@ -125,10 +127,12 @@ class TestRobotObservationBuilder:
         assert obs[6 + 6 + 5] == pytest.approx(0.0)
 
     def test_ego_encoding(self):
-        robot = _make_state(0, kind="robot", x=1.0, y=2.0, vx=0.1, vy=0.2, goal_x=3.0, goal_y=4.0, radius=0.2)
+        robot = _make_state(
+            0, kind="robot", x=1.0, y=2.0, vx=0.1, vy=0.2, goal_x=3.0, goal_y=4.0, radius=0.2
+        )
         obs = _build_robot_observation(robot, [], max_neighbours=4)
-        assert obs[0] == pytest.approx(2.0)   # dx_goal
-        assert obs[1] == pytest.approx(2.0)   # dy_goal
+        assert obs[0] == pytest.approx(2.0)  # dx_goal
+        assert obs[1] == pytest.approx(2.0)  # dy_goal
         assert obs[2] == pytest.approx(0.1)
         assert obs[3] == pytest.approx(0.2)
         assert obs[4] == pytest.approx(math.hypot(0.1, 0.2))
@@ -139,9 +143,11 @@ class TestRobotObservationBuilder:
 #  PolicyHumanController unit tests (no torch needed)
 # ---------------------------------------------------------------------------
 
+
 def _torch_available() -> bool:
     try:
         import torch
+
         return True
     except ImportError:
         return False
@@ -155,11 +161,13 @@ class TestPolicyHumanControllerInit:
         assert ctrl.max_neighbours == 4
 
     def test_cfg_dict(self):
-        ctrl = PolicyHumanController(cfg={
-            "model_path": "/tmp/model_dir",
-            "device": "cuda:0",
-            "max_neighbours": 8,
-        })
+        ctrl = PolicyHumanController(
+            cfg={
+                "model_path": "/tmp/model_dir",
+                "device": "cuda:0",
+                "max_neighbours": 8,
+            }
+        )
         assert str(ctrl.model_path) == "/tmp/model_dir"
         assert ctrl.device_str == "cuda:0"
         assert ctrl.max_neighbours == 8
@@ -183,9 +191,7 @@ class TestPolicyHumanControllerInit:
         assert ctrl.human_ids == [1, 2]
         assert ctrl.goals[1] == (5.0, 5.0)
 
-    @pytest.mark.skipif(
-        not _torch_available(), reason="PyTorch not installed"
-    )
+    @pytest.mark.skipif(not _torch_available(), reason="PyTorch not installed")
     def test_missing_model_path_raises(self):
         ctrl = PolicyHumanController(cfg={"model_path": "/tmp/nonexistent_model.pt"})
         ctrl.reset([1], {1: (0.0, 0.0)}, {1: (5.0, 5.0)})
@@ -197,6 +203,7 @@ class TestPolicyHumanControllerInit:
 #  PolicyRobotController unit tests (no torch needed)
 # ---------------------------------------------------------------------------
 
+
 class TestPolicyRobotControllerInit:
     def test_cfg_defaults(self):
         ctrl = PolicyRobotController(cfg={})
@@ -206,13 +213,15 @@ class TestPolicyRobotControllerInit:
         assert ctrl.max_speed == pytest.approx(0.8)
 
     def test_cfg_custom(self):
-        ctrl = PolicyRobotController(cfg={
-            "model_path": "/tmp/robot_policy.pt",
-            "device": "cuda:1",
-            "max_neighbours": 10,
-            "goal_tolerance": 0.3,
-            "max_speed": 1.2,
-        })
+        ctrl = PolicyRobotController(
+            cfg={
+                "model_path": "/tmp/robot_policy.pt",
+                "device": "cuda:1",
+                "max_neighbours": 10,
+                "goal_tolerance": 0.3,
+                "max_speed": 1.2,
+            }
+        )
         assert ctrl.model_path_str == "/tmp/robot_policy.pt"
         assert ctrl.device_str == "cuda:1"
         assert ctrl.max_neighbours == 10
@@ -241,10 +250,12 @@ class TestPolicyRobotControllerInit:
 #  Plugin registration tests
 # ---------------------------------------------------------------------------
 
+
 class TestPolicyPluginRegistration:
     def test_human_policy_registered(self):
         from navirl.core.registry import get_human_controller
         from navirl.plugins import register_default_plugins
+
         register_default_plugins()
         factory = get_human_controller("policy")
         assert factory is not None
@@ -252,6 +263,7 @@ class TestPolicyPluginRegistration:
     def test_robot_policy_registered(self):
         from navirl.core.registry import get_robot_controller
         from navirl.plugins import register_default_plugins
+
         register_default_plugins()
         factory = get_robot_controller("policy")
         assert factory is not None
@@ -259,6 +271,7 @@ class TestPolicyPluginRegistration:
     def test_human_policy_creates_correct_type(self):
         from navirl.core.registry import get_human_controller
         from navirl.plugins import register_default_plugins
+
         register_default_plugins()
         factory = get_human_controller("policy")
         ctrl = factory({"model_path": "/tmp/fake.pt"})
@@ -267,6 +280,7 @@ class TestPolicyPluginRegistration:
     def test_robot_policy_creates_correct_type(self):
         from navirl.core.registry import get_robot_controller
         from navirl.plugins import register_default_plugins
+
         register_default_plugins()
         factory = get_robot_controller("policy")
         ctrl = factory({"model_path": "/tmp/fake.pt"})
@@ -277,9 +291,11 @@ class TestPolicyPluginRegistration:
 #  Scenario validation accepts policy type
 # ---------------------------------------------------------------------------
 
+
 class TestScenarioValidationPolicyType:
     def test_human_policy_type_accepted(self):
         from navirl.scenarios.validate import _validate_humans
+
         errors: list[str] = []
         humans = {
             "count": 3,
@@ -292,6 +308,7 @@ class TestScenarioValidationPolicyType:
 
     def test_robot_policy_type_accepted(self):
         from navirl.scenarios.validate import _validate_robot
+
         errors: list[str] = []
         robot = {
             "controller": {"type": "policy", "params": {"model_path": "/tmp/m.pt"}},
@@ -303,6 +320,7 @@ class TestScenarioValidationPolicyType:
 
     def test_robot_social_astar_accepted(self):
         from navirl.scenarios.validate import _validate_robot
+
         errors: list[str] = []
         robot = {
             "controller": {"type": "social_astar", "params": {}},

--- a/tests/test_prm_controller.py
+++ b/tests/test_prm_controller.py
@@ -42,9 +42,12 @@ def _make_state(robot_id=0, x=0.0, y=0.0, goal_x=10.0, goal_y=10.0):
     return AgentState(
         agent_id=robot_id,
         kind="robot",
-        x=x, y=y,
-        vx=0.0, vy=0.0,
-        goal_x=goal_x, goal_y=goal_y,
+        x=x,
+        y=y,
+        vx=0.0,
+        vy=0.0,
+        goal_x=goal_x,
+        goal_y=goal_y,
         radius=0.3,
         max_speed=1.0,
     )
@@ -202,11 +205,13 @@ class TestPRMStep:
         assert speed <= ctrl.max_speed + 0.01
 
     def test_velocity_smoothing(self):
-        ctrl = PRMRobotController({
-            "num_samples": 10,
-            "velocity_smoothing": 0.5,
-            "replan_interval": 100,
-        })
+        ctrl = PRMRobotController(
+            {
+                "num_samples": 10,
+                "velocity_smoothing": 0.5,
+                "replan_interval": 100,
+            }
+        )
         backend = _MockBackend()
         ctrl.reset(0, (0.0, 0.0), (10.0, 0.0), backend)
         states = {0: _make_state(0, x=0.0, y=0.0, goal_x=10.0, goal_y=0.0)}
@@ -222,18 +227,22 @@ class TestPRMStep:
         states = {0: _make_state(0, x=1.0, y=1.0)}
         # Step 5 should trigger replan
         events = []
+
         def capture_event(etype, aid, payload):
             events.append(etype)
+
         ctrl.step(5, 0.2, 0.04, states, capture_event)
         assert "robot_prm_replan" in events
 
     def test_slowdown_near_target(self):
-        ctrl = PRMRobotController({
-            "num_samples": 10,
-            "slowdown_dist": 1.0,
-            "max_speed": 2.0,
-            "replan_interval": 100,
-        })
+        ctrl = PRMRobotController(
+            {
+                "num_samples": 10,
+                "slowdown_dist": 1.0,
+                "max_speed": 2.0,
+                "replan_interval": 100,
+            }
+        )
         backend = _MockBackend()
         ctrl.reset(0, (0.0, 0.0), (0.5, 0.0), backend)
         states = {0: _make_state(0, x=0.0, y=0.0, goal_x=0.5, goal_y=0.0)}

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -6,6 +6,7 @@ Covers:
   - navirl.robots.holonomic
   - navirl.robots.sensors_config
 """
+
 from __future__ import annotations
 
 import math
@@ -496,9 +497,7 @@ class TestWaypointFollower:
 class TestGenerateSmoothTrajectory:
     def test_same_start_goal(self):
         cfg = HolonomicConfig()
-        pos, vel, t = generate_smooth_trajectory(
-            np.array([1.0, 2.0]), np.array([1.0, 2.0]), cfg
-        )
+        pos, vel, t = generate_smooth_trajectory(np.array([1.0, 2.0]), np.array([1.0, 2.0]), cfg)
         assert pos.shape == (1, 2)
         assert vel.shape == (1, 2)
 
@@ -639,9 +638,7 @@ class TestSensorSuite:
         assert len(suite.enabled_mounts()) == 1
 
     def test_any_sensor_sees(self):
-        m = SensorMount(
-            name="lidar", fov_horizontal=2 * np.pi, max_range=10.0, min_range=0.1
-        )
+        m = SensorMount(name="lidar", fov_horizontal=2 * np.pi, max_range=10.0, min_range=0.1)
         suite = SensorSuite([m])
         assert suite.any_sensor_sees(0, 0, 0, np.array([5.0, 0.0]))
         assert not suite.any_sensor_sees(0, 0, 0, np.array([50.0, 0.0]))
@@ -659,9 +656,7 @@ class TestFusePositionEstimates:
         np.testing.assert_allclose(result, [3.0, 4.0])
 
     def test_weighted_average(self):
-        cfg = SensorFusionConfig(
-            weights=[FusionWeight("a", 1.0), FusionWeight("b", 3.0)]
-        )
+        cfg = SensorFusionConfig(weights=[FusionWeight("a", 1.0), FusionWeight("b", 3.0)])
         estimates = {"a": np.array([0.0, 0.0]), "b": np.array([4.0, 4.0])}
         result = fuse_position_estimates(estimates, cfg)
         np.testing.assert_allclose(result, [3.0, 3.0])

--- a/tests/test_routine_coverage.py
+++ b/tests/test_routine_coverage.py
@@ -50,9 +50,15 @@ from navirl.routines.schema import (
 
 
 def _make_agent(agent_id=1, x=0.0, y=0.0, **kw):
-    defaults = dict(
-        kind="human", vx=0.0, vy=0.0, goal_x=5.0, goal_y=5.0, radius=0.2, max_speed=1.0
-    )
+    defaults = {
+        "kind": "human",
+        "vx": 0.0,
+        "vy": 0.0,
+        "goal_x": 5.0,
+        "goal_y": 5.0,
+        "radius": 0.2,
+        "max_speed": 1.0,
+    }
     defaults.update(kw)
     return AgentState(agent_id=agent_id, x=x, y=y, **defaults)
 
@@ -60,7 +66,7 @@ def _make_agent(agent_id=1, x=0.0, y=0.0, **kw):
 def _make_bb(agent=None, **kw):
     if agent is None:
         agent = _make_agent()
-    defaults = dict(dt=0.1, metadata={"sim_time": 0.0})
+    defaults = {"dt": 0.1, "metadata": {"sim_time": 0.0}}
     defaults.update(kw)
     return Blackboard(agent=agent, **defaults)
 
@@ -81,7 +87,12 @@ class TestCompilerTaskTypes:
         spec = RoutineSpec(
             id="interact",
             description="Interact",
-            tasks=[Task(type=TaskType.INTERACT, params={"location": (1.0, 2.0), "interaction_type": "vending"})],
+            tasks=[
+                Task(
+                    type=TaskType.INTERACT,
+                    params={"location": (1.0, 2.0), "interaction_type": "vending"},
+                )
+            ],
         )
         plan = self.compiler.compile(spec)
         assert isinstance(plan.root_node, InteractAtLocation)
@@ -707,13 +718,13 @@ class TestControllerEventEmission:
             tasks=[Task.wait(0.0)],
         )
         controller = CompiledRoutineController({1: spec})
-        controller.reset(
-            human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 3.0)}, backend=None
-        )
+        controller.reset(human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 3.0)}, backend=None)
 
         emit = Mock()
         # At time_s=1.0, the WaitForDuration with duration 0.0 should complete
-        controller.step(step=0, time_s=1.0, dt=0.1, states=self.states, robot_id=100, emit_event=emit)
+        controller.step(
+            step=0, time_s=1.0, dt=0.1, states=self.states, robot_id=100, emit_event=emit
+        )
 
         # Check routine_completed event was emitted
         event_names = [call[0][0] for call in emit.call_args_list]
@@ -727,9 +738,7 @@ class TestControllerEventEmission:
             tasks=[Task.go_to(1.0, 1.0)],
         )
         controller = CompiledRoutineController({1: spec})
-        controller.reset(
-            human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 3.0)}, backend=None
-        )
+        controller.reset(human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 3.0)}, backend=None)
 
         # Sabotage the behavior plan to cause an error
         plan = controller.compiled_plans[1]
@@ -758,9 +767,7 @@ class TestFallbackBehaviors:
     def test_static_fallback(self):
         """Static fallback keeps agent in place."""
         controller = CompiledRoutineController({}, fallback_behavior="static")
-        controller.reset(
-            human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None
-        )
+        controller.reset(human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None)
 
         emit = Mock()
         actions = controller.step(
@@ -774,9 +781,7 @@ class TestFallbackBehaviors:
     def test_goal_swap_fallback(self):
         """Goal swap fallback moves agent toward goal."""
         controller = CompiledRoutineController({}, fallback_behavior="goal_swap")
-        controller.reset(
-            human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None
-        )
+        controller.reset(human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None)
 
         emit = Mock()
         actions = controller.step(
@@ -793,14 +798,10 @@ class TestFallbackBehaviors:
         states = {1: agent_at_goal, 100: self.robot}
 
         controller = CompiledRoutineController({}, fallback_behavior="goal_swap")
-        controller.reset(
-            human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None
-        )
+        controller.reset(human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None)
 
         emit = Mock()
-        controller.step(
-            step=0, time_s=0.0, dt=0.1, states=states, robot_id=100, emit_event=emit
-        )
+        controller.step(step=0, time_s=0.0, dt=0.1, states=states, robot_id=100, emit_event=emit)
 
         # Should have emitted goal_swap event
         event_names = [call[0][0] for call in emit.call_args_list]
@@ -834,9 +835,7 @@ class TestFallbackBehaviors:
     def test_unknown_fallback_raises(self):
         """Unknown fallback behavior raises ValueError."""
         controller = CompiledRoutineController({}, fallback_behavior="unknown")
-        controller.reset(
-            human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None
-        )
+        controller.reset(human_ids=[1], starts={1: (0.0, 0.0)}, goals={1: (5.0, 5.0)}, backend=None)
 
         emit = Mock()
         with pytest.raises(ValueError, match="Unknown fallback behavior"):
@@ -866,9 +865,7 @@ class TestControllerRoutineManagement:
     def test_compile_routines_failure(self):
         """_compile_routines handles individual routine compile failures."""
         bad_spec = RoutineSpec(id="bad", description="Bad", tasks=[])
-        good_spec = RoutineSpec(
-            id="good", description="Good", tasks=[Task.go_to(1.0, 1.0)]
-        )
+        good_spec = RoutineSpec(id="good", description="Good", tasks=[Task.go_to(1.0, 1.0)])
 
         controller = CompiledRoutineController({1: bad_spec, 2: good_spec})
         # Good spec should compile, bad should be skipped
@@ -956,9 +953,8 @@ class TestPathValidation:
 
     def test_directory_path_raises(self):
         """Directory path raises ValueError."""
-        with tempfile.TemporaryDirectory() as d:
-            with pytest.raises(ValueError, match="not a file"):
-                _validate_file_path(d)
+        with tempfile.TemporaryDirectory() as d, pytest.raises(ValueError, match="not a file"):
+            _validate_file_path(d)
 
     def test_path_traversal_raises(self):
         """Path traversal attempt raises ValueError."""

--- a/tests/test_routine_performance.py
+++ b/tests/test_routine_performance.py
@@ -25,6 +25,7 @@ class TestRoutinePerformanceFixture(TestCase):
 
         # Verify it's actually a GoToGoal instance
         from navirl.models.behavior_tree import GoToGoal
+
         self.assertIsInstance(goto_goal_instance1, GoToGoal)
 
     def test_goto_target_reset_state(self) -> None:

--- a/tests/test_safety_extended.py
+++ b/tests/test_safety_extended.py
@@ -278,10 +278,12 @@ class TestPredictiveRiskModel:
 
     def test_assess_risk_shape(self, model):
         agent_traj = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
-        obs_traj = np.array([
-            [[5.0, 5.0], [5.0, 5.0], [5.0, 5.0], [5.0, 5.0]],
-            [[10.0, 10.0], [10.0, 10.0], [10.0, 10.0], [10.0, 10.0]],
-        ])
+        obs_traj = np.array(
+            [
+                [[5.0, 5.0], [5.0, 5.0], [5.0, 5.0], [5.0, 5.0]],
+                [[10.0, 10.0], [10.0, 10.0], [10.0, 10.0], [10.0, 10.0]],
+            ]
+        )
         risks = model.assess_risk(agent_traj, obs_traj)
         assert risks.shape == (4,)
         assert np.all(risks >= 0.0)

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -307,7 +307,9 @@ class TestCameraSensor:
         assert img.dtype == np.uint8
 
     def test_perspective_output_shape(self):
-        cam = CameraSensor(CameraConfig(resolution_x=64, resolution_y=48, render_mode="perspective"))
+        cam = CameraSensor(
+            CameraConfig(resolution_x=64, resolution_y=48, render_mode="perspective")
+        )
         ws = _basic_world_state()
         img = cam.observe(ws)
         assert img.shape == (48, 64, 3)

--- a/tests/test_serialization_extended.py
+++ b/tests/test_serialization_extended.py
@@ -39,11 +39,13 @@ def tmp_dir(tmp_path):
 def _has_toml_write():
     try:
         import tomli_w
+
         return True
     except ImportError:
         pass
     try:
         import toml
+
         return True
     except ImportError:
         return False

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -247,9 +247,7 @@ class TestSimulationClock:
         clock = SimulationClock(dt=0.1)
         clock.start()
         count = []
-        clock.schedule(
-            0.1, lambda e: count.append(1), repeat_interval=0.1
-        )
+        clock.schedule(0.1, lambda e: count.append(1), repeat_interval=0.1)
         for _ in range(5):
             clock.tick_fixed()
         assert len(count) == 5
@@ -296,6 +294,7 @@ class TestSimulationClock:
         clock = SimulationClock(dt=0.05, real_time=True)
         clock.start()
         import time as _time
+
         _time.sleep(0.02)
         dt = clock.tick()
         assert dt > 0
@@ -312,6 +311,7 @@ class TestSimulationClock:
         clock = SimulationClock(dt=0.05, time_scale=1.0)
         clock.start()
         import time as _time
+
         _time.sleep(0.01)
         dt = clock.tick_variable()
         assert dt > 0
@@ -323,6 +323,7 @@ class TestSimulationClock:
         clock = SimulationClock(dt=0.01)
         clock.start()
         import time as _time
+
         _time.sleep(0.03)
         steps = clock.accumulate_and_step()
         assert steps >= 1
@@ -411,6 +412,7 @@ class TestSimulationClock:
         clock.tick_fixed()
         clock.pause()
         import time as _time
+
         _time.sleep(0.05)
         clock.resume()
         stats = clock.stats()
@@ -450,9 +452,7 @@ class TestStaticObstacle:
 
 class TestDynamicObstacle:
     def test_creation(self):
-        obs = DynamicObstacle(
-            entity_id=2, position=(0, 0), velocity=(1, 0), radius=0.3, mass=2.0
-        )
+        obs = DynamicObstacle(entity_id=2, position=(0, 0), velocity=(1, 0), radius=0.3, mass=2.0)
         assert obs.kind() == "dynamic_obstacle"
         assert obs.mass == pytest.approx(2.0)
 
@@ -871,12 +871,8 @@ class TestEventFilter:
 
     def test_data_key_filter(self):
         filt = EventFilter(data_key="tag", data_value="important")
-        rec1 = EventRecord(
-            event_type=EventType.CUSTOM, data={"tag": "important"}
-        )
-        rec2 = EventRecord(
-            event_type=EventType.CUSTOM, data={"tag": "other"}
-        )
+        rec1 = EventRecord(event_type=EventType.CUSTOM, data={"tag": "important"})
+        rec2 = EventRecord(event_type=EventType.CUSTOM, data={"tag": "other"})
         assert filt.matches(rec1)
         assert not filt.matches(rec2)
 
@@ -1194,27 +1190,13 @@ class TestWorldBuilder:
         assert len(world.walls) == 1
 
     def test_boundary_walls(self):
-        world = (
-            WorldBuilder()
-            .set_size(10, 10)
-            .add_boundary_walls()
-            .build()
-        )
+        world = WorldBuilder().set_size(10, 10).add_boundary_walls().build()
         assert len(world.walls) == 4
 
     def test_metadata(self):
-        world = (
-            WorldBuilder()
-            .set_metadata("test_key", "test_value")
-            .build()
-        )
+        world = WorldBuilder().set_metadata("test_key", "test_value").build()
         assert world.get_metadata("test_key") == "test_value"
 
     def test_wrap(self):
-        world = (
-            WorldBuilder()
-            .set_size(10, 10)
-            .enable_wrap()
-            .build()
-        )
+        world = WorldBuilder().set_size(10, 10).enable_wrap().build()
         assert world.wrap is True

--- a/tests/test_simulation_physics.py
+++ b/tests/test_simulation_physics.py
@@ -83,9 +83,7 @@ class TestEulerStep:
         np.testing.assert_allclose(vel, [1.0, 0.0])
 
     def test_constant_acceleration(self):
-        pos, vel = _euler_step(
-            np.zeros(2), np.zeros(2), np.array([2.0, 0.0]), 1.0
-        )
+        pos, vel = _euler_step(np.zeros(2), np.zeros(2), np.array([2.0, 0.0]), 1.0)
         # v_new = 0 + 2*1 = 2; x_new = 0 + 2*1 = 2
         np.testing.assert_allclose(vel, [2.0, 0.0])
         np.testing.assert_allclose(pos, [2.0, 0.0])

--- a/tests/test_simulation_runner.py
+++ b/tests/test_simulation_runner.py
@@ -94,8 +94,13 @@ class TestProgressInfo:
 
     def test_custom_fields(self):
         p = ProgressInfo(
-            episode=3, total_episodes=10, step=100, sim_time=5.0, wall_time=2.0,
-            done=True, message="completed",
+            episode=3,
+            total_episodes=10,
+            step=100,
+            sim_time=5.0,
+            wall_time=2.0,
+            done=True,
+            message="completed",
         )
         assert p.done is True
         assert p.message == "completed"
@@ -118,8 +123,12 @@ class TestSimulationRunnerInit:
         physics = SimplePhysics()
         bus = EventBus()
         runner = SimulationRunner(
-            world=basic_world, clock=clock, physics=physics,
-            event_bus=bus, headless=False, seed=123,
+            world=basic_world,
+            clock=clock,
+            physics=physics,
+            event_bus=bus,
+            headless=False,
+            seed=123,
         )
         assert runner.clock is clock
         assert runner.physics is physics

--- a/tests/test_social_groups_extended.py
+++ b/tests/test_social_groups_extended.py
@@ -21,9 +21,17 @@ from navirl.humans.social_groups import (
 # ---------------------------------------------------------------------------
 
 
-def _make_state(pid: int, x: float, y: float, vx: float = 0.0, vy: float = 0.0,
-                heading: float = 0.0, goal_x: float = 10.0, goal_y: float = 10.0,
-                radius: float = 0.3) -> PedestrianState:
+def _make_state(
+    pid: int,
+    x: float,
+    y: float,
+    vx: float = 0.0,
+    vy: float = 0.0,
+    heading: float = 0.0,
+    goal_x: float = 10.0,
+    goal_y: float = 10.0,
+    radius: float = 0.3,
+) -> PedestrianState:
     return PedestrianState(
         pid=pid,
         position=np.array([x, y], dtype=np.float64),
@@ -78,7 +86,9 @@ class TestFFormation:
     def test_compute_positions_start_angle(self):
         ff = FFormation()
         pos_default = ff.compute_positions(np.array([0.0, 0.0]), n_members=2, start_angle=0.0)
-        pos_rotated = ff.compute_positions(np.array([0.0, 0.0]), n_members=2, start_angle=math.pi/2)
+        pos_rotated = ff.compute_positions(
+            np.array([0.0, 0.0]), n_members=2, start_angle=math.pi / 2
+        )
         # Rotated positions should differ
         assert not np.allclose(pos_default[0], pos_rotated[0])
 
@@ -596,8 +606,8 @@ class TestIntersectionDecision:
 
     def test_leader_extra_vote(self):
         s1 = _make_state(1, 0, 0, goal_x=10, goal_y=0)  # wants right
-        s2 = _make_state(2, 0, 0, goal_x=0, goal_y=10)   # wants up
-        s3 = _make_state(3, 0, 0, goal_x=0, goal_y=10)   # wants up
+        s2 = _make_state(2, 0, 0, goal_x=0, goal_y=10)  # wants up
+        s3 = _make_state(3, 0, 0, goal_x=0, goal_y=10)  # wants up
         states = _states_dict(s1, s2, s3)
         g = SocialGroup(member_ids=[1, 2, 3], leader_id=1)
         rng = np.random.default_rng(42)
@@ -712,10 +722,7 @@ class TestGroupManager:
 
     def test_create_group_with_kwargs(self):
         mgr = GroupManager()
-        g = mgr.create_group(
-            [1, 2], leader_id=1, goal=np.array([5.0, 5.0]),
-            cohesion_strength=2.0
-        )
+        g = mgr.create_group([1, 2], leader_id=1, goal=np.array([5.0, 5.0]), cohesion_strength=2.0)
         assert g.leader_id == 1
         assert g.cohesion_strength == 2.0
         np.testing.assert_allclose(g.goal, [5.0, 5.0])

--- a/tests/test_spatial_extended.py
+++ b/tests/test_spatial_extended.py
@@ -83,7 +83,9 @@ class TestSpatialHashGridEdgeCases:
         grid.insert(1, np.array([1.0, 0.0]))
         grid.insert(2, np.array([100.0, 0.0]))
         results = grid.query_k_nearest(
-            np.array([0.0, 0.0]), k=2, max_radius=5.0,
+            np.array([0.0, 0.0]),
+            k=2,
+            max_radius=5.0,
         )
         ids = [r[0] for r in results]
         assert 0 in ids
@@ -102,7 +104,9 @@ class TestSpatialHashGridEdgeCases:
         grid = SpatialHashGrid(cell_size=1.0)
         grid.insert(0, np.array([0.0, 0.0]))
         results = grid.query_k_nearest(
-            np.array([0.0, 0.0]), k=5, max_radius=100.0,
+            np.array([0.0, 0.0]),
+            k=5,
+            max_radius=100.0,
         )
         assert len(results) == 1
 
@@ -203,20 +207,33 @@ class TestComputeVoronoiNeighbors:
         assert 0 in neighbors[1]
 
     def test_triangle(self):
-        positions = np.array([
-            [0.0, 0.0], [2.0, 0.0], [1.0, 2.0],
-        ])
+        positions = np.array(
+            [
+                [0.0, 0.0],
+                [2.0, 0.0],
+                [1.0, 2.0],
+            ]
+        )
         neighbors = compute_voronoi_neighbors(positions)
         # Each point should neighbor the other two
         for i in range(3):
             assert len(neighbors[i]) == 2
 
     def test_grid_pattern(self):
-        positions = np.array([
-            [0, 0], [1, 0], [2, 0],
-            [0, 1], [1, 1], [2, 1],
-            [0, 2], [1, 2], [2, 2],
-        ], dtype=float)
+        positions = np.array(
+            [
+                [0, 0],
+                [1, 0],
+                [2, 0],
+                [0, 1],
+                [1, 1],
+                [2, 1],
+                [0, 2],
+                [1, 2],
+                [2, 2],
+            ],
+            dtype=float,
+        )
         neighbors = compute_voronoi_neighbors(positions)
         # Center point (index 4) should have many neighbors
         assert len(neighbors[4]) >= 4

--- a/tests/test_standard_metrics.py
+++ b/tests/test_standard_metrics.py
@@ -202,13 +202,15 @@ class TestStandardMetricsCompute:
         """Robot and human far apart — no collision."""
         rows = []
         for step in range(5):
-            rows.append({
-                "step": step,
-                "agents": [
-                    _make_agent(0, "robot", 0.0, 0.0, vx=0.1, goal_x=2.0, goal_y=0.0),
-                    _make_agent(1, "human", 0.0, 3.0, goal_x=0.0, goal_y=-1.0),
-                ],
-            })
+            rows.append(
+                {
+                    "step": step,
+                    "agents": [
+                        _make_agent(0, "robot", 0.0, 0.0, vx=0.1, goal_x=2.0, goal_y=0.0),
+                        _make_agent(1, "human", 0.0, 3.0, goal_x=0.0, goal_y=-1.0),
+                    ],
+                }
+            )
         report = self._run_metrics(rows, tmp_path=tmp_path)
         assert report["collisions_agent_agent"] == 0
         assert report["min_dist_robot_human_min"] > 2.0
@@ -239,12 +241,14 @@ class TestStandardMetricsCompute:
         rows = []
         for step in range(10):
             x = 0.01 * step
-            rows.append({
-                "step": step,
-                "agents": [
-                    _make_agent(0, "robot", x, 0.0, vx=0.1, goal_x=1.0, goal_y=0.0),
-                ],
-            })
+            rows.append(
+                {
+                    "step": step,
+                    "agents": [
+                        _make_agent(0, "robot", x, 0.0, vx=0.1, goal_x=1.0, goal_y=0.0),
+                    ],
+                }
+            )
         report = self._run_metrics(rows, tmp_path=tmp_path)
         assert report["path_length_robot"] == pytest.approx(0.09, abs=0.01)
 
@@ -258,12 +262,14 @@ class TestStandardMetricsCompute:
                 vx, vy = 1.0, 0.1
             else:
                 vx, vy = 1.0, -0.1
-            rows.append({
-                "step": step,
-                "agents": [
-                    _make_agent(0, "robot", 0.0, 0.0, vx=vx, vy=vy, goal_x=5.0, goal_y=5.0),
-                ],
-            })
+            rows.append(
+                {
+                    "step": step,
+                    "agents": [
+                        _make_agent(0, "robot", 0.0, 0.0, vx=vx, vy=vy, goal_x=5.0, goal_y=5.0),
+                    ],
+                }
+            )
         report = self._run_metrics(rows, tmp_path=tmp_path)
         # High oscillation expected
         assert report["oscillation_score"] > 0.0
@@ -274,12 +280,14 @@ class TestStandardMetricsCompute:
         for step in range(10):
             # Accelerating then decelerating
             vx = 0.1 * step if step < 5 else 0.1 * (10 - step)
-            rows.append({
-                "step": step,
-                "agents": [
-                    _make_agent(0, "robot", 0.0, 0.0, vx=vx, vy=0.0, goal_x=5.0, goal_y=0.0),
-                ],
-            })
+            rows.append(
+                {
+                    "step": step,
+                    "agents": [
+                        _make_agent(0, "robot", 0.0, 0.0, vx=vx, vy=0.0, goal_x=5.0, goal_y=0.0),
+                    ],
+                }
+            )
         report = self._run_metrics(rows, tmp_path=tmp_path)
         assert report["jerk_proxy"] > 0.0
 
@@ -306,16 +314,23 @@ class TestStandardMetricsCompute:
         rows = []
         # 100 steps of near-zero speed, far from goal
         for step in range(100):
-            rows.append({
-                "step": step,
-                "agents": [
-                    _make_agent(
-                        0, "robot", 0.0, 0.0,
-                        vx=0.001, vy=0.0,
-                        goal_x=5.0, goal_y=5.0,
-                    ),
-                ],
-            })
+            rows.append(
+                {
+                    "step": step,
+                    "agents": [
+                        _make_agent(
+                            0,
+                            "robot",
+                            0.0,
+                            0.0,
+                            vx=0.001,
+                            vy=0.0,
+                            goal_x=5.0,
+                            goal_y=5.0,
+                        ),
+                    ],
+                }
+            )
         report = self._run_metrics(rows, tmp_path=tmp_path)
         assert report["deadlock_count"] >= 1
 
@@ -379,17 +394,24 @@ class TestStandardMetricsCompute:
         """Agent with DONE behavior should not count as deadlocked."""
         rows = []
         for step in range(100):
-            rows.append({
-                "step": step,
-                "agents": [
-                    _make_agent(
-                        0, "robot", 0.0, 0.0,
-                        vx=0.0, vy=0.0,
-                        goal_x=5.0, goal_y=5.0,
-                        behavior="DONE",
-                    ),
-                ],
-            })
+            rows.append(
+                {
+                    "step": step,
+                    "agents": [
+                        _make_agent(
+                            0,
+                            "robot",
+                            0.0,
+                            0.0,
+                            vx=0.0,
+                            vy=0.0,
+                            goal_x=5.0,
+                            goal_y=5.0,
+                            behavior="DONE",
+                        ),
+                    ],
+                }
+            )
         report = self._run_metrics(rows, tmp_path=tmp_path)
         assert report["deadlock_count"] == 0
 

--- a/tests/test_tensorboard_logger.py
+++ b/tests/test_tensorboard_logger.py
@@ -494,9 +494,7 @@ class TestAddImage:
     def test_basic(self, enabled_logger, mock_writer):
         img = np.zeros((64, 64, 3), dtype=np.uint8)
         enabled_logger.add_image("img", img, step=1)
-        mock_writer.add_image.assert_called_once_with(
-            "img", img, global_step=1, dataformats="HWC"
-        )
+        mock_writer.add_image.assert_called_once_with("img", img, global_step=1, dataformats="HWC")
 
     def test_disabled_noop(self, disabled_logger):
         disabled_logger.add_image("img", np.zeros((4, 4, 3)), step=0)
@@ -528,7 +526,12 @@ class TestLogTrajectoryImage:
         enabled_logger.log_trajectory_image(step=1, positions=positions)
         mock_writer.add_image.assert_called_once()
         call_args = mock_writer.add_image.call_args
-        assert call_args.kwargs.get("dataformats", call_args.args[3] if len(call_args.args) > 3 else None) or True
+        assert (
+            call_args.kwargs.get(
+                "dataformats", call_args.args[3] if len(call_args.args) > 3 else None
+            )
+            or True
+        )
         img = call_args.args[1]
         assert img.shape == (256, 256, 3)
 

--- a/tests/test_training_buffer.py
+++ b/tests/test_training_buffer.py
@@ -344,9 +344,7 @@ class TestRolloutBuffer:
         buf.compute_returns_and_advantages(last_val, gamma=1.0, gae_lambda=1.0)
         # With gamma=1, lambda=1, values=0, rewards=[1,1,1], last_value=0
         # advantages should be [3, 2, 1] (MC returns)
-        np.testing.assert_array_almost_equal(
-            buf.advantages[:, 0], [3.0, 2.0, 1.0]
-        )
+        np.testing.assert_array_almost_equal(buf.advantages[:, 0], [3.0, 2.0, 1.0])
 
     def test_reset(self):
         buf = RolloutBuffer(5, OBS_SHAPE, ACT_SHAPE, n_envs=1)

--- a/tests/test_training_callbacks.py
+++ b/tests/test_training_callbacks.py
@@ -180,8 +180,11 @@ class TestEvalCallback:
         model = MagicMock()
         model.predict.return_value = (0, None)
         cb = EvalCallback(
-            eval_env=env, eval_freq=1, n_eval_episodes=1,
-            best_model_save_path=str(tmp_path), verbose=1,
+            eval_env=env,
+            eval_freq=1,
+            n_eval_episodes=1,
+            best_model_save_path=str(tmp_path),
+            verbose=1,
         )
         cb.on_step({"self": model})
         assert model.save.called

--- a/tests/test_training_trainer.py
+++ b/tests/test_training_trainer.py
@@ -120,9 +120,7 @@ class TestTrainerConfig:
         assert cfg.seed == 99
 
     def test_from_dict_ignores_unknown_keys(self):
-        cfg = TrainerConfig.from_dict(
-            {"total_timesteps": 10, "unknown_key": "ignored"}
-        )
+        cfg = TrainerConfig.from_dict({"total_timesteps": 10, "unknown_key": "ignored"})
         assert cfg.total_timesteps == 10
         assert not hasattr(cfg, "unknown_key")
 
@@ -173,9 +171,7 @@ class TestTrainingLogger:
 
     def test_tensorboard_import_failure(self):
         """If tensorboard is not installed, logging still works."""
-        logger = TrainingLogger(
-            log_dir="/tmp/test_logger_tb", use_tensorboard=True
-        )
+        logger = TrainingLogger(log_dir="/tmp/test_logger_tb", use_tensorboard=True)
         assert logger._tb_writer is None  # torch.utils.tensorboard not available
         logger.log_scalar("x", 1.0, 0)
         logger.close()
@@ -219,9 +215,7 @@ class TestEvalResult:
         assert d["per_episode_rewards"] == [4.0, 6.0]
 
     def test_default_fields(self):
-        result = EvalResult(
-            mean_reward=0.0, std_reward=0.0, mean_length=0.0, success_rate=0.0
-        )
+        result = EvalResult(mean_reward=0.0, std_reward=0.0, mean_length=0.0, success_rate=0.0)
         assert result.per_episode_rewards == []
         assert result.per_episode_lengths == []
 

--- a/tests/test_trajectory_dataset.py
+++ b/tests/test_trajectory_dataset.py
@@ -37,6 +37,7 @@ from navirl.data.trajectory_dataset import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_trajectory(n=30, agent_id="ped_0", dt=0.4):
     """Create a simple linear trajectory for testing."""
     ts = np.arange(n, dtype=np.float64) * dt
@@ -542,9 +543,7 @@ class TestExtractSceneContext:
 
 class TestTrajectoryDatasetPipeline:
     def test_load_csv(self, tmp_path):
-        csv_data = "\n".join(
-            [f"{i},ped_0,{float(i)},{float(i) * 0.5}" for i in range(30)]
-        )
+        csv_data = "\n".join([f"{i},ped_0,{float(i)},{float(i) * 0.5}" for i in range(30)])
         p = tmp_path / "data.csv"
         p.write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(obs_len=4, pred_len=4)
@@ -580,9 +579,7 @@ class TestTrajectoryDatasetPipeline:
             pipeline.load(p)
 
     def test_process_and_splits(self, tmp_path):
-        csv_data = "\n".join(
-            [f"{i},ped_0,{float(i)},{float(i) * 0.5}" for i in range(40)]
-        )
+        csv_data = "\n".join([f"{i},ped_0,{float(i)},{float(i) * 0.5}" for i in range(40)])
         p = tmp_path / "data.csv"
         p.write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(
@@ -597,18 +594,14 @@ class TestTrajectoryDatasetPipeline:
 
     def test_load_multiple(self, tmp_path):
         for name in ["a.csv", "b.csv"]:
-            csv_data = "\n".join(
-                [f"{i},{name},{ float(i)},{float(i)}" for i in range(30)]
-            )
+            csv_data = "\n".join([f"{i},{name},{float(i)},{float(i)}" for i in range(30)])
             (tmp_path / name).write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(obs_len=4, pred_len=4)
         pipeline.load_multiple([tmp_path / "a.csv", tmp_path / "b.csv"])
         assert len(pipeline.trajectories) == 2
 
     def test_get_numpy_arrays(self, tmp_path):
-        csv_data = "\n".join(
-            [f"{i},ped_0,{float(i)},{float(i)}" for i in range(40)]
-        )
+        csv_data = "\n".join([f"{i},ped_0,{float(i)},{float(i)}" for i in range(40)])
         p = tmp_path / "data.csv"
         p.write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(obs_len=4, pred_len=4)
@@ -629,9 +622,7 @@ class TestTrajectoryDatasetPipeline:
             pipeline.get_numpy_arrays("invalid")
 
     def test_iterate_batches(self, tmp_path):
-        csv_data = "\n".join(
-            [f"{i},ped_0,{float(i)},{float(i)}" for i in range(50)]
-        )
+        csv_data = "\n".join([f"{i},ped_0,{float(i)},{float(i)}" for i in range(50)])
         p = tmp_path / "data.csv"
         p.write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(obs_len=4, pred_len=4)
@@ -646,9 +637,7 @@ class TestTrajectoryDatasetPipeline:
         assert batches == []
 
     def test_summary(self, tmp_path):
-        csv_data = "\n".join(
-            [f"{i},ped_0,{float(i)},{float(i)}" for i in range(30)]
-        )
+        csv_data = "\n".join([f"{i},ped_0,{float(i)},{float(i)}" for i in range(30)])
         p = tmp_path / "data.csv"
         p.write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(obs_len=4, pred_len=4)
@@ -660,9 +649,7 @@ class TestTrajectoryDatasetPipeline:
         assert s["augmentation_enabled"] is False
 
     def test_with_augmentation(self, tmp_path):
-        csv_data = "\n".join(
-            [f"{i},ped_0,{float(i)},{float(i)}" for i in range(30)]
-        )
+        csv_data = "\n".join([f"{i},ped_0,{float(i)},{float(i)}" for i in range(30)])
         p = tmp_path / "data.csv"
         p.write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(
@@ -676,9 +663,7 @@ class TestTrajectoryDatasetPipeline:
         assert s["num_windows"] > s["num_train"] + s["num_val"] + s["num_test"] or True
 
     def test_method_chaining(self, tmp_path):
-        csv_data = "\n".join(
-            [f"{i},ped_0,{float(i)},{float(i)}" for i in range(30)]
-        )
+        csv_data = "\n".join([f"{i},ped_0,{float(i)},{float(i)}" for i in range(30)])
         p = tmp_path / "data.csv"
         p.write_text(csv_data)
         pipeline = TrajectoryDatasetPipeline(obs_len=4, pred_len=4)

--- a/tests/test_trajectory_viz.py
+++ b/tests/test_trajectory_viz.py
@@ -168,9 +168,7 @@ class TestPlotTrajectory:
 
     def test_with_title_and_label(self, straight_xy):
         x, y = straight_xy
-        fig, ax = plot_trajectory(
-            x, y, title="Test", label="robot", xlabel="X", ylabel="Y"
-        )
+        fig, ax = plot_trajectory(x, y, title="Test", label="robot", xlabel="X", ylabel="Y")
         assert ax.get_title() == "Test"
 
     def test_no_equal_aspect(self, straight_xy):
@@ -464,9 +462,7 @@ class TestPlotTrajectoryUncertainty:
         sigma_x = np.ones(n) * 0.2
         sigma_y = np.ones(n) * 0.15
         rho = np.ones(n) * 0.5
-        fig, ax = plot_trajectory_uncertainty(
-            x, y, sigma_x, sigma_y, correlation=rho
-        )
+        fig, ax = plot_trajectory_uncertainty(x, y, sigma_x, sigma_y, correlation=rho)
         assert isinstance(fig, plt.Figure)
 
     def test_few_ellipses(self, straight_xy):
@@ -489,9 +485,7 @@ class TestPlotTrajectoryUncertainty:
         x, y = straight_xy
         n = len(x)
         _, ax0 = plt.subplots()
-        fig, ax = plot_trajectory_uncertainty(
-            x, y, np.ones(n) * 0.1, np.ones(n) * 0.1, ax=ax0
-        )
+        fig, ax = plot_trajectory_uncertainty(x, y, np.ones(n) * 0.1, np.ones(n) * 0.1, ax=ax0)
         assert ax is ax0
 
 
@@ -520,9 +514,7 @@ class TestPlotSocialDistances:
 
     def test_no_min_distance_line(self):
         positions = [{0: (0.0, 0.0), 1: (1.0, 0.0)}]
-        fig, ax = plot_social_distances_over_time(
-            positions, min_distance_line=None
-        )
+        fig, ax = plot_social_distances_over_time(positions, min_distance_line=None)
         assert isinstance(fig, plt.Figure)
 
     def test_no_min_envelope(self):
@@ -530,9 +522,7 @@ class TestPlotSocialDistances:
             {0: (0.0, 0.0), 1: (1.0, 0.0)},
             {0: (0.5, 0.0), 1: (1.5, 0.0)},
         ]
-        fig, ax = plot_social_distances_over_time(
-            positions, show_min_envelope=False
-        )
+        fig, ax = plot_social_distances_over_time(positions, show_min_envelope=False)
         assert isinstance(fig, plt.Figure)
 
     def test_single_agent_no_pairs(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -593,12 +593,14 @@ class TestSpatialHashGrid:
 
 class TestKDTree2D:
     def _make_tree(self):
-        points = np.array([
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [5.0, 5.0],
-            [10.0, 10.0],
-        ])
+        points = np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [5.0, 5.0],
+                [10.0, 10.0],
+            ]
+        )
         return KDTree2D(points, entity_ids=[10, 20, 30, 40])
 
     def test_size(self):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -135,22 +135,14 @@ class TestValidateUnitsMetadata:
 
     def test_nonpositive_ppm(self):
         scenario = {
-            "scene": {
-                "map": {
-                    "resolved": {"pixels_per_meter": -1.0, "meters_per_pixel": -1.0}
-                }
-            }
+            "scene": {"map": {"resolved": {"pixels_per_meter": -1.0, "meters_per_pixel": -1.0}}}
         }
         result = validate_units_metadata(scenario)
         assert result["pass"] is False
 
     def test_inconsistent_scale(self):
         scenario = {
-            "scene": {
-                "map": {
-                    "resolved": {"pixels_per_meter": 40.0, "meters_per_pixel": 0.1}
-                }
-            }
+            "scene": {"map": {"resolved": {"pixels_per_meter": 40.0, "meters_per_pixel": 0.1}}}
         }
         result = validate_units_metadata(scenario)
         assert result["pass"] is False
@@ -188,9 +180,7 @@ class TestValidateUnitsMetadata:
         assert "height_m_nonpositive" in reasons
 
     def test_fallback_to_top_level_map_keys(self):
-        scenario = {
-            "scene": {"map": {"pixels_per_meter": 20.0, "meters_per_pixel": 0.05}}
-        }
+        scenario = {"scene": {"map": {"pixels_per_meter": 20.0, "meters_per_pixel": 0.05}}}
         result = validate_units_metadata(scenario)
         assert result["pass"] is True
         assert result["pixels_per_meter"] == 20.0
@@ -347,10 +337,7 @@ class TestValidateSpeedAccelBounds:
 class TestValidateMotionJitter:
     def test_no_jitter(self, tmp_dir):
         # Constant heading (positive x)
-        rows = [
-            {"step": i, "agents": [{"id": 0, "vx": 1.0, "vy": 0.0}]}
-            for i in range(10)
-        ]
+        rows = [{"step": i, "agents": [{"id": 0, "vx": 1.0, "vy": 0.0}]} for i in range(10)]
         p = _write_jsonl(tmp_dir / "state.jsonl", rows)
         result = validate_motion_jitter(p, min_speed=0.5, max_flip_rate=0.5)
         assert result["pass"] is True

--- a/tests/test_validators_extended.py
+++ b/tests/test_validators_extended.py
@@ -62,9 +62,12 @@ def _make_agent_entry(
 ) -> dict:
     return {
         "id": aid,
-        "x": x, "y": y,
-        "vx": vx, "vy": vy,
-        "goal_x": goal_x, "goal_y": goal_y,
+        "x": x,
+        "y": y,
+        "vx": vx,
+        "vy": vy,
+        "goal_x": goal_x,
+        "goal_y": goal_y,
         "kind": kind,
         "behavior": behavior,
         "max_speed": max_speed,
@@ -126,14 +129,20 @@ class TestValidateNoTeleport:
 
     def test_multiple_agents(self, tmp_path):
         rows = [
-            _make_state_row(0, [
-                _make_agent_entry(aid=0, x=0.0),
-                _make_agent_entry(aid=1, x=5.0),
-            ]),
-            _make_state_row(1, [
-                _make_agent_entry(aid=0, x=0.1),
-                _make_agent_entry(aid=1, x=50.0),  # teleport
-            ]),
+            _make_state_row(
+                0,
+                [
+                    _make_agent_entry(aid=0, x=0.0),
+                    _make_agent_entry(aid=1, x=5.0),
+                ],
+            ),
+            _make_state_row(
+                1,
+                [
+                    _make_agent_entry(aid=0, x=0.1),
+                    _make_agent_entry(aid=1, x=50.0),  # teleport
+                ],
+            ),
         ]
         fp = _write_state(tmp_path, rows)
         result = validate_no_teleport(fp, teleport_thresh=1.0)
@@ -184,8 +193,7 @@ class TestValidateMotionJitter:
     def test_smooth_motion_passes(self, tmp_path):
         # Constant heading, no jitter
         rows = [
-            _make_state_row(i, [_make_agent_entry(x=float(i), vx=1.0, vy=0.0)])
-            for i in range(20)
+            _make_state_row(i, [_make_agent_entry(x=float(i), vx=1.0, vy=0.0)]) for i in range(20)
         ]
         fp = _write_state(tmp_path, rows)
         result = validate_motion_jitter(fp, min_speed=0.1, max_flip_rate=0.5)
@@ -204,10 +212,7 @@ class TestValidateMotionJitter:
         assert result["worst_flip_rate"] > 0.3
 
     def test_low_speed_ignored(self, tmp_path):
-        rows = [
-            _make_state_row(i, [_make_agent_entry(vx=0.001, vy=0.0)])
-            for i in range(10)
-        ]
+        rows = [_make_state_row(i, [_make_agent_entry(vx=0.001, vy=0.0)]) for i in range(10)]
         fp = _write_state(tmp_path, rows)
         result = validate_motion_jitter(fp, min_speed=0.1, max_flip_rate=0.5)
         assert result["pass"] is True
@@ -293,9 +298,9 @@ class TestValidateDeadlockBounded:
 
     def test_done_behavior_resets_streak(self, tmp_path):
         rows = [
-            _make_state_row(i, [
-                _make_agent_entry(x=0.0, vx=0.0, vy=0.0, goal_x=10.0, behavior="DONE")
-            ])
+            _make_state_row(
+                i, [_make_agent_entry(x=0.0, vx=0.0, vy=0.0, goal_x=10.0, behavior="DONE")]
+            )
             for i in range(100)
         ]
         fp = _write_state(tmp_path, rows)
@@ -304,9 +309,9 @@ class TestValidateDeadlockBounded:
 
     def test_yielding_not_flagged(self, tmp_path):
         rows = [
-            _make_state_row(i, [
-                _make_agent_entry(x=0.0, vx=0.0, vy=0.0, goal_x=10.0, behavior="YIELDING")
-            ])
+            _make_state_row(
+                i, [_make_agent_entry(x=0.0, vx=0.0, vy=0.0, goal_x=10.0, behavior="YIELDING")]
+            )
             for i in range(100)
         ]
         fp = _write_state(tmp_path, rows)
@@ -327,7 +332,10 @@ class TestValidateAgentStopDuration:
         ]
         fp = _write_state(tmp_path, rows)
         result = validate_agent_stop_duration(
-            fp, dt=0.04, max_stop_seconds=1.0, stop_speed_thresh=0.1,
+            fp,
+            dt=0.04,
+            max_stop_seconds=1.0,
+            stop_speed_thresh=0.1,
         )
         assert result["pass"] is True
 
@@ -338,34 +346,41 @@ class TestValidateAgentStopDuration:
         ]
         fp = _write_state(tmp_path, rows)
         result = validate_agent_stop_duration(
-            fp, dt=0.04, max_stop_seconds=1.0, stop_speed_thresh=0.1,
+            fp,
+            dt=0.04,
+            max_stop_seconds=1.0,
+            stop_speed_thresh=0.1,
         )
         assert result["pass"] is False
         assert result["num_violations"] > 0
 
     def test_wait_behavior_excluded(self, tmp_path):
         rows = [
-            _make_state_row(i, [
-                _make_agent_entry(x=0.0, vx=0.0, vy=0.0, goal_x=10.0, behavior="WAIT")
-            ])
+            _make_state_row(
+                i, [_make_agent_entry(x=0.0, vx=0.0, vy=0.0, goal_x=10.0, behavior="WAIT")]
+            )
             for i in range(200)
         ]
         fp = _write_state(tmp_path, rows)
         result = validate_agent_stop_duration(
-            fp, dt=0.04, max_stop_seconds=1.0, stop_speed_thresh=0.1,
+            fp,
+            dt=0.04,
+            max_stop_seconds=1.0,
+            stop_speed_thresh=0.1,
         )
         assert result["pass"] is True
 
     def test_near_goal_not_flagged(self, tmp_path):
         # Agent stopped but at goal (within goal_tol=0.2)
         rows = [
-            _make_state_row(i, [
-                _make_agent_entry(x=10.0, vx=0.0, vy=0.0, goal_x=10.0, goal_y=0.0)
-            ])
+            _make_state_row(i, [_make_agent_entry(x=10.0, vx=0.0, vy=0.0, goal_x=10.0, goal_y=0.0)])
             for i in range(200)
         ]
         fp = _write_state(tmp_path, rows)
         result = validate_agent_stop_duration(
-            fp, dt=0.04, max_stop_seconds=1.0, stop_speed_thresh=0.1,
+            fp,
+            dt=0.04,
+            max_stop_seconds=1.0,
+            stop_speed_thresh=0.1,
         )
         assert result["pass"] is True

--- a/tests/test_velocity_obstacle.py
+++ b/tests/test_velocity_obstacle.py
@@ -26,14 +26,27 @@ from navirl.models.velocity_obstacle import (
 
 
 def _agent(
-    aid=0, x=0.0, y=0.0, vx=0.0, vy=0.0, radius=0.25, max_speed=1.5,
-    gx=10.0, gy=0.0,
+    aid=0,
+    x=0.0,
+    y=0.0,
+    vx=0.0,
+    vy=0.0,
+    radius=0.25,
+    max_speed=1.5,
+    gx=10.0,
+    gy=0.0,
 ):
     return AgentState(
-        agent_id=aid, kind="human",
-        x=x, y=y, vx=vx, vy=vy,
-        goal_x=gx, goal_y=gy,
-        radius=radius, max_speed=max_speed,
+        agent_id=aid,
+        kind="human",
+        x=x,
+        y=y,
+        vx=vx,
+        vy=vy,
+        goal_x=gx,
+        goal_y=gy,
+        radius=radius,
+        max_speed=max_speed,
     )
 
 

--- a/tests/test_verify_runner.py
+++ b/tests/test_verify_runner.py
@@ -361,8 +361,18 @@ class TestWriteReport:
         invariants_data = {
             "overall_pass": False,
             "checks": [
-                {"name": "collision_free", "pass": False, "severity": "critical", "num_violations": 5},
-                {"name": "speed_limit", "pass": False, "severity": "low", "message": "minor overshoot"},
+                {
+                    "name": "collision_free",
+                    "pass": False,
+                    "severity": "critical",
+                    "num_violations": 5,
+                },
+                {
+                    "name": "speed_limit",
+                    "pass": False,
+                    "severity": "low",
+                    "message": "minor overshoot",
+                },
                 {"name": "goal_reached", "pass": True},
             ],
         }
@@ -399,9 +409,21 @@ class TestWriteReport:
             "status": "fail",
             "confidence": 0.4,
             "violations": [
-                {"type": "unsafe_proximity", "severity": "high", "evidence": "Robot too close to human at step 42"},
-                {"type": "odd_trajectory", "severity": "medium", "evidence": "Zigzag pattern detected"},
-                {"type": "minor_wobble", "severity": "low", "evidence": "Slight oscillation observed"},
+                {
+                    "type": "unsafe_proximity",
+                    "severity": "high",
+                    "evidence": "Robot too close to human at step 42",
+                },
+                {
+                    "type": "odd_trajectory",
+                    "severity": "medium",
+                    "evidence": "Zigzag pattern detected",
+                },
+                {
+                    "type": "minor_wobble",
+                    "severity": "low",
+                    "evidence": "Slight oscillation observed",
+                },
             ],
         }
         (bundle_dir / "judge.json").write_text(json.dumps(judge_data))

--- a/tests/test_wandb_logger.py
+++ b/tests/test_wandb_logger.py
@@ -15,6 +15,7 @@ import pytest
 # Build a fake wandb module so the real import succeeds with mocks
 # ---------------------------------------------------------------------------
 
+
 def _make_mock_wandb() -> types.ModuleType:
     """Create a mock ``wandb`` module with the attributes the logger needs."""
     mod = types.ModuleType("wandb")
@@ -67,6 +68,7 @@ else:
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _make_mock_run() -> MagicMock:
     """Return a mock W&B run object."""
     run = MagicMock(name="wandb_run")
@@ -86,21 +88,27 @@ def mock_run():
 @pytest.fixture()
 def enabled_logger(mock_run):
     """Return a WandbLogger that believes it is enabled, with mocked wandb."""
-    with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-         patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+    with (
+        patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+        patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+    ):
         _mock_wandb.init.return_value = mock_run
         lg = WandbLogger(project="test", run_name="unit", enabled=True)
     # Ensure subsequent calls also see the mock
-    with patch("navirl.logging.wandb_logger.wandb", _mock_wandb), \
-         patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True):
+    with (
+        patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+    ):
         yield lg
 
 
 @pytest.fixture()
 def disabled_logger():
     """Return a disabled WandbLogger."""
-    with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-         patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+    with (
+        patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+        patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+    ):
         lg = WandbLogger(project="test", enabled=False)
     yield lg
 
@@ -108,6 +116,7 @@ def disabled_logger():
 # ---------------------------------------------------------------------------
 # is_wandb_available
 # ---------------------------------------------------------------------------
+
 
 class TestIsWandbAvailable:
     def test_returns_true_when_available(self):
@@ -122,6 +131,7 @@ class TestIsWandbAvailable:
 # ---------------------------------------------------------------------------
 # SweepConfig
 # ---------------------------------------------------------------------------
+
 
 class TestSweepConfig:
     def test_build_minimal(self):
@@ -196,10 +206,13 @@ class TestSweepConfig:
 # AlertManager
 # ---------------------------------------------------------------------------
 
+
 class TestAlertManager:
     def test_send_info(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="t", enabled=True)
             _mock_wandb.alert.reset_mock()
@@ -212,8 +225,10 @@ class TestAlertManager:
             )
 
     def test_send_warn(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="t", enabled=True)
             _mock_wandb.alert.reset_mock()
@@ -224,8 +239,10 @@ class TestAlertManager:
             assert call_kwargs["wait_duration"] == 5.0
 
     def test_send_error(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="t", enabled=True)
             _mock_wandb.alert.reset_mock()
@@ -242,8 +259,10 @@ class TestAlertManager:
             _mock_wandb.alert.assert_not_called()
 
     def test_on_metric_threshold_above_triggered(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="t", enabled=True)
             _mock_wandb.alert.reset_mock()
@@ -252,8 +271,10 @@ class TestAlertManager:
             assert "loss" in _mock_wandb.alert.call_args.kwargs["title"]
 
     def test_on_metric_threshold_above_not_triggered(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="t", enabled=True)
             _mock_wandb.alert.reset_mock()
@@ -261,8 +282,10 @@ class TestAlertManager:
             _mock_wandb.alert.assert_not_called()
 
     def test_on_metric_threshold_below_triggered(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="t", enabled=True)
             _mock_wandb.alert.reset_mock()
@@ -270,8 +293,10 @@ class TestAlertManager:
             _mock_wandb.alert.assert_called_once()
 
     def test_on_metric_threshold_below_not_triggered(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="t", enabled=True)
             _mock_wandb.alert.reset_mock()
@@ -283,25 +308,32 @@ class TestAlertManager:
 # WandbLogger
 # ---------------------------------------------------------------------------
 
+
 class TestWandbLoggerConstruction:
     def test_enabled_construction(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             assert lg.enabled is True
             assert lg.run is mock_run
 
     def test_disabled_construction(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             lg = WandbLogger(project="p", enabled=False)
             assert lg.enabled is False
             assert lg.run is None
 
     def test_raises_import_error_when_wandb_unavailable_and_not_disabled(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False), \
-             pytest.raises(ImportError, match="wandb is not installed"):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", False),
+            pytest.raises(ImportError, match="wandb is not installed"),
+        ):
             WandbLogger(project="p", enabled=True, mode="online")
 
     def test_no_error_when_mode_disabled_and_wandb_unavailable(self):
@@ -312,41 +344,53 @@ class TestWandbLoggerConstruction:
 
 class TestWandbLoggerProperties:
     def test_run_id(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             assert lg.run_id == "run-abc123"
 
     def test_run_id_none_when_disabled(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             lg = WandbLogger(project="p", enabled=False)
             assert lg.run_id is None
 
     def test_run_url(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             assert lg.run_url == "https://wandb.ai/test/run-abc123"
 
     def test_run_url_none_when_disabled(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             lg = WandbLogger(project="p", enabled=False)
             assert lg.run_url is None
 
     def test_alerts_property(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             assert isinstance(lg.alerts, AlertManager)
 
     def test_is_closed_initially_false(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             assert lg.is_closed is False
@@ -354,8 +398,10 @@ class TestWandbLoggerProperties:
 
 class TestWandbLoggerContextManager:
     def test_context_manager_returns_self_and_finishes(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             with lg as ctx:
@@ -367,8 +413,10 @@ class TestWandbLoggerContextManager:
 
 class TestWandbLoggerConfig:
     def test_update_config(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             mock_run.config = MagicMock()
             lg = WandbLogger(project="p", enabled=True)
@@ -376,15 +424,19 @@ class TestWandbLoggerConfig:
             mock_run.config.update.assert_called_with({"lr": 0.001})
 
     def test_update_config_disabled_is_noop(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             lg = WandbLogger(project="p", enabled=False)
             # Should not raise
             lg.update_config({"lr": 0.001})
 
     def test_set_config(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             mock_run.config = {}
             lg = WandbLogger(project="p", enabled=True)
@@ -395,16 +447,20 @@ class TestWandbLoggerConfig:
 
 class TestWandbLoggerLog:
     def test_log_with_step(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log({"loss": 0.5}, step=10)
             mock_run.log.assert_called_with({"loss": 0.5}, step=10, commit=True)
 
     def test_log_auto_step_increments(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log({"a": 1})  # step=0
@@ -414,8 +470,10 @@ class TestWandbLoggerLog:
             assert calls[1][1]["step"] == 1
 
     def test_log_commit_false_does_not_increment(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log({"a": 1}, commit=False)  # step=0, no increment
@@ -425,22 +483,28 @@ class TestWandbLoggerLog:
             assert calls[1][1]["step"] == 0
 
     def test_log_disabled_is_noop(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             lg = WandbLogger(project="p", enabled=False)
             lg.log({"x": 1})  # should not raise
 
     def test_log_scalar(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_scalar("metric", 3.14, step=5)
             mock_run.log.assert_called_with({"metric": 3.14}, step=5, commit=True)
 
     def test_log_scalars_with_prefix(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_scalars({"a": 1.0, "b": 2.0}, step=0, prefix="train")
@@ -449,8 +513,10 @@ class TestWandbLoggerLog:
             assert "train/b" in call_data
 
     def test_log_scalars_without_prefix(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_scalars({"x": 5.0}, step=0)
@@ -460,8 +526,10 @@ class TestWandbLoggerLog:
 
 class TestWandbLoggerTrainingHelpers:
     def test_log_training_step_basic(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_training_step(step=1, loss=0.5)
@@ -471,8 +539,10 @@ class TestWandbLoggerTrainingHelpers:
             assert "train/grad_norm" not in call_data
 
     def test_log_training_step_with_optional_params(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_training_step(step=2, loss=0.3, lr=1e-4, grad_norm=0.1, extra={"entropy": 0.9})
@@ -483,8 +553,10 @@ class TestWandbLoggerTrainingHelpers:
             assert call_data["train/entropy"] == 0.9
 
     def test_log_evaluation(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_evaluation(step=10, metrics={"reward": 5.0, "success": 0.8})
@@ -493,8 +565,10 @@ class TestWandbLoggerTrainingHelpers:
             assert "eval/success" in call_data
 
     def test_log_episode_basic(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_episode(episode=5, reward=10.0, length=100)
@@ -504,8 +578,10 @@ class TestWandbLoggerTrainingHelpers:
             assert "episode/success" not in call_data
 
     def test_log_episode_with_success_and_extra(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.log_episode(episode=5, reward=10.0, length=100, success=True, extra={"col": 3.0})
@@ -516,8 +592,10 @@ class TestWandbLoggerTrainingHelpers:
 
 class TestWandbLoggerHistogram:
     def test_log_histogram(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Histogram.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -527,8 +605,10 @@ class TestWandbLoggerHistogram:
             assert call_kwargs[1]["num_bins"] == 32
 
     def test_log_reward_distribution(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Histogram.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -538,8 +618,10 @@ class TestWandbLoggerHistogram:
 
 class TestWandbLoggerTable:
     def test_log_table(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Table.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -547,8 +629,10 @@ class TestWandbLoggerTable:
             _mock_wandb.Table.assert_called_once_with(columns=["a", "b"], data=[[1, 2], [3, 4]])
 
     def test_log_trajectory_table(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Table.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -556,8 +640,11 @@ class TestWandbLoggerTable:
             velocities = np.array([[1.0, 0.0], [0.6, 0.8]])
             rewards = np.array([1.0, 2.0])
             lg.log_trajectory_table(
-                step=0, agent_id=1, positions=positions,
-                velocities=velocities, rewards=rewards,
+                step=0,
+                agent_id=1,
+                positions=positions,
+                velocities=velocities,
+                rewards=rewards,
             )
             _mock_wandb.Table.assert_called_once()
             call_kwargs = _mock_wandb.Table.call_args[1]
@@ -571,8 +658,10 @@ class TestWandbLoggerTable:
             assert rows[1][speed_idx] == pytest.approx(1.0)
 
     def test_log_trajectory_table_positions_only(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Table.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -585,8 +674,10 @@ class TestWandbLoggerTable:
 
 class TestWandbLoggerImages:
     def test_log_image(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Image.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -595,8 +686,10 @@ class TestWandbLoggerImages:
             _mock_wandb.Image.assert_called_once_with(img, caption="frame 0")
 
     def test_log_images_with_captions(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Image.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -605,8 +698,10 @@ class TestWandbLoggerImages:
             assert _mock_wandb.Image.call_count == 3
 
     def test_log_images_without_captions(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Image.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -617,8 +712,10 @@ class TestWandbLoggerImages:
 
 class TestWandbLoggerArtifacts:
     def test_log_artifact_file(self, mock_run, tmp_path):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             art = MagicMock()
             _mock_wandb.Artifact.return_value = art
@@ -632,8 +729,10 @@ class TestWandbLoggerArtifacts:
             mock_run.log_artifact.assert_called_once()
 
     def test_log_artifact_directory(self, mock_run, tmp_path):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             art = MagicMock()
             _mock_wandb.Artifact.return_value = art
@@ -646,8 +745,10 @@ class TestWandbLoggerArtifacts:
             art.add_dir.assert_called_once_with(str(d))
 
     def test_log_model_checkpoint_adds_latest_alias(self, mock_run, tmp_path):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             art = MagicMock()
             _mock_wandb.Artifact.return_value = art
@@ -660,8 +761,10 @@ class TestWandbLoggerArtifacts:
             assert "latest" in call_kwargs["aliases"]
 
     def test_log_model_checkpoint_preserves_existing_aliases(self, mock_run, tmp_path):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             art = MagicMock()
             _mock_wandb.Artifact.return_value = art
@@ -675,8 +778,10 @@ class TestWandbLoggerArtifacts:
             assert "latest" in call_kwargs["aliases"]
 
     def test_use_artifact(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             art_mock = MagicMock()
             art_mock.download.return_value = "/tmp/artifacts/model"
@@ -688,8 +793,10 @@ class TestWandbLoggerArtifacts:
             assert result == Path("/tmp/artifacts/model")
 
     def test_use_artifact_with_version(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             art_mock = MagicMock()
             art_mock.download.return_value = "/tmp/art"
@@ -700,16 +807,20 @@ class TestWandbLoggerArtifacts:
             mock_run.use_artifact.assert_called_with("model:v3", type=None)
 
     def test_use_artifact_disabled_returns_none(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             lg = WandbLogger(project="p", enabled=False)
             assert lg.use_artifact("x") is None
 
 
 class TestWandbLoggerSummary:
     def test_set_summary(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             mock_run.summary = {}
             lg = WandbLogger(project="p", enabled=True)
@@ -717,8 +828,10 @@ class TestWandbLoggerSummary:
             assert mock_run.summary["best_reward"] == 99.0
 
     def test_set_summaries(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             mock_run.summary = {}
             lg = WandbLogger(project="p", enabled=True)
@@ -729,8 +842,10 @@ class TestWandbLoggerSummary:
 
 class TestWandbLoggerTags:
     def test_add_tags(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             mock_run.tags = ("existing",)
             lg = WandbLogger(project="p", enabled=True)
@@ -738,8 +853,10 @@ class TestWandbLoggerTags:
             assert set(mock_run.tags) == {"existing", "new1", "new2"}
 
     def test_remove_tags(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             mock_run.tags = ("a", "b", "c")
             lg = WandbLogger(project="p", enabled=True)
@@ -750,8 +867,10 @@ class TestWandbLoggerTags:
 
 class TestWandbLoggerSweep:
     def test_create_sweep_with_dict(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.sweep.reset_mock()
             _mock_wandb.sweep.return_value = "sweep-id"
             result = WandbLogger.create_sweep({"method": "random"}, project="p")
@@ -759,8 +878,10 @@ class TestWandbLoggerSweep:
             _mock_wandb.sweep.assert_called_once()
 
     def test_create_sweep_with_sweep_config(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.sweep.reset_mock()
             _mock_wandb.sweep.return_value = "sweep-id-2"
             sc = SweepConfig("bayes", "loss", "minimize").add_uniform("lr", 0.0, 1.0)
@@ -779,8 +900,10 @@ class TestWandbLoggerSweep:
 
 class TestWandbLoggerCustomCharts:
     def test_define_and_log_custom_chart(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Table.reset_mock()
             _mock_wandb.plot_table.reset_mock()
@@ -790,8 +913,10 @@ class TestWandbLoggerCustomCharts:
             _mock_wandb.plot_table.assert_called_once()
 
     def test_log_custom_chart_without_definition_falls_back_to_table(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.Table.reset_mock()
             _mock_wandb.plot_table.reset_mock()
@@ -801,8 +926,10 @@ class TestWandbLoggerCustomCharts:
             _mock_wandb.plot_table.assert_not_called()
 
     def test_log_custom_chart_empty_data_is_noop(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             mock_run.log.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
@@ -812,8 +939,10 @@ class TestWandbLoggerCustomCharts:
 
 class TestWandbLoggerContextManagers:
     def test_train_step_context(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             with lg.train_step_context(step=5) as m:
@@ -824,8 +953,10 @@ class TestWandbLoggerContextManagers:
             assert call_data["train/loss"] == 0.1
 
     def test_eval_context(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             with lg.eval_context(step=10) as m:
@@ -837,20 +968,27 @@ class TestWandbLoggerContextManagers:
 
 class TestWandbLoggerWatchModel:
     def test_watch_model(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             _mock_wandb.watch.reset_mock()
             lg = WandbLogger(project="p", enabled=True)
             fake_model = MagicMock()
             lg.watch_model(fake_model, log="gradients", log_freq=50, log_graph=True)
             _mock_wandb.watch.assert_called_once_with(
-                fake_model, log="gradients", log_freq=50, log_graph=True,
+                fake_model,
+                log="gradients",
+                log_freq=50,
+                log_graph=True,
             )
 
     def test_watch_model_disabled_is_noop(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.watch.reset_mock()
             lg = WandbLogger(project="p", enabled=False)
             lg.watch_model(MagicMock())
@@ -859,8 +997,10 @@ class TestWandbLoggerWatchModel:
 
 class TestWandbLoggerFinish:
     def test_finish(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.finish(exit_code=0, quiet=True)
@@ -868,8 +1008,10 @@ class TestWandbLoggerFinish:
             assert lg.is_closed is True
 
     def test_double_finish_is_safe(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.finish()
@@ -877,8 +1019,10 @@ class TestWandbLoggerFinish:
             mock_run.finish.assert_called_once()
 
     def test_finish_without_args(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = WandbLogger(project="p", enabled=True)
             lg.finish()
@@ -889,10 +1033,13 @@ class TestWandbLoggerFinish:
 # Factory
 # ---------------------------------------------------------------------------
 
+
 class TestCreateWandbLogger:
     def test_creates_enabled_logger(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.return_value = mock_run
             lg = create_wandb_logger(project="test", enabled=True)
             assert lg.enabled is True
@@ -904,8 +1051,10 @@ class TestCreateWandbLogger:
             assert lg.enabled is False
 
     def test_disabled_explicitly(self):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             lg = create_wandb_logger(project="test", enabled=False, mode="disabled")
             assert lg.enabled is False
 
@@ -921,8 +1070,10 @@ class TestWandbLoggerInitKwargs:
     """Verify that optional init kwargs (entity, dir, resume, run_id) are passed through."""
 
     def test_entity_passed(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.reset_mock()
             _mock_wandb.init.return_value = mock_run
             WandbLogger(project="p", entity="myteam", enabled=True)
@@ -930,8 +1081,10 @@ class TestWandbLoggerInitKwargs:
             assert call_kwargs["entity"] == "myteam"
 
     def test_dir_passed(self, mock_run, tmp_path):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.reset_mock()
             _mock_wandb.init.return_value = mock_run
             WandbLogger(project="p", dir=tmp_path, enabled=True)
@@ -939,8 +1092,10 @@ class TestWandbLoggerInitKwargs:
             assert call_kwargs["dir"] == str(tmp_path)
 
     def test_resume_and_run_id_passed(self, mock_run):
-        with patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True), \
-             patch("navirl.logging.wandb_logger.wandb", _mock_wandb):
+        with (
+            patch("navirl.logging.wandb_logger._WANDB_AVAILABLE", True),
+            patch("navirl.logging.wandb_logger.wandb", _mock_wandb),
+        ):
             _mock_wandb.init.reset_mock()
             _mock_wandb.init.return_value = mock_run
             WandbLogger(project="p", resume="must", run_id="abc", enabled=True)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -178,6 +178,7 @@ from navirl.envs.wrappers import (
 # Helpers: a simple mock environment
 # ---------------------------------------------------------------------------
 
+
 class MockEnv(_gym_mod.Env):
     """Deterministic environment for testing wrappers."""
 
@@ -308,19 +309,23 @@ class TestFlattenObservation:
     def test_flattens_dict_observation(self):
         env = MockEnv(obs_shape=(4,))
         # Replace observation_space with a Dict space
-        env.observation_space = _spaces_mod.Dict({
-            "pos": _spaces_mod.Box(low=-1, high=1, shape=(2,)),
-            "vel": _spaces_mod.Box(low=-1, high=1, shape=(3,)),
-        })
+        env.observation_space = _spaces_mod.Dict(
+            {
+                "pos": _spaces_mod.Box(low=-1, high=1, shape=(2,)),
+                "vel": _spaces_mod.Box(low=-1, high=1, shape=(3,)),
+            }
+        )
         wrapped = FlattenObservation(env)
         assert wrapped.observation_space.shape == (5,)
 
     def test_observation_returns_flat_array(self):
         env = MockEnv(obs_shape=(4,))
-        env.observation_space = _spaces_mod.Dict({
-            "a": _spaces_mod.Box(low=0, high=1, shape=(2,)),
-            "b": _spaces_mod.Box(low=0, high=1, shape=(2,)),
-        })
+        env.observation_space = _spaces_mod.Dict(
+            {
+                "a": _spaces_mod.Box(low=0, high=1, shape=(2,)),
+                "b": _spaces_mod.Box(low=0, high=1, shape=(2,)),
+            }
+        )
         wrapped = FlattenObservation(env)
         obs_dict = {"a": np.array([1.0, 2.0]), "b": np.array([3.0, 4.0])}
         result = wrapped.observation(obs_dict)
@@ -532,8 +537,10 @@ class TestInferShapingFnArity:
         class Opaque:
             def __call__(self, *args):
                 return 0.0
+
             # Make inspect.signature fail
             __signature__ = None
+
         opaque = Opaque()
         # inspect.signature raises TypeError for __signature__=None in some versions;
         # if it doesn't, the VAR_POSITIONAL path gives 6 anyway
@@ -741,8 +748,10 @@ class TestMonitorWrapper:
 class TestCurriculumWrapper:
     def test_scheduler_sets_difficulty(self):
         env = MockEnv()
+
         def scheduler(steps):
             return min(steps / 100, 1.0)
+
         wrapped = CurriculumWrapper(env, scheduler=scheduler)
         wrapped.reset()
         assert env.difficulty == 0.0  # 0 steps so far
@@ -847,9 +856,11 @@ class TestVecEnvWrapper:
         def make_env():
             e = MockEnv()
             original_close = e.close
+
             def tracked_close():
                 envs_closed.append(True)
                 original_close()
+
             e.close = tracked_close
             return e
 


### PR DESCRIPTION
## Summary
- Adds a dedicated **lint job** to CI that runs `ruff check` and `ruff format --check`, ensuring code quality is enforced on every PR — not just locally via pre-commit hooks
- Adds **coverage reporting** (`--cov=navirl --cov-report=xml`) to the test job with artifact upload for the primary matrix entry
- Fixes all 5 remaining ruff lint violations (SIM117 nested `with` statements, C408 `dict()` calls) and auto-formats 71 files that were out of spec
- Adds `agents` optional dependency group for `torch>=2.0` (used in `navirl/agents/networks/`)

Addresses [#12](https://github.com/felipefelixarias/NavIRL/issues/12) — CI enforces code quality annotations.

## Test plan
- [x] `ruff check .` passes (0 errors)
- [x] `ruff format --check .` passes (0 files would be reformatted)
- [x] `pytest tests/test_coverage_gaps.py` — 51 passed
- [x] `pytest tests/test_routine_coverage.py` — 72 passed
- [x] `pytest tests/test_config.py tests/test_routine_compiler.py tests/test_planning.py` — 130 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)