### PR TITLE
test: add 242 tests for ROS integration and social A* modules

### DIFF
--- a/tests/test_ros_conversions.py
+++ b/tests/test_ros_conversions.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from navirl.ros.conversions import (
+    action_to_twist,
+    image_to_numpy,
+    laser_scan_to_lidar_obs,
+    odometry_to_state,
+    person_array_to_social_obs,
+    pose_to_goal,
+)
+
+# ---------------------------------------------------------------------------
+# Helper factories for duck-typed message objects
+# ---------------------------------------------------------------------------
+
+
+def _make_laser_scan(
+    ranges: list[float],
+    range_min: float = 0.0,
+    range_max: float = 30.0,
+) -> SimpleNamespace:
+    return SimpleNamespace(ranges=ranges, range_min=range_min, range_max=range_max)
+
+
+def _make_odometry(
+    x: float = 0.0,
+    y: float = 0.0,
+    qx: float = 0.0,
+    qy: float = 0.0,
+    qz: float = 0.0,
+    qw: float = 1.0,
+    vx: float = 0.0,
+    vy: float = 0.0,
+    omega: float = 0.0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        pose=SimpleNamespace(
+            pose=SimpleNamespace(
+                position=SimpleNamespace(x=x, y=y, z=0.0),
+                orientation=SimpleNamespace(x=qx, y=qy, z=qz, w=qw),
+            ),
+        ),
+        twist=SimpleNamespace(
+            twist=SimpleNamespace(
+                linear=SimpleNamespace(x=vx, y=vy, z=0.0),
+                angular=SimpleNamespace(x=0.0, y=0.0, z=omega),
+            ),
+        ),
+    )
+
+
+def _make_track(
+    x: float = 0.0,
+    y: float = 0.0,
+    vx: float = 0.0,
+    vy: float = 0.0,
+    qx: float = 0.0,
+    qy: float = 0.0,
+    qz: float = 0.0,
+    qw: float = 1.0,
+    track_id: int = 0,
+    detection_score: float = 1.0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        pose=SimpleNamespace(
+            pose=SimpleNamespace(
+                position=SimpleNamespace(x=x, y=y, z=0.0),
+                orientation=SimpleNamespace(x=qx, y=qy, z=qz, w=qw),
+            ),
+        ),
+        twist=SimpleNamespace(
+            twist=SimpleNamespace(
+                linear=SimpleNamespace(x=vx, y=vy, z=0.0),
+                angular=SimpleNamespace(x=0.0, y=0.0, z=0.0),
+            ),
+        ),
+        track_id=track_id,
+        detection_score=detection_score,
+    )
+
+
+def _make_person_array(tracks: list[SimpleNamespace]) -> SimpleNamespace:
+    return SimpleNamespace(tracks=tracks)
+
+
+def _make_image(
+    height: int,
+    width: int,
+    data: bytes,
+    encoding: str = "rgb8",
+) -> SimpleNamespace:
+    return SimpleNamespace(height=height, width=width, data=data, encoding=encoding)
+
+
+# ===================================================================
+# laser_scan_to_lidar_obs
+# ===================================================================
+
+
+class TestLaserScanToLidarObs:
+    def test_normal_ranges(self):
+        msg = _make_laser_scan([1.0, 2.0, 3.0], range_min=0.0, range_max=30.0)
+        result = laser_scan_to_lidar_obs(msg)
+        assert result.dtype == np.float32
+        assert result.shape == (3,)
+        np.testing.assert_array_almost_equal(result, [1.0, 2.0, 3.0])
+
+    def test_inf_replaced_with_range_max(self):
+        msg = _make_laser_scan([1.0, float("inf"), float("-inf")], range_max=10.0)
+        result = laser_scan_to_lidar_obs(msg)
+        np.testing.assert_array_almost_equal(result, [1.0, 10.0, 10.0])
+
+    def test_nan_replaced_with_range_max(self):
+        msg = _make_laser_scan([float("nan"), 5.0], range_max=20.0)
+        result = laser_scan_to_lidar_obs(msg)
+        np.testing.assert_array_almost_equal(result, [20.0, 5.0])
+
+    def test_clipping_to_range(self):
+        msg = _make_laser_scan([0.5, 50.0, -1.0], range_min=1.0, range_max=10.0)
+        result = laser_scan_to_lidar_obs(msg)
+        # 0.5 clipped up to 1.0, 50.0 clipped down to 10.0, -1.0 clipped up to 1.0
+        np.testing.assert_array_almost_equal(result, [1.0, 10.0, 1.0])
+
+    def test_empty_ranges(self):
+        msg = _make_laser_scan([], range_max=10.0)
+        result = laser_scan_to_lidar_obs(msg)
+        assert result.shape == (0,)
+        assert result.dtype == np.float32
+
+    def test_single_element(self):
+        msg = _make_laser_scan([7.5], range_max=30.0)
+        result = laser_scan_to_lidar_obs(msg)
+        assert result.shape == (1,)
+        assert result[0] == pytest.approx(7.5)
+
+    def test_all_invalid(self):
+        msg = _make_laser_scan(
+            [float("inf"), float("nan"), float("-inf")], range_max=5.0
+        )
+        result = laser_scan_to_lidar_obs(msg)
+        np.testing.assert_array_almost_equal(result, [5.0, 5.0, 5.0])
+
+    def test_default_range_max_when_missing(self):
+        # range_max defaults to 30.0 via getattr
+        msg = SimpleNamespace(ranges=[float("inf")])
+        result = laser_scan_to_lidar_obs(msg)
+        assert result[0] == pytest.approx(30.0)
+
+
+# ===================================================================
+# odometry_to_state
+# ===================================================================
+
+
+class TestOdometryToState:
+    def test_identity_orientation(self):
+        msg = _make_odometry(x=1.0, y=2.0, vx=0.5, vy=0.1, omega=0.3)
+        state = odometry_to_state(msg)
+        assert state["x"] == pytest.approx(1.0)
+        assert state["y"] == pytest.approx(2.0)
+        assert state["yaw"] == pytest.approx(0.0)  # identity quaternion -> yaw 0
+        assert state["vx"] == pytest.approx(0.5)
+        assert state["vy"] == pytest.approx(0.1)
+        assert state["omega"] == pytest.approx(0.3)
+
+    def test_90_degree_yaw(self):
+        # Quaternion for 90-degree rotation about z: qz=sin(pi/4), qw=cos(pi/4)
+        qz = math.sin(math.pi / 4)
+        qw = math.cos(math.pi / 4)
+        msg = _make_odometry(qz=qz, qw=qw)
+        state = odometry_to_state(msg)
+        assert state["yaw"] == pytest.approx(math.pi / 2, abs=1e-6)
+
+    def test_180_degree_yaw(self):
+        # Quaternion for 180-degree rotation: qz=1, qw=0
+        msg = _make_odometry(qz=1.0, qw=0.0)
+        state = odometry_to_state(msg)
+        assert abs(state["yaw"]) == pytest.approx(math.pi, abs=1e-6)
+
+    def test_zero_state(self):
+        msg = _make_odometry()
+        state = odometry_to_state(msg)
+        assert set(state.keys()) == {"x", "y", "yaw", "vx", "vy", "omega"}
+        for key in state:
+            assert state[key] == pytest.approx(0.0)
+
+    def test_negative_velocities(self):
+        msg = _make_odometry(vx=-1.0, vy=-2.0, omega=-0.5)
+        state = odometry_to_state(msg)
+        assert state["vx"] == pytest.approx(-1.0)
+        assert state["vy"] == pytest.approx(-2.0)
+        assert state["omega"] == pytest.approx(-0.5)
+
+
+# ===================================================================
+# person_array_to_social_obs
+# ===================================================================
+
+
+class TestPersonArrayToSocialObs:
+    def test_empty_tracks(self):
+        msg = _make_person_array([])
+        result = person_array_to_social_obs(msg)
+        assert result.shape == (0, 7)
+        assert result.dtype == np.float64
+
+    def test_single_track(self):
+        track = _make_track(x=1.0, y=2.0, vx=0.5, vy=-0.3, track_id=42, detection_score=0.9)
+        msg = _make_person_array([track])
+        result = person_array_to_social_obs(msg)
+        assert result.shape == (1, 7)
+        assert result[0, 0] == pytest.approx(1.0)  # x
+        assert result[0, 1] == pytest.approx(2.0)  # y
+        assert result[0, 2] == pytest.approx(0.5)  # vx
+        assert result[0, 3] == pytest.approx(-0.3)  # vy
+        assert result[0, 4] == pytest.approx(0.0)  # theta (identity quat)
+        assert result[0, 5] == pytest.approx(42.0)  # track_id
+        assert result[0, 6] == pytest.approx(0.9)  # detection_score
+
+    def test_multiple_tracks(self):
+        tracks = [
+            _make_track(x=1.0, y=2.0, track_id=1),
+            _make_track(x=3.0, y=4.0, track_id=2),
+            _make_track(x=5.0, y=6.0, track_id=3),
+        ]
+        msg = _make_person_array(tracks)
+        result = person_array_to_social_obs(msg)
+        assert result.shape == (3, 7)
+        np.testing.assert_array_almost_equal(result[:, 0], [1.0, 3.0, 5.0])
+        np.testing.assert_array_almost_equal(result[:, 1], [2.0, 4.0, 6.0])
+
+    def test_no_tracks_attribute_uses_persons(self):
+        track = _make_track(x=10.0, y=20.0, track_id=99)
+        msg = SimpleNamespace(persons=[track])
+        result = person_array_to_social_obs(msg)
+        assert result.shape == (1, 7)
+        assert result[0, 0] == pytest.approx(10.0)
+
+    def test_no_tracks_or_persons_returns_empty(self):
+        msg = SimpleNamespace()
+        result = person_array_to_social_obs(msg)
+        assert result.shape == (0, 7)
+
+    def test_fallback_detection_id(self):
+        # Track without track_id but with detection_id
+        track = _make_track(x=1.0, y=2.0)
+        del track.track_id
+        track.detection_id = 77
+        msg = _make_person_array([track])
+        result = person_array_to_social_obs(msg)
+        assert result[0, 5] == pytest.approx(77.0)
+
+    def test_fallback_is_matched(self):
+        # Track without detection_score but with is_matched
+        track = _make_track(x=1.0, y=2.0)
+        del track.detection_score
+        track.is_matched = 0.5
+        msg = _make_person_array([track])
+        result = person_array_to_social_obs(msg)
+        assert result[0, 6] == pytest.approx(0.5)
+
+    def test_orientation_in_track(self):
+        qz = math.sin(math.pi / 4)
+        qw = math.cos(math.pi / 4)
+        track = _make_track(qz=qz, qw=qw)
+        msg = _make_person_array([track])
+        result = person_array_to_social_obs(msg)
+        assert result[0, 4] == pytest.approx(math.pi / 2, abs=1e-6)
+
+
+# ===================================================================
+# action_to_twist
+# ===================================================================
+
+
+class TestActionToTwist:
+    def test_continuous_action(self):
+        result = action_to_twist(np.array([1.5, 0.3]), action_type="continuous")
+        assert result["linear_x"] == pytest.approx(1.5)
+        assert result["angular_z"] == pytest.approx(0.3)
+        assert result["linear_y"] == 0.0
+        assert result["linear_z"] == 0.0
+        assert result["angular_x"] == 0.0
+        assert result["angular_y"] == 0.0
+
+    def test_continuous_single_element(self):
+        result = action_to_twist(np.array([2.0]), action_type="continuous")
+        assert result["linear_x"] == pytest.approx(2.0)
+        assert result["angular_z"] == pytest.approx(0.0)
+
+    def test_continuous_empty(self):
+        result = action_to_twist(np.array([]), action_type="continuous")
+        assert result["linear_x"] == pytest.approx(0.0)
+        assert result["angular_z"] == pytest.approx(0.0)
+
+    @pytest.mark.parametrize(
+        "idx, expected_linear, expected_angular",
+        [
+            (0, 0.0, 0.0),    # stop
+            (1, 0.5, 0.0),    # forward
+            (2, -0.3, 0.0),   # backward
+            (3, 0.2, 0.5),    # turn left
+            (4, 0.2, -0.5),   # turn right
+            (5, 0.5, 0.3),    # forward-left
+            (6, 0.5, -0.3),   # forward-right
+        ],
+    )
+    def test_discrete_actions(self, idx, expected_linear, expected_angular):
+        result = action_to_twist(np.array([idx]), action_type="discrete")
+        assert result["linear_x"] == pytest.approx(expected_linear)
+        assert result["angular_z"] == pytest.approx(expected_angular)
+
+    def test_discrete_unknown_index(self):
+        result = action_to_twist(np.array([99]), action_type="discrete")
+        assert result["linear_x"] == pytest.approx(0.0)
+        assert result["angular_z"] == pytest.approx(0.0)
+
+    def test_discrete_negative_index(self):
+        result = action_to_twist(np.array([-1]), action_type="discrete")
+        assert result["linear_x"] == pytest.approx(0.0)
+        assert result["angular_z"] == pytest.approx(0.0)
+
+    def test_discrete_empty(self):
+        result = action_to_twist(np.array([]), action_type="discrete")
+        assert result["linear_x"] == pytest.approx(0.0)
+        assert result["angular_z"] == pytest.approx(0.0)
+
+    def test_accepts_python_list(self):
+        result = action_to_twist([1.0, -0.5], action_type="continuous")
+        assert result["linear_x"] == pytest.approx(1.0)
+        assert result["angular_z"] == pytest.approx(-0.5)
+
+    def test_accepts_scalar(self):
+        result = action_to_twist(np.float64(3.0), action_type="discrete")
+        assert result["linear_x"] == pytest.approx(0.2)
+        assert result["angular_z"] == pytest.approx(0.5)
+
+    def test_continuous_negative_values(self):
+        result = action_to_twist(np.array([-1.0, -2.0]), action_type="continuous")
+        assert result["linear_x"] == pytest.approx(-1.0)
+        assert result["angular_z"] == pytest.approx(-2.0)
+
+
+# ===================================================================
+# pose_to_goal
+# ===================================================================
+
+
+class TestPoseToGoal:
+    def test_pose_stamped_style(self):
+        # PoseStamped: msg.pose.position.x
+        msg = SimpleNamespace(
+            pose=SimpleNamespace(position=SimpleNamespace(x=3.0, y=4.0))
+        )
+        result = pose_to_goal(msg)
+        assert result == (pytest.approx(3.0), pytest.approx(4.0))
+
+    def test_plain_pose_style(self):
+        # Pose: msg.position.x
+        msg = SimpleNamespace(position=SimpleNamespace(x=5.0, y=6.0))
+        result = pose_to_goal(msg)
+        assert result == (pytest.approx(5.0), pytest.approx(6.0))
+
+    def test_bare_position(self):
+        # Bare object with x, y directly (no .pose, no .position)
+        msg = SimpleNamespace(x=7.0, y=8.0)
+        result = pose_to_goal(msg)
+        assert result == (pytest.approx(7.0), pytest.approx(8.0))
+
+    def test_negative_coordinates(self):
+        msg = SimpleNamespace(position=SimpleNamespace(x=-1.5, y=-2.5))
+        result = pose_to_goal(msg)
+        assert result == (pytest.approx(-1.5), pytest.approx(-2.5))
+
+    def test_zero_coordinates(self):
+        msg = SimpleNamespace(position=SimpleNamespace(x=0.0, y=0.0))
+        result = pose_to_goal(msg)
+        assert result == (0.0, 0.0)
+
+
+# ===================================================================
+# image_to_numpy
+# ===================================================================
+
+
+class TestImageToNumpy:
+    def test_rgb8(self):
+        height, width = 2, 3
+        data = bytes(range(height * width * 3))
+        msg = _make_image(height, width, data, encoding="rgb8")
+        result = image_to_numpy(msg)
+        assert result.shape == (2, 3, 3)
+        assert result.dtype == np.uint8
+
+    def test_bgr8_converted_to_rgb(self):
+        height, width = 1, 1
+        # BGR pixel: B=10, G=20, R=30
+        data = bytes([10, 20, 30])
+        msg = _make_image(height, width, data, encoding="bgr8")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 1, 3)
+        # After BGR->RGB reversal: R=30, G=20, B=10
+        np.testing.assert_array_equal(result[0, 0], [30, 20, 10])
+
+    def test_bgra8_converted_to_argb(self):
+        height, width = 1, 1
+        # BGRA pixel: B=10, G=20, R=30, A=255
+        data = bytes([10, 20, 30, 255])
+        msg = _make_image(height, width, data, encoding="bgra8")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 1, 4)
+        # After full channel reversal: A=255, R=30, G=20, B=10
+        np.testing.assert_array_equal(result[0, 0], [255, 30, 20, 10])
+
+    def test_mono8(self):
+        height, width = 2, 2
+        data = bytes([0, 64, 128, 255])
+        msg = _make_image(height, width, data, encoding="mono8")
+        result = image_to_numpy(msg)
+        assert result.shape == (2, 2)
+        assert result.dtype == np.uint8
+        np.testing.assert_array_equal(result, [[0, 64], [128, 255]])
+
+    def test_32fc1(self):
+        height, width = 1, 2
+        arr = np.array([1.5, 2.5], dtype=np.float32)
+        data = arr.tobytes()
+        msg = _make_image(height, width, data, encoding="32FC1")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 2)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, [[1.5, 2.5]])
+
+    def test_rgba8(self):
+        height, width = 1, 1
+        data = bytes([100, 150, 200, 255])
+        msg = _make_image(height, width, data, encoding="rgba8")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 1, 4)
+        assert result.dtype == np.uint8
+        np.testing.assert_array_equal(result[0, 0], [100, 150, 200, 255])
+
+    def test_8uc1(self):
+        height, width = 1, 3
+        data = bytes([10, 20, 30])
+        msg = _make_image(height, width, data, encoding="8UC1")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 3)
+        assert result.dtype == np.uint8
+
+    def test_8uc3(self):
+        height, width = 1, 1
+        data = bytes([10, 20, 30])
+        msg = _make_image(height, width, data, encoding="8UC3")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 1, 3)
+        assert result.dtype == np.uint8
+
+    def test_16uc1(self):
+        height, width = 1, 2
+        arr = np.array([1000, 2000], dtype=np.uint16)
+        data = arr.tobytes()
+        msg = _make_image(height, width, data, encoding="16UC1")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 2)
+        assert result.dtype == np.uint16
+        np.testing.assert_array_equal(result, [[1000, 2000]])
+
+    def test_unknown_encoding_defaults_to_uint8_3ch(self):
+        height, width = 1, 1
+        data = bytes([10, 20, 30])
+        msg = _make_image(height, width, data, encoding="unknown_enc")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 1, 3)
+        assert result.dtype == np.uint8
+
+    def test_bgr8_larger_image(self):
+        height, width = 2, 2
+        # 4 BGR pixels
+        data = bytes(
+            [
+                10, 20, 30,  # (0,0)
+                40, 50, 60,  # (0,1)
+                70, 80, 90,  # (1,0)
+                100, 110, 120,  # (1,1)
+            ]
+        )
+        msg = _make_image(height, width, data, encoding="bgr8")
+        result = image_to_numpy(msg)
+        assert result.shape == (2, 2, 3)
+        # First pixel BGR(10,20,30) -> RGB(30,20,10)
+        np.testing.assert_array_equal(result[0, 0], [30, 20, 10])
+        np.testing.assert_array_equal(result[1, 1], [120, 110, 100])
+
+    def test_data_as_list(self):
+        # data passed as a list of ints (not bytes) -- converted via bytes()
+        height, width = 1, 2
+        data = [10, 20, 30, 40, 50, 60]
+        msg = _make_image(height, width, data, encoding="rgb8")
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 2, 3)
+
+    def test_default_encoding(self):
+        # When encoding attribute missing, defaults to rgb8
+        height, width = 1, 1
+        data = bytes([1, 2, 3])
+        msg = SimpleNamespace(height=height, width=width, data=data)
+        result = image_to_numpy(msg)
+        assert result.shape == (1, 1, 3)

--- a/tests/test_ros_costmap.py
+++ b/tests/test_ros_costmap.py
@@ -1,0 +1,639 @@
+from __future__ import annotations
+
+import math
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from navirl.ros.costmap import (
+    FREE_SPACE,
+    INSCRIBED_COST,
+    LETHAL_COST,
+    NO_INFORMATION,
+    CostmapManager,
+    InflationCostmapLayer,
+    PredictiveCostmapLayer,
+    SocialCostmapLayer,
+    StaticCostmapLayer,
+    _gaussian_kernel,
+    _grid_to_world,
+    _world_to_grid,
+)
+
+# =====================================================================
+# Helper functions
+# =====================================================================
+
+
+class TestWorldToGrid:
+    """Tests for _world_to_grid."""
+
+    def test_origin_maps_to_zero(self) -> None:
+        gx, gy = _world_to_grid(0.0, 0.0, 0.0, 0.0, 0.05)
+        assert (gx, gy) == (0, 0)
+
+    def test_positive_offset(self) -> None:
+        gx, gy = _world_to_grid(1.0, 2.0, 0.0, 0.0, 0.05)
+        assert gx == 20
+        assert gy == 40
+
+    def test_negative_origin(self) -> None:
+        gx, gy = _world_to_grid(0.0, 0.0, -5.0, -5.0, 0.05)
+        assert gx == 100
+        assert gy == 100
+
+    def test_returns_int(self) -> None:
+        gx, gy = _world_to_grid(0.123, 0.456, 0.0, 0.0, 0.05)
+        assert isinstance(gx, int)
+        assert isinstance(gy, int)
+
+
+class TestGridToWorld:
+    """Tests for _grid_to_world."""
+
+    def test_origin_maps_to_origin(self) -> None:
+        wx, wy = _grid_to_world(0, 0, -5.0, -5.0, 0.05)
+        assert wx == pytest.approx(-5.0)
+        assert wy == pytest.approx(-5.0)
+
+    def test_positive_cells(self) -> None:
+        wx, wy = _grid_to_world(100, 100, -5.0, -5.0, 0.05)
+        assert wx == pytest.approx(0.0)
+        assert wy == pytest.approx(0.0)
+
+
+class TestRoundTrip:
+    """World -> grid -> world should return ~original coordinates."""
+
+    @pytest.mark.parametrize(
+        "wx, wy",
+        [(0.0, 0.0), (1.5, -2.3), (-4.9, -4.9), (4.95, 4.95)],
+    )
+    def test_round_trip(self, wx: float, wy: float) -> None:
+        origin_x, origin_y, res = -5.0, -5.0, 0.05
+        gx, gy = _world_to_grid(wx, wy, origin_x, origin_y, res)
+        wx2, wy2 = _grid_to_world(gx, gy, origin_x, origin_y, res)
+        assert wx2 == pytest.approx(wx, abs=res)
+        assert wy2 == pytest.approx(wy, abs=res)
+
+
+class TestGaussianKernel:
+    """Tests for _gaussian_kernel."""
+
+    def test_sums_to_one(self) -> None:
+        k = _gaussian_kernel(5, 1.0)
+        assert k.sum() == pytest.approx(1.0, abs=1e-12)
+
+    def test_shape(self) -> None:
+        k = _gaussian_kernel(7, 2.0)
+        assert k.shape == (7, 7)
+
+    def test_center_is_max(self) -> None:
+        k = _gaussian_kernel(5, 1.0)
+        center = k[2, 2]
+        assert center == k.max()
+
+    def test_symmetric(self) -> None:
+        k = _gaussian_kernel(9, 3.0)
+        np.testing.assert_allclose(k, k[::-1, :], atol=1e-15)
+        np.testing.assert_allclose(k, k[:, ::-1], atol=1e-15)
+
+    def test_all_positive(self) -> None:
+        k = _gaussian_kernel(5, 1.0)
+        assert (k > 0).all()
+
+
+# =====================================================================
+# Constants
+# =====================================================================
+
+
+class TestConstants:
+    def test_values(self) -> None:
+        assert FREE_SPACE == 0
+        assert INSCRIBED_COST == 99
+        assert LETHAL_COST == 100
+        assert NO_INFORMATION == -1
+
+
+# =====================================================================
+# CostmapManager
+# =====================================================================
+
+
+class TestCostmapManagerInit:
+    def test_default_dimensions(self) -> None:
+        mgr = CostmapManager()
+        assert mgr.width == 200
+        assert mgr.height == 200
+        assert mgr.resolution == 0.05
+        assert mgr.origin_x == -5.0
+        assert mgr.origin_y == -5.0
+
+    def test_custom_dimensions(self) -> None:
+        mgr = CostmapManager(width=50, height=60, resolution=0.1, origin=(0.0, 0.0))
+        assert mgr.width == 50
+        assert mgr.height == 60
+        assert mgr.resolution == 0.1
+
+    def test_master_starts_free(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        assert (mgr.master == FREE_SPACE).all()
+
+    def test_master_returns_copy(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        m = mgr.master
+        m[0, 0] = 50
+        assert mgr.master[0, 0] == FREE_SPACE
+
+
+class TestCostmapManagerLayers:
+    def test_add_and_get_layer(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        layer = StaticCostmapLayer()
+        mgr.add_layer("static", layer)
+        assert mgr.get_layer("static") is layer
+
+    def test_get_missing_layer_returns_none(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        assert mgr.get_layer("nonexistent") is None
+
+    def test_remove_layer(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        layer = StaticCostmapLayer()
+        mgr.add_layer("static", layer)
+        mgr.remove_layer("static")
+        assert mgr.get_layer("static") is None
+
+    def test_remove_nonexistent_is_noop(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        mgr.remove_layer("nope")  # should not raise
+
+    def test_add_layer_resizes(self) -> None:
+        mgr = CostmapManager(width=30, height=40)
+        layer = StaticCostmapLayer()
+        mgr.add_layer("s", layer)
+        assert layer.grid.shape == (40, 30)
+
+
+class TestCostmapManagerUpdate:
+    def test_update_empty_returns_free(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        result = mgr.update()
+        assert (result == FREE_SPACE).all()
+
+    def test_update_merges_via_max(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+
+        layer_a = StaticCostmapLayer()
+        mgr.add_layer("a", layer_a)
+        arr_a = np.zeros((10, 10), dtype=np.int8)
+        arr_a[5, 5] = 50
+        layer_a.load_from_array(arr_a)
+
+        layer_b = StaticCostmapLayer()
+        mgr.add_layer("b", layer_b)
+        arr_b = np.zeros((10, 10), dtype=np.int8)
+        arr_b[5, 5] = 80
+        layer_b.load_from_array(arr_b)
+
+        merged = mgr.update()
+        assert merged[5, 5] == 80  # max of 50 and 80
+
+    def test_update_returns_copy(self) -> None:
+        mgr = CostmapManager(width=10, height=10)
+        result = mgr.update()
+        result[0, 0] = 99
+        assert mgr.master[0, 0] == FREE_SPACE
+
+
+class TestCostmapManagerConvenience:
+    def test_world_to_grid(self) -> None:
+        mgr = CostmapManager(width=200, height=200, resolution=0.05, origin=(-5.0, -5.0))
+        gx, gy = mgr.world_to_grid(0.0, 0.0)
+        assert gx == 100
+        assert gy == 100
+
+    def test_grid_to_world(self) -> None:
+        mgr = CostmapManager(resolution=0.05, origin=(-5.0, -5.0))
+        wx, wy = mgr.grid_to_world(100, 100)
+        assert wx == pytest.approx(0.0)
+        assert wy == pytest.approx(0.0)
+
+    def test_in_bounds_true(self) -> None:
+        mgr = CostmapManager(width=200, height=200)
+        assert mgr.in_bounds(0, 0) is True
+        assert mgr.in_bounds(199, 199) is True
+
+    def test_in_bounds_false(self) -> None:
+        mgr = CostmapManager(width=200, height=200)
+        assert mgr.in_bounds(-1, 0) is False
+        assert mgr.in_bounds(0, -1) is False
+        assert mgr.in_bounds(200, 0) is False
+        assert mgr.in_bounds(0, 200) is False
+
+    def test_in_bounds_edge_cases(self) -> None:
+        mgr = CostmapManager(width=1, height=1)
+        assert mgr.in_bounds(0, 0) is True
+        assert mgr.in_bounds(1, 0) is False
+
+
+# =====================================================================
+# OccupancyGrid conversion (dict fallback, no ROS2)
+# =====================================================================
+
+
+class TestOccupancyGridConversion:
+    def test_to_occupancy_grid_dict_keys(self) -> None:
+        mgr = CostmapManager(width=10, height=10, resolution=0.1, origin=(1.0, 2.0))
+        d = mgr.to_occupancy_grid(frame_id="odom")
+        # When ROS2 is unavailable the result is a plain dict
+        if isinstance(d, dict):
+            assert d["frame_id"] == "odom"
+            assert d["resolution"] == 0.1
+            assert d["width"] == 10
+            assert d["height"] == 10
+            assert d["origin"] == (1.0, 2.0)
+            assert len(d["data"]) == 100
+
+    def test_to_occupancy_grid_data_matches_master(self) -> None:
+        mgr = CostmapManager(width=5, height=5)
+        layer = StaticCostmapLayer()
+        mgr.add_layer("s", layer)
+        arr = np.zeros((5, 5), dtype=np.int8)
+        arr[2, 3] = 42
+        layer.load_from_array(arr)
+        mgr.update()
+
+        d = mgr.to_occupancy_grid()
+        if isinstance(d, dict):
+            assert d["data"][2 * 5 + 3] == 42
+
+    def test_to_occupancy_grid_with_stamp(self) -> None:
+        mgr = CostmapManager(width=5, height=5)
+        result = mgr.to_occupancy_grid(frame_id="map", stamp=12345)
+        # Should not raise regardless of stamp type
+        assert result is not None
+
+    def test_from_occupancy_grid_round_trip(self) -> None:
+        """Build a msg-like object and reconstruct a CostmapManager."""
+        original = CostmapManager(width=8, height=6, resolution=0.1, origin=(1.0, 2.0))
+        layer = StaticCostmapLayer()
+        original.add_layer("s", layer)
+        arr = np.zeros((6, 8), dtype=np.int8)
+        arr[3, 4] = 77
+        layer.load_from_array(arr)
+        original.update()
+
+        # Build a fake ROS-like msg object
+        msg = types.SimpleNamespace(
+            info=types.SimpleNamespace(
+                width=8,
+                height=6,
+                resolution=0.1,
+                origin=types.SimpleNamespace(
+                    position=types.SimpleNamespace(x=1.0, y=2.0),
+                ),
+            ),
+            data=original.master.ravel().tolist(),
+        )
+
+        restored = CostmapManager.from_occupancy_grid(msg)
+        assert restored.width == 8
+        assert restored.height == 6
+        assert restored.resolution == pytest.approx(0.1)
+        assert restored.origin_x == pytest.approx(1.0)
+        assert restored.origin_y == pytest.approx(2.0)
+        np.testing.assert_array_equal(restored.master, original.master)
+
+
+# =====================================================================
+# StaticCostmapLayer
+# =====================================================================
+
+
+class TestStaticCostmapLayer:
+    def test_load_from_array(self) -> None:
+        mgr = CostmapManager(width=5, height=5)
+        layer = StaticCostmapLayer()
+        mgr.add_layer("static", layer)
+
+        arr = np.full((5, 5), 42, dtype=np.int8)
+        layer.load_from_array(arr)
+        np.testing.assert_array_equal(layer.grid, arr)
+
+    def test_load_clips_values(self) -> None:
+        layer = StaticCostmapLayer()
+        arr = np.array([[200, -50]], dtype=np.int16)
+        layer.load_from_array(arr)
+        assert layer.grid[0, 0] == 100
+        assert layer.grid[0, 1] == -1
+
+    def test_update_is_noop(self) -> None:
+        layer = StaticCostmapLayer()
+        arr = np.array([[10, 20]], dtype=np.int8)
+        layer.load_from_array(arr)
+        layer.update()
+        assert layer.grid[0, 0] == 10
+
+    def test_clear(self) -> None:
+        mgr = CostmapManager(width=5, height=5)
+        layer = StaticCostmapLayer()
+        mgr.add_layer("s", layer)
+        layer.load_from_array(np.full((5, 5), 50, dtype=np.int8))
+        layer.clear()
+        assert (layer.grid == FREE_SPACE).all()
+
+    def test_persistence_through_updates(self) -> None:
+        """Static layer should keep its data across manager updates."""
+        mgr = CostmapManager(width=5, height=5)
+        layer = StaticCostmapLayer()
+        mgr.add_layer("s", layer)
+        arr = np.zeros((5, 5), dtype=np.int8)
+        arr[1, 1] = 88
+        layer.load_from_array(arr)
+
+        mgr.update()
+        mgr.update()
+        assert mgr.master[1, 1] == 88
+
+
+# =====================================================================
+# SocialCostmapLayer
+# =====================================================================
+
+
+class TestSocialCostmapLayer:
+    def _make_manager_with_social(
+        self, width: int = 200, height: int = 200
+    ) -> tuple[CostmapManager, SocialCostmapLayer]:
+        mgr = CostmapManager(width=width, height=height, resolution=0.05, origin=(-5.0, -5.0))
+        layer = SocialCostmapLayer(personal_radius=0.5, social_radius=2.0, front_scale=1.5)
+        mgr.add_layer("social", layer)
+        return mgr, layer
+
+    def test_no_pedestrians_stays_free(self) -> None:
+        mgr, layer = self._make_manager_with_social()
+        mgr.update(pedestrians=None)
+        assert (mgr.master == FREE_SPACE).all()
+
+    def test_empty_pedestrians_stays_free(self) -> None:
+        mgr, layer = self._make_manager_with_social()
+        mgr.update(pedestrians=np.array([]))
+        assert (mgr.master == FREE_SPACE).all()
+
+    def test_single_pedestrian_creates_cost(self) -> None:
+        mgr, layer = self._make_manager_with_social()
+        # Pedestrian at world (0, 0), heading 0
+        ped = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0]])
+        mgr.update(pedestrians=ped)
+
+        # Grid center for (0,0) with origin (-5,-5) and res 0.05 => (100,100)
+        master = mgr.master
+        assert master[100, 100] > FREE_SPACE
+
+    def test_cost_near_pedestrian_is_high(self) -> None:
+        mgr, layer = self._make_manager_with_social()
+        ped = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0]])
+        mgr.update(pedestrians=ped)
+        master = mgr.master
+        # The cell right at the pedestrian should be at inscribed cost
+        assert master[100, 100] >= INSCRIBED_COST
+
+    def test_cost_decays_with_distance(self) -> None:
+        mgr, layer = self._make_manager_with_social()
+        ped = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0]])
+        mgr.update(pedestrians=ped)
+        master = mgr.master
+        # Far from pedestrian should be less
+        assert master[100, 100] > master[100, 130]
+
+    def test_multiple_pedestrians(self) -> None:
+        mgr, layer = self._make_manager_with_social()
+        peds = np.array([
+            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+            [2.0, 2.0, 0.0, 0.0, 0.0, 2.0, 1.0],
+        ])
+        mgr.update(pedestrians=peds)
+        master = mgr.master
+        # Both pedestrian locations should have cost
+        assert master[100, 100] > FREE_SPACE  # (0,0) -> (100,100)
+        gx2, gy2 = mgr.world_to_grid(2.0, 2.0)
+        assert master[gy2, gx2] > FREE_SPACE
+
+    def test_1d_pedestrian_reshaped(self) -> None:
+        """A single pedestrian passed as 1D should still work."""
+        mgr, layer = self._make_manager_with_social()
+        ped = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0])
+        mgr.update(pedestrians=ped)
+        assert mgr.master[100, 100] > FREE_SPACE
+
+    def test_pedestrian_out_of_bounds(self) -> None:
+        """Pedestrian far outside the grid should not crash."""
+        mgr, layer = self._make_manager_with_social()
+        ped = np.array([[100.0, 100.0, 0.0, 0.0, 0.0, 1.0, 1.0]])
+        mgr.update(pedestrians=ped)  # should not raise
+        assert (mgr.master == FREE_SPACE).all()
+
+
+# =====================================================================
+# PredictiveCostmapLayer
+# =====================================================================
+
+
+class TestPredictiveCostmapLayer:
+    def _make_manager_with_predictive(
+        self,
+    ) -> tuple[CostmapManager, PredictiveCostmapLayer]:
+        mgr = CostmapManager(width=200, height=200, resolution=0.05, origin=(-5.0, -5.0))
+        layer = PredictiveCostmapLayer(decay_factor=0.85, prediction_radius=0.4)
+        mgr.add_layer("predictive", layer)
+        return mgr, layer
+
+    def test_no_trajectories_stays_free(self) -> None:
+        mgr, layer = self._make_manager_with_predictive()
+        mgr.update(predicted_trajectories=None)
+        assert (mgr.master == FREE_SPACE).all()
+
+    def test_empty_trajectories_stays_free(self) -> None:
+        mgr, layer = self._make_manager_with_predictive()
+        mgr.update(predicted_trajectories=[])
+        assert (mgr.master == FREE_SPACE).all()
+
+    def test_single_trajectory_creates_cost(self) -> None:
+        mgr, layer = self._make_manager_with_predictive()
+        traj = np.array([[0.0, 0.0], [0.5, 0.0], [1.0, 0.0]])
+        mgr.update(predicted_trajectories=[traj])
+        master = mgr.master
+        # First point at grid (100, 100) should have cost
+        assert master[100, 100] > FREE_SPACE
+
+    def test_cost_decays_along_trajectory(self) -> None:
+        mgr, layer = self._make_manager_with_predictive()
+        # Trajectory along x-axis, spaced far enough to not overlap
+        traj = np.array([[0.0, 0.0], [2.0, 0.0], [4.0, 0.0]])
+        mgr.update(predicted_trajectories=[traj])
+        master = mgr.master
+
+        gx0, gy0 = mgr.world_to_grid(0.0, 0.0)
+        gx1, gy1 = mgr.world_to_grid(2.0, 0.0)
+        gx2, gy2 = mgr.world_to_grid(4.0, 0.0)
+
+        cost_first = master[gy0, gx0]
+        cost_second = master[gy1, gx1]
+        cost_third = master[gy2, gx2]
+
+        assert cost_first > FREE_SPACE
+        assert cost_second > FREE_SPACE
+        # Due to decay, later steps should have equal or lower cost at center
+        assert cost_first >= cost_second
+        assert cost_second >= cost_third
+
+    def test_multiple_trajectories(self) -> None:
+        mgr, layer = self._make_manager_with_predictive()
+        traj1 = np.array([[0.0, 0.0], [0.5, 0.0]])
+        traj2 = np.array([[0.0, 2.0], [0.5, 2.0]])
+        mgr.update(predicted_trajectories=[traj1, traj2])
+        master = mgr.master
+
+        gx1, gy1 = mgr.world_to_grid(0.0, 0.0)
+        gx2, gy2 = mgr.world_to_grid(0.0, 2.0)
+        assert master[gy1, gx1] > FREE_SPACE
+        assert master[gy2, gx2] > FREE_SPACE
+
+    def test_bad_trajectory_shape_skipped(self) -> None:
+        """A 1D trajectory should be skipped without error."""
+        mgr, layer = self._make_manager_with_predictive()
+        bad_traj = np.array([0.0, 1.0])
+        mgr.update(predicted_trajectories=[bad_traj])
+        assert (mgr.master == FREE_SPACE).all()
+
+    def test_trajectory_out_of_bounds(self) -> None:
+        """Trajectory points outside the grid should not crash."""
+        mgr, layer = self._make_manager_with_predictive()
+        traj = np.array([[100.0, 100.0], [200.0, 200.0]])
+        mgr.update(predicted_trajectories=[traj])  # should not raise
+
+
+# =====================================================================
+# InflationCostmapLayer (requires scipy)
+# =====================================================================
+
+
+class TestInflationCostmapLayer:
+    @pytest.fixture(autouse=True)
+    def _require_scipy(self) -> None:
+        pytest.importorskip("scipy")
+
+    def _make_manager_with_inflation(
+        self,
+    ) -> tuple[CostmapManager, InflationCostmapLayer]:
+        mgr = CostmapManager(width=50, height=50, resolution=0.05, origin=(0.0, 0.0))
+        layer = InflationCostmapLayer(inflation_radius=0.3)
+        mgr.add_layer("inflation", layer)
+        return mgr, layer
+
+    def test_no_source_is_noop(self) -> None:
+        mgr, layer = self._make_manager_with_inflation()
+        mgr.update()
+        assert (mgr.master == FREE_SPACE).all()
+
+    def test_set_source_inflates(self) -> None:
+        mgr, layer = self._make_manager_with_inflation()
+        src = np.zeros((50, 50), dtype=np.int8)
+        src[25, 25] = LETHAL_COST
+        layer.set_source(src)
+        mgr.update()
+
+        master = mgr.master
+        # The lethal cell should remain lethal
+        assert master[25, 25] == LETHAL_COST
+        # Nearby cells should have been inflated (non-zero)
+        assert master[25, 26] > FREE_SPACE
+        assert master[26, 25] > FREE_SPACE
+
+    def test_inflation_does_not_exceed_inscribed(self) -> None:
+        """Non-lethal inflated cells should not exceed INSCRIBED_COST."""
+        mgr, layer = self._make_manager_with_inflation()
+        src = np.zeros((50, 50), dtype=np.int8)
+        src[25, 25] = LETHAL_COST
+        layer.set_source(src)
+        mgr.update()
+
+        master = mgr.master
+        non_lethal = master[master < LETHAL_COST]
+        assert (non_lethal <= INSCRIBED_COST).all()
+
+    def test_obstacles_kwarg(self) -> None:
+        """Passing obstacles via kwargs should also work."""
+        mgr, layer = self._make_manager_with_inflation()
+        src = np.zeros((50, 50), dtype=np.int8)
+        src[10, 10] = LETHAL_COST
+        mgr.update(obstacles=src)
+        assert mgr.master[10, 10] == LETHAL_COST
+
+
+# =====================================================================
+# _CostmapLayerBase
+# =====================================================================
+
+
+class TestCostmapLayerBase:
+    def test_resize(self) -> None:
+        layer = StaticCostmapLayer()  # concrete subclass
+        layer.resize(30, 40, 0.1, 1.0, 2.0)
+        assert layer.grid.shape == (40, 30)
+
+    def test_clear_resets_grid(self) -> None:
+        layer = StaticCostmapLayer()
+        layer.resize(5, 5, 0.05, 0.0, 0.0)
+        layer.load_from_array(np.full((5, 5), 50, dtype=np.int8))
+        layer.clear()
+        assert (layer.grid == FREE_SPACE).all()
+
+    def test_grid_property(self) -> None:
+        layer = StaticCostmapLayer()
+        assert isinstance(layer.grid, np.ndarray)
+
+
+# =====================================================================
+# Integration: multiple layers combined
+# =====================================================================
+
+
+class TestMultiLayerIntegration:
+    def test_static_plus_social(self) -> None:
+        mgr = CostmapManager(width=200, height=200, resolution=0.05, origin=(-5.0, -5.0))
+
+        static = StaticCostmapLayer()
+        mgr.add_layer("static", static)
+        arr = np.zeros((200, 200), dtype=np.int8)
+        arr[50, 50] = 80
+        static.load_from_array(arr)
+
+        social = SocialCostmapLayer()
+        mgr.add_layer("social", social)
+
+        ped = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0]])
+        merged = mgr.update(pedestrians=ped)
+
+        # Static obstacle should be present
+        assert merged[50, 50] == 80
+        # Social cost should be present near pedestrian
+        assert merged[100, 100] > FREE_SPACE
+
+    def test_all_layers_cleared_on_update(self) -> None:
+        """Social layer should clear before re-stamping on each update."""
+        mgr = CostmapManager(width=200, height=200, resolution=0.05, origin=(-5.0, -5.0))
+        social = SocialCostmapLayer()
+        mgr.add_layer("social", social)
+
+        ped = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0]])
+        mgr.update(pedestrians=ped)
+
+        # Update with no pedestrians should clear social cost
+        mgr.update(pedestrians=np.array([]))
+        second = mgr.master
+        assert (second == FREE_SPACE).all()

--- a/tests/test_ros_launch_helpers.py
+++ b/tests/test_ros_launch_helpers.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import os
+import stat
+import textwrap
+
+import pytest
+import yaml
+
+from navirl.ros.launch_helpers import (
+    create_param_file,
+    generate_launch_description,
+    setup_workspace,
+)
+
+# ---------------------------------------------------------------------------
+# generate_launch_description
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateLaunchDescription:
+    """Tests for generate_launch_description."""
+
+    def test_default_params(self):
+        """Minimal config produces valid launch source with defaults."""
+        src = generate_launch_description({"agent_type": "irl"})
+        assert "from launch import LaunchDescription" in src
+        assert "from launch_ros.actions import Node" in src
+        assert 'package="navirl"' in src
+        assert 'executable="navirl_node"' in src
+        assert 'output="screen"' in src
+        assert "'agent_type': 'irl'" in src
+        assert "'action_rate': 10.0" in src
+        assert "'observation_type': 'lidar'" in src
+
+    def test_custom_agent_config(self):
+        """Custom agent_config values appear in the generated source."""
+        cfg = {
+            "agent_type": "bc",
+            "model_path": "/models/bc.pt",
+            "action_rate": 20.0,
+            "observation_type": "rgbd",
+        }
+        src = generate_launch_description(cfg)
+        assert "'agent_type': 'bc'" in src
+        assert "'model_path': '/models/bc.pt'" in src
+        assert "'action_rate': 20.0" in src
+        assert "'observation_type': 'rgbd'" in src
+
+    def test_custom_executable_and_package(self):
+        """Custom executable and package names are reflected."""
+        src = generate_launch_description(
+            {"agent_type": "irl"},
+            executable="my_node",
+            package="my_pkg",
+        )
+        assert 'executable="my_node"' in src
+        assert 'package="my_pkg"' in src
+
+    def test_output_log(self):
+        """Non-default output mode is reflected."""
+        src = generate_launch_description(
+            {"agent_type": "irl"}, output="log"
+        )
+        assert 'output="log"' in src
+
+    def test_namespace(self):
+        """Namespace argument appears in the Node constructor."""
+        src = generate_launch_description(
+            {"agent_type": "irl"}, namespace="robot1"
+        )
+        assert 'namespace="robot1"' in src
+
+    def test_no_namespace_by_default(self):
+        """No namespace= line when namespace is empty string."""
+        src = generate_launch_description({"agent_type": "irl"})
+        assert "namespace=" not in src
+
+    def test_extra_remappings(self):
+        """Extra remappings are rendered as tuples in the Node call."""
+        remaps = {"/cmd_vel": "/robot1/cmd_vel", "/scan": "/robot1/scan"}
+        src = generate_launch_description(
+            {"agent_type": "irl"}, extra_remappings=remaps
+        )
+        assert "remappings=" in src
+        assert '("/cmd_vel", "/robot1/cmd_vel")' in src
+        assert '("/scan", "/robot1/scan")' in src
+
+    def test_no_remappings_by_default(self):
+        """No remappings line when extra_remappings is None."""
+        src = generate_launch_description({"agent_type": "irl"})
+        assert "remappings=" not in src
+
+    def test_extra_config_keys_merged(self):
+        """Keys beyond the four standard ones are merged into parameters."""
+        cfg = {"agent_type": "irl", "custom_param": 42}
+        src = generate_launch_description(cfg)
+        assert "'custom_param': 42" in src
+
+    def test_agent_type_defaults_to_irl(self):
+        """If agent_type is missing from config, it defaults to 'irl'."""
+        src = generate_launch_description({})
+        assert "'agent_type': 'irl'" in src
+
+    def test_model_path_defaults_to_empty(self):
+        """If model_path is missing, it defaults to empty string."""
+        src = generate_launch_description({"agent_type": "irl"})
+        assert "'model_path': ''" in src
+
+    def test_returns_string(self):
+        """Return type is str."""
+        result = generate_launch_description({"agent_type": "irl"})
+        assert isinstance(result, str)
+
+    def test_contains_node_constructor(self):
+        """Generated source contains a Node() call."""
+        src = generate_launch_description({"agent_type": "irl"})
+        assert "Node(" in src
+
+    def test_contains_launch_description(self):
+        """Generated source contains LaunchDescription."""
+        src = generate_launch_description({"agent_type": "irl"})
+        assert "LaunchDescription(" in src
+
+    def test_action_rate_cast_to_float(self):
+        """action_rate is cast to float even if provided as int."""
+        src = generate_launch_description({"agent_type": "irl", "action_rate": 5})
+        assert "'action_rate': 5.0" in src
+
+
+# ---------------------------------------------------------------------------
+# create_param_file
+# ---------------------------------------------------------------------------
+
+
+class TestCreateParamFile:
+    """Tests for create_param_file."""
+
+    def test_explicit_path(self, tmp_path):
+        """Writing to an explicit path returns that path and creates the file."""
+        dest = tmp_path / "params.yaml"
+        result = create_param_file({"speed": 1.0}, path=dest)
+        assert result == str(dest.resolve())
+        assert dest.exists()
+
+    def test_yaml_content(self, tmp_path):
+        """Written YAML matches ROS2 parameter format."""
+        dest = tmp_path / "params.yaml"
+        create_param_file({"speed": 1.0, "mode": "fast"}, path=dest)
+        data = yaml.safe_load(dest.read_text())
+        assert data == {
+            "navirl_node": {
+                "ros__parameters": {"speed": 1.0, "mode": "fast"},
+            }
+        }
+
+    def test_custom_node_name(self, tmp_path):
+        """Custom node_name is reflected as the top-level YAML key."""
+        dest = tmp_path / "params.yaml"
+        create_param_file({"x": 1}, path=dest, node_name="my_node")
+        data = yaml.safe_load(dest.read_text())
+        assert "my_node" in data
+        assert data["my_node"]["ros__parameters"]["x"] == 1
+
+    def test_temp_file_created_when_path_is_none(self):
+        """When path is None a temp file is created and its path returned."""
+        result = create_param_file({"a": 1})
+        try:
+            assert os.path.isabs(result)
+            assert os.path.isfile(result)
+            assert "navirl_params_" in os.path.basename(result)
+            assert result.endswith(".yaml")
+        finally:
+            os.unlink(result)
+
+    def test_temp_file_permissions(self):
+        """Temp files are created with 0o600 permissions."""
+        result = create_param_file({"a": 1})
+        try:
+            mode = os.stat(result).st_mode
+            # Check owner read/write, no group/other access
+            assert mode & 0o777 == 0o600
+        finally:
+            os.unlink(result)
+
+    def test_temp_file_yaml_content(self):
+        """Temp file contains valid YAML with correct structure."""
+        result = create_param_file({"key": "value"})
+        try:
+            with open(result) as f:
+                data = yaml.safe_load(f)
+            assert data["navirl_node"]["ros__parameters"]["key"] == "value"
+        finally:
+            os.unlink(result)
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Parent directories are created if they don't exist."""
+        dest = tmp_path / "a" / "b" / "c" / "params.yaml"
+        result = create_param_file({"x": 1}, path=dest)
+        assert os.path.isfile(result)
+
+    def test_returns_absolute_path(self, tmp_path):
+        """Returned path is always absolute."""
+        dest = tmp_path / "params.yaml"
+        result = create_param_file({"x": 1}, path=dest)
+        assert os.path.isabs(result)
+
+    def test_empty_config(self, tmp_path):
+        """An empty config dict produces valid YAML with empty parameters."""
+        dest = tmp_path / "params.yaml"
+        create_param_file({}, path=dest)
+        data = yaml.safe_load(dest.read_text())
+        assert data["navirl_node"]["ros__parameters"] == {}
+
+    def test_path_as_string(self, tmp_path):
+        """Accepts path as a plain string."""
+        dest = str(tmp_path / "params.yaml")
+        result = create_param_file({"a": 1}, path=dest)
+        assert os.path.isfile(result)
+
+
+# ---------------------------------------------------------------------------
+# setup_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestSetupWorkspace:
+    """Tests for setup_workspace."""
+
+    def test_returns_absolute_path(self, tmp_path):
+        """Returned path is the resolved absolute workspace root."""
+        ws = setup_workspace(tmp_path / "ws")
+        assert ws.is_absolute()
+        assert ws == (tmp_path / "ws").resolve()
+
+    def test_directory_structure(self, tmp_path):
+        """All expected directories are created."""
+        ws = setup_workspace(tmp_path / "ws")
+        pkg = "navirl_ros"
+        assert (ws / "src" / pkg).is_dir()
+        assert (ws / "src" / pkg / pkg).is_dir()
+        assert (ws / "src" / pkg / "resource").is_dir()
+
+    def test_package_xml_exists(self, tmp_path):
+        """package.xml is created with correct content."""
+        ws = setup_workspace(tmp_path / "ws")
+        pkg_xml = ws / "src" / "navirl_ros" / "package.xml"
+        assert pkg_xml.is_file()
+        content = pkg_xml.read_text()
+        assert "<name>navirl_ros</name>" in content
+        assert "<version>0.1.0</version>" in content
+        assert "ament_python" in content
+        assert "<depend>rclpy</depend>" in content
+
+    def test_setup_py_exists(self, tmp_path):
+        """setup.py is created with correct package name."""
+        ws = setup_workspace(tmp_path / "ws")
+        setup_py = ws / "src" / "navirl_ros" / "setup.py"
+        assert setup_py.is_file()
+        content = setup_py.read_text()
+        assert 'package_name = "navirl_ros"' in content
+        assert "setuptools" in content
+
+    def test_setup_cfg_exists(self, tmp_path):
+        """setup.cfg is created."""
+        ws = setup_workspace(tmp_path / "ws")
+        setup_cfg = ws / "src" / "navirl_ros" / "setup.cfg"
+        assert setup_cfg.is_file()
+        content = setup_cfg.read_text()
+        assert "navirl_ros" in content
+
+    def test_resource_marker(self, tmp_path):
+        """Resource marker file exists (required by ament)."""
+        ws = setup_workspace(tmp_path / "ws")
+        marker = ws / "src" / "navirl_ros" / "resource" / "navirl_ros"
+        assert marker.is_file()
+
+    def test_init_py(self, tmp_path):
+        """__init__.py is created with a docstring."""
+        ws = setup_workspace(tmp_path / "ws")
+        init = ws / "src" / "navirl_ros" / "navirl_ros" / "__init__.py"
+        assert init.is_file()
+        assert "ROS2 package wrapper" in init.read_text()
+
+    def test_custom_package_name(self, tmp_path):
+        """Custom package_name is used throughout the workspace."""
+        ws = setup_workspace(tmp_path / "ws", package_name="my_robot")
+        assert (ws / "src" / "my_robot").is_dir()
+        assert (ws / "src" / "my_robot" / "my_robot" / "__init__.py").is_file()
+        assert (ws / "src" / "my_robot" / "resource" / "my_robot").is_file()
+        pkg_xml = (ws / "src" / "my_robot" / "package.xml").read_text()
+        assert "<name>my_robot</name>" in pkg_xml
+
+    def test_idempotent(self, tmp_path):
+        """Calling setup_workspace twice does not raise."""
+        ws1 = setup_workspace(tmp_path / "ws")
+        ws2 = setup_workspace(tmp_path / "ws")
+        assert ws1 == ws2

--- a/tests/test_ros_tf_utils.py
+++ b/tests/test_ros_tf_utils.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from navirl.ros.tf_utils import (
+    TransformManager,
+    _invert_2d,
+    _yaw_to_rotation_matrix,
+    robot_to_world,
+    world_to_robot,
+)
+
+# ---- _yaw_to_rotation_matrix ------------------------------------------------
+
+
+class TestYawToRotationMatrix:
+    """Tests for the 2x2 rotation matrix helper."""
+
+    def test_identity_at_zero(self):
+        R = _yaw_to_rotation_matrix(0.0)
+        np.testing.assert_allclose(R, np.eye(2), atol=1e-15)
+
+    def test_shape(self):
+        R = _yaw_to_rotation_matrix(1.0)
+        assert R.shape == (2, 2)
+
+    def test_determinant_is_one(self):
+        for yaw in [0.0, math.pi / 4, math.pi / 2, math.pi, -math.pi / 3, 2.5]:
+            R = _yaw_to_rotation_matrix(yaw)
+            assert pytest.approx(np.linalg.det(R), abs=1e-14) == 1.0
+
+    def test_orthogonality(self):
+        for yaw in [0.3, math.pi / 6, -1.2, math.pi]:
+            R = _yaw_to_rotation_matrix(yaw)
+            np.testing.assert_allclose(R @ R.T, np.eye(2), atol=1e-14)
+            np.testing.assert_allclose(R.T @ R, np.eye(2), atol=1e-14)
+
+    def test_90_degrees(self):
+        R = _yaw_to_rotation_matrix(math.pi / 2)
+        expected = np.array([[0, -1], [1, 0]], dtype=np.float64)
+        np.testing.assert_allclose(R, expected, atol=1e-14)
+
+    def test_180_degrees(self):
+        R = _yaw_to_rotation_matrix(math.pi)
+        expected = np.array([[-1, 0], [0, -1]], dtype=np.float64)
+        np.testing.assert_allclose(R, expected, atol=1e-14)
+
+    def test_negative_90_degrees(self):
+        R = _yaw_to_rotation_matrix(-math.pi / 2)
+        expected = np.array([[0, 1], [-1, 0]], dtype=np.float64)
+        np.testing.assert_allclose(R, expected, atol=1e-14)
+
+    def test_inverse_equals_transpose(self):
+        yaw = 0.77
+        R = _yaw_to_rotation_matrix(yaw)
+        np.testing.assert_allclose(np.linalg.inv(R), R.T, atol=1e-14)
+
+    def test_composition(self):
+        """R(a) @ R(b) == R(a + b)."""
+        a, b = 0.5, 1.1
+        np.testing.assert_allclose(
+            _yaw_to_rotation_matrix(a) @ _yaw_to_rotation_matrix(b),
+            _yaw_to_rotation_matrix(a + b),
+            atol=1e-14,
+        )
+
+
+# ---- world_to_robot / robot_to_world ----------------------------------------
+
+
+class TestWorldToRobot:
+    """Tests for world_to_robot conversion."""
+
+    def test_identity_pose_dict(self):
+        pose = {"x": 0.0, "y": 0.0, "yaw": 0.0}
+        result = world_to_robot((3.0, 4.0), pose)
+        np.testing.assert_allclose(result, [3.0, 4.0], atol=1e-14)
+
+    def test_identity_pose_tuple(self):
+        pose = (0.0, 0.0, 0.0)
+        result = world_to_robot(np.array([3.0, 4.0]), pose)
+        np.testing.assert_allclose(result, [3.0, 4.0], atol=1e-14)
+
+    def test_pure_translation(self):
+        pose = {"x": 1.0, "y": 2.0, "yaw": 0.0}
+        result = world_to_robot((4.0, 5.0), pose)
+        np.testing.assert_allclose(result, [3.0, 3.0], atol=1e-14)
+
+    def test_pure_rotation_90(self):
+        pose = (0.0, 0.0, math.pi / 2)
+        result = world_to_robot((1.0, 0.0), pose)
+        # Rotating by -pi/2: (1,0) -> (0, -1)
+        np.testing.assert_allclose(result, [0.0, -1.0], atol=1e-14)
+
+    def test_translation_and_rotation(self):
+        pose = {"x": 1.0, "y": 0.0, "yaw": math.pi / 2}
+        # delta = (2-1, 3-0) = (1, 3), rotate by -pi/2 -> (3, -1)
+        result = world_to_robot((2.0, 3.0), pose)
+        np.testing.assert_allclose(result, [3.0, -1.0], atol=1e-14)
+
+    def test_yaw_180(self):
+        pose = (0.0, 0.0, math.pi)
+        result = world_to_robot((1.0, 0.0), pose)
+        np.testing.assert_allclose(result, [-1.0, 0.0], atol=1e-14)
+
+    def test_accepts_numpy_pos(self):
+        pose = (0.0, 0.0, 0.0)
+        result = world_to_robot(np.array([5.0, 6.0]), pose)
+        np.testing.assert_allclose(result, [5.0, 6.0], atol=1e-14)
+
+
+class TestRobotToWorld:
+    """Tests for robot_to_world conversion."""
+
+    def test_identity_pose_dict(self):
+        pose = {"x": 0.0, "y": 0.0, "yaw": 0.0}
+        result = robot_to_world((3.0, 4.0), pose)
+        np.testing.assert_allclose(result, [3.0, 4.0], atol=1e-14)
+
+    def test_identity_pose_tuple(self):
+        pose = (0.0, 0.0, 0.0)
+        result = robot_to_world(np.array([1.0, 2.0]), pose)
+        np.testing.assert_allclose(result, [1.0, 2.0], atol=1e-14)
+
+    def test_pure_translation(self):
+        pose = {"x": 1.0, "y": 2.0, "yaw": 0.0}
+        result = robot_to_world((3.0, 3.0), pose)
+        np.testing.assert_allclose(result, [4.0, 5.0], atol=1e-14)
+
+    def test_pure_rotation_90(self):
+        pose = (0.0, 0.0, math.pi / 2)
+        result = robot_to_world((1.0, 0.0), pose)
+        # Rotate (1,0) by pi/2 -> (0, 1)
+        np.testing.assert_allclose(result, [0.0, 1.0], atol=1e-14)
+
+    def test_yaw_negative_90(self):
+        pose = (0.0, 0.0, -math.pi / 2)
+        result = robot_to_world((1.0, 0.0), pose)
+        np.testing.assert_allclose(result, [0.0, -1.0], atol=1e-14)
+
+
+class TestRoundTrip:
+    """world_to_robot and robot_to_world should be inverses."""
+
+    @pytest.mark.parametrize(
+        "world_pt,pose",
+        [
+            ((5.0, 3.0), {"x": 1.0, "y": 2.0, "yaw": 0.5}),
+            ((0.0, 0.0), (3.0, 4.0, math.pi / 3)),
+            ((-2.0, 7.0), {"x": -1.0, "y": -1.0, "yaw": -math.pi / 4}),
+            ((10.0, -3.0), (0.0, 0.0, math.pi)),
+        ],
+    )
+    def test_world_robot_world(self, world_pt, pose):
+        robot_pt = world_to_robot(world_pt, pose)
+        recovered = robot_to_world(robot_pt, pose)
+        np.testing.assert_allclose(recovered, world_pt, atol=1e-12)
+
+    @pytest.mark.parametrize(
+        "robot_pt,pose",
+        [
+            ((1.0, 0.0), (2.0, 3.0, 0.7)),
+            ((0.0, 0.0), {"x": 0.0, "y": 0.0, "yaw": 1.0}),
+            ((-1.0, 2.0), (5.0, -5.0, -1.5)),
+        ],
+    )
+    def test_robot_world_robot(self, robot_pt, pose):
+        world_pt = robot_to_world(robot_pt, pose)
+        recovered = world_to_robot(world_pt, pose)
+        np.testing.assert_allclose(recovered, robot_pt, atol=1e-12)
+
+
+# ---- _invert_2d --------------------------------------------------------------
+
+
+class TestInvert2D:
+    """Tests for the internal rigid-transform inversion helper."""
+
+    def test_identity(self):
+        ix, iy = _invert_2d(0.0, 0.0, 0.0)
+        assert pytest.approx(ix, abs=1e-14) == 0.0
+        assert pytest.approx(iy, abs=1e-14) == 0.0
+
+    def test_pure_translation(self):
+        ix, iy = _invert_2d(3.0, 4.0, 0.0)
+        assert pytest.approx(ix, abs=1e-14) == -3.0
+        assert pytest.approx(iy, abs=1e-14) == -4.0
+
+    def test_pure_rotation(self):
+        ix, iy = _invert_2d(0.0, 0.0, math.pi / 2)
+        assert pytest.approx(ix, abs=1e-14) == 0.0
+        assert pytest.approx(iy, abs=1e-14) == 0.0
+
+    def test_double_invert_returns_to_original(self):
+        x, y, yaw = 2.0, -1.0, 0.8
+        ix, iy = _invert_2d(x, y, yaw)
+        rx, ry = _invert_2d(ix, iy, -yaw)
+        assert pytest.approx(rx, abs=1e-12) == x
+        assert pytest.approx(ry, abs=1e-12) == y
+
+
+# ---- TransformManager -------------------------------------------------------
+
+
+class TestTransformManager:
+    """Tests for TransformManager in manual-cache mode (no ROS2)."""
+
+    def test_creation(self):
+        tm = TransformManager()
+        assert tm is not None
+
+    def test_set_and_lookup(self):
+        tm = TransformManager()
+        tm.set_transform("map", "base_link", 1.0, 2.0, 0.5)
+        x, y, yaw = tm.lookup("map", "base_link")
+        assert pytest.approx(x) == 1.0
+        assert pytest.approx(y) == 2.0
+        assert pytest.approx(yaw) == 0.5
+
+    def test_lookup_missing_raises(self):
+        tm = TransformManager()
+        with pytest.raises(Exception, match="not available"):
+            tm.lookup("map", "nonexistent")
+
+    def test_inverse_lookup(self):
+        tm = TransformManager()
+        tm.set_transform("map", "base_link", 3.0, 0.0, 0.0)
+        # Inverse: base_link -> map should give (-3, 0, 0)
+        x, y, yaw = tm.lookup("base_link", "map")
+        assert pytest.approx(x, abs=1e-12) == -3.0
+        assert pytest.approx(y, abs=1e-12) == 0.0
+        assert pytest.approx(yaw, abs=1e-12) == 0.0
+
+    def test_inverse_lookup_with_rotation(self):
+        tm = TransformManager()
+        tm.set_transform("map", "odom", 1.0, 0.0, math.pi / 2)
+        x, y, yaw = tm.lookup("odom", "map")
+        # invert_2d(1, 0, pi/2): inv_x = -(cos(pi/2)*1 + sin(pi/2)*0) = 0
+        #                         inv_y = -(- sin(pi/2)*1 + cos(pi/2)*0) = 1
+        # yaw = -pi/2
+        assert pytest.approx(x, abs=1e-12) == 0.0
+        assert pytest.approx(y, abs=1e-12) == 1.0
+        assert pytest.approx(yaw, abs=1e-12) == -math.pi / 2
+
+    def test_overwrite_transform(self):
+        tm = TransformManager()
+        tm.set_transform("map", "base_link", 1.0, 2.0, 0.0)
+        tm.set_transform("map", "base_link", 5.0, 6.0, 1.0)
+        x, y, yaw = tm.lookup("map", "base_link")
+        assert pytest.approx(x) == 5.0
+        assert pytest.approx(y) == 6.0
+        assert pytest.approx(yaw) == 1.0
+
+    def test_transform_point_identity(self):
+        tm = TransformManager()
+        tm.set_transform("map", "base_link", 0.0, 0.0, 0.0)
+        result = tm.transform_point((3.0, 4.0), "base_link", "map")
+        np.testing.assert_allclose(result, [3.0, 4.0], atol=1e-12)
+
+    def test_transform_point_translation(self):
+        tm = TransformManager()
+        tm.set_transform("map", "base_link", 1.0, 2.0, 0.0)
+        result = tm.transform_point((0.0, 0.0), "base_link", "map")
+        np.testing.assert_allclose(result, [1.0, 2.0], atol=1e-12)
+
+    def test_transform_point_rotation(self):
+        tm = TransformManager()
+        tm.set_transform("map", "base_link", 0.0, 0.0, math.pi / 2)
+        result = tm.transform_point((1.0, 0.0), "base_link", "map")
+        np.testing.assert_allclose(result, [0.0, 1.0], atol=1e-12)
+
+    def test_transform_point_combined(self):
+        tm = TransformManager()
+        tm.set_transform("map", "base_link", 1.0, 2.0, math.pi / 2)
+        result = tm.transform_point((1.0, 0.0), "base_link", "map")
+        # R(pi/2) @ [1,0] + [1,2] = [0,1] + [1,2] = [1,3]
+        np.testing.assert_allclose(result, [1.0, 3.0], atol=1e-12)
+
+    def test_transform_point_accepts_numpy(self):
+        tm = TransformManager()
+        tm.set_transform("a", "b", 0.0, 0.0, 0.0)
+        result = tm.transform_point(np.array([2.0, 3.0]), "b", "a")
+        np.testing.assert_allclose(result, [2.0, 3.0], atol=1e-12)
+
+    def test_spin_once_no_crash(self):
+        tm = TransformManager()
+        tm.spin_once()
+        tm.spin_once(timeout_sec=0.1)
+
+    def test_custom_cache_duration(self):
+        tm = TransformManager(cache_duration=5.0)
+        assert tm._cache_duration == 5.0
+
+    def test_multiple_frames(self):
+        tm = TransformManager()
+        tm.set_transform("map", "odom", 1.0, 0.0, 0.0)
+        tm.set_transform("odom", "base_link", 0.0, 1.0, 0.0)
+        x1, y1, _ = tm.lookup("map", "odom")
+        x2, y2, _ = tm.lookup("odom", "base_link")
+        assert pytest.approx(x1) == 1.0
+        assert pytest.approx(x2) == 0.0
+        assert pytest.approx(y2) == 1.0
+
+    def test_stale_transform_still_returned_with_warning(self):
+        """Even stale transforms are returned (with a warning)."""
+        tm = TransformManager(cache_duration=0.0)
+        tm.set_transform("map", "base_link", 1.0, 2.0, 0.3)
+        # cache_duration=0 means it's immediately stale, but still returned
+        x, y, yaw = tm.lookup("map", "base_link")
+        assert pytest.approx(x) == 1.0
+        assert pytest.approx(y) == 2.0
+        assert pytest.approx(yaw) == 0.3

--- a/tests/test_social_astar.py
+++ b/tests/test_social_astar.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from navirl.core.types import Action, AgentState
+from navirl.robots.baselines.social_astar import SocialCostAStarRobotController
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_backend(path=None, collision=False):
+    """Return a mock backend with configurable shortest_path and collision."""
+    backend = MagicMock()
+    backend.shortest_path.return_value = path or []
+    backend.check_obstacle_collision.return_value = collision
+    return backend
+
+
+def _make_state(
+    agent_id=0,
+    x=0.0,
+    y=0.0,
+    vx=0.0,
+    vy=0.0,
+    max_speed=1.0,
+    kind="human",
+    radius=0.3,
+):
+    return AgentState(
+        agent_id=agent_id,
+        kind=kind,
+        x=x,
+        y=y,
+        vx=vx,
+        vy=vy,
+        goal_x=0.0,
+        goal_y=0.0,
+        radius=radius,
+        max_speed=max_speed,
+    )
+
+
+def _emit_event(event_type, agent_id, payload):
+    """No-op event sink."""
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorDefaults:
+    def test_default_config_values(self):
+        ctrl = SocialCostAStarRobotController()
+        assert ctrl.goal_tolerance == pytest.approx(0.2)
+        assert ctrl.replan_interval == 15
+        assert ctrl.max_speed == pytest.approx(0.8)
+        assert ctrl.slowdown_dist == pytest.approx(0.7)
+        assert ctrl.target_lookahead == 3
+        assert ctrl.velocity_smoothing == pytest.approx(0.4)
+        assert ctrl.stop_speed == pytest.approx(0.02)
+        assert ctrl.social_radius == pytest.approx(2.0)
+        assert ctrl.personal_space == pytest.approx(0.8)
+        assert ctrl.social_weight == pytest.approx(3.0)
+        assert ctrl.crossing_penalty == pytest.approx(2.0)
+
+    def test_custom_config_override(self):
+        cfg = {
+            "goal_tolerance": 0.5,
+            "replan_interval": 10,
+            "max_speed": 1.2,
+            "slowdown_dist": 1.0,
+            "target_lookahead": 5,
+            "velocity_smoothing": 0.6,
+            "stop_speed": 0.05,
+            "social_radius": 3.0,
+            "personal_space": 1.0,
+            "social_weight": 4.0,
+            "crossing_penalty": 3.0,
+        }
+        ctrl = SocialCostAStarRobotController(cfg)
+        assert ctrl.goal_tolerance == pytest.approx(0.5)
+        assert ctrl.replan_interval == 10
+        assert ctrl.max_speed == pytest.approx(1.2)
+        assert ctrl.slowdown_dist == pytest.approx(1.0)
+        assert ctrl.target_lookahead == 5
+        assert ctrl.velocity_smoothing == pytest.approx(0.6)
+        assert ctrl.stop_speed == pytest.approx(0.05)
+        assert ctrl.social_radius == pytest.approx(3.0)
+        assert ctrl.personal_space == pytest.approx(1.0)
+        assert ctrl.social_weight == pytest.approx(4.0)
+        assert ctrl.crossing_penalty == pytest.approx(3.0)
+
+    def test_initial_state_attributes(self):
+        ctrl = SocialCostAStarRobotController()
+        assert ctrl.robot_id == -1
+        assert ctrl.start == (0.0, 0.0)
+        assert ctrl.goal == (0.0, 0.0)
+        assert ctrl.backend is None
+        assert ctrl.path == []
+        assert ctrl.path_idx == 0
+        assert ctrl.last_pref == (0.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _point_to_line_distance tests
+# ---------------------------------------------------------------------------
+
+
+class TestPointToLineDistance:
+    def setup_method(self):
+        self.ctrl = SocialCostAStarRobotController()
+
+    def test_normal_segment_perpendicular(self):
+        # Point (1, 1) to segment from (0, 0) to (2, 0) -> distance = 1.0
+        dist = self.ctrl._point_to_line_distance(1.0, 1.0, 0.0, 0.0, 2.0, 0.0)
+        assert dist == pytest.approx(1.0)
+
+    def test_degenerate_segment_zero_length(self):
+        # Segment is a single point (3, 4), test point at origin
+        dist = self.ctrl._point_to_line_distance(0.0, 0.0, 3.0, 4.0, 3.0, 4.0)
+        assert dist == pytest.approx(5.0)
+
+    def test_point_on_line(self):
+        # Point lies exactly on the segment
+        dist = self.ctrl._point_to_line_distance(1.0, 0.0, 0.0, 0.0, 2.0, 0.0)
+        assert dist == pytest.approx(0.0)
+
+    def test_point_at_start_endpoint(self):
+        dist = self.ctrl._point_to_line_distance(0.0, 0.0, 0.0, 0.0, 4.0, 0.0)
+        assert dist == pytest.approx(0.0)
+
+    def test_point_at_end_endpoint(self):
+        dist = self.ctrl._point_to_line_distance(4.0, 0.0, 0.0, 0.0, 4.0, 0.0)
+        assert dist == pytest.approx(0.0)
+
+    def test_point_beyond_start(self):
+        # Point projects before the start of the segment
+        dist = self.ctrl._point_to_line_distance(-1.0, 0.0, 0.0, 0.0, 4.0, 0.0)
+        assert dist == pytest.approx(1.0)
+
+    def test_point_beyond_end(self):
+        # Point projects past the end of the segment
+        dist = self.ctrl._point_to_line_distance(5.0, 3.0, 0.0, 0.0, 4.0, 0.0)
+        # Closest is (4, 0), distance = sqrt(1 + 9) = sqrt(10)
+        assert dist == pytest.approx(math.sqrt(10.0))
+
+    def test_diagonal_segment(self):
+        # Segment from (0,0) to (1,1), point at (1,0)
+        # Projection t = 0.5, proj = (0.5, 0.5), dist = sqrt(0.25+0.25)
+        dist = self.ctrl._point_to_line_distance(1.0, 0.0, 0.0, 0.0, 1.0, 1.0)
+        assert dist == pytest.approx(math.sqrt(0.5))
+
+
+# ---------------------------------------------------------------------------
+# _compute_social_cost tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSocialCost:
+    def setup_method(self):
+        self.ctrl = SocialCostAStarRobotController()
+        self.ctrl.robot_id = 0
+
+    def test_empty_states(self):
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), {})
+        assert cost == 0.0
+
+    def test_skip_self(self):
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0)}
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
+        assert cost == 0.0
+
+    def test_distant_human_no_cost(self):
+        # Human at (10, 10) is far outside social_radius=2.0
+        states = {1: _make_state(agent_id=1, x=10.0, y=10.0)}
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
+        assert cost == 0.0
+
+    def test_human_within_social_radius_but_outside_personal_space(self):
+        # Human at (1.5, 0) is within social_radius=2.0 but outside personal_space=0.8
+        # No proximity cost, no crossing penalty (stationary)
+        states = {1: _make_state(agent_id=1, x=1.5, y=0.0)}
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
+        assert cost == 0.0
+
+    def test_human_inside_personal_space(self):
+        # Human at (0.4, 0) -> dist = 0.4, inside personal_space=0.8
+        # proximity_cost = 3.0 * (0.8 - 0.4) / 0.8 = 3.0 * 0.5 = 1.5
+        # social_cost += 1.5^2 = 2.25
+        states = {1: _make_state(agent_id=1, x=0.4, y=0.0)}
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
+        expected_prox = 3.0 * (0.8 - 0.4) / 0.8
+        assert cost == pytest.approx(expected_prox ** 2)
+
+    def test_human_at_same_position(self):
+        # Human at (0, 0) -> dist = 0, inside personal_space
+        # proximity_cost = 3.0 * (0.8 - 0) / 0.8 = 3.0
+        # social_cost += 9.0
+        states = {1: _make_state(agent_id=1, x=0.0, y=0.0)}
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
+        assert cost == pytest.approx(9.0)
+
+    def test_moving_human_crossing_penalty(self):
+        # Human at (0, 1) moving in +x direction at speed 1.0 (vx=1.0, vy=0.0)
+        # Future position: (2.0, 1.0). Path from (0,1) to (2,1).
+        # Robot pos (1.0, 0.5): perpendicular distance to that line = 0.5
+        # 0.5 < personal_space=0.8, so crossing_cost = 2.0 * (0.8 - 0.5) = 0.6
+        # Also dist from robot (1,0.5) to human (0,1) = sqrt(1 + 0.25) ~ 1.118 < 2.0 (social radius)
+        # but 1.118 > 0.8 (personal_space), so no proximity cost
+        states = {1: _make_state(agent_id=1, x=0.0, y=1.0, vx=1.0, vy=0.0)}
+        cost = self.ctrl._compute_social_cost((1.0, 0.5), states)
+        expected_crossing = 2.0 * (0.8 - 0.5)
+        assert cost == pytest.approx(expected_crossing)
+
+    def test_moving_human_no_crossing_when_far_from_path(self):
+        # Human at (0, 0) moving +x at 1.0 m/s. Future: (2, 0). Path along x-axis.
+        # Robot at (1, 5): line distance to x-axis segment > personal_space
+        states = {1: _make_state(agent_id=1, x=0.0, y=0.0, vx=1.0, vy=0.0)}
+        cost = self.ctrl._compute_social_cost((1.0, 5.0), states)
+        assert cost == 0.0
+
+    def test_multiple_humans(self):
+        # Two humans inside personal space; costs should accumulate
+        states = {
+            1: _make_state(agent_id=1, x=0.3, y=0.0),
+            2: _make_state(agent_id=2, x=0.0, y=0.3),
+        }
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
+        # Each contributes a quadratic proximity cost
+        assert cost > 0.0
+        # Each individually
+        cost1 = self.ctrl._compute_social_cost((0.0, 0.0), {1: states[1]})
+        cost2 = self.ctrl._compute_social_cost((0.0, 0.0), {2: states[2]})
+        assert cost == pytest.approx(cost1 + cost2)
+
+    def test_slow_human_no_crossing_penalty(self):
+        # Human moving at speed < 0.1 should not trigger crossing penalty
+        states = {1: _make_state(agent_id=1, x=0.0, y=0.5, vx=0.05, vy=0.0)}
+        cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
+        # Only proximity cost, dist = 0.5 < personal_space = 0.8
+        prox = 3.0 * (0.8 - 0.5) / 0.8
+        assert cost == pytest.approx(prox ** 2)
+
+
+# ---------------------------------------------------------------------------
+# reset tests
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_sets_state(self):
+        ctrl = SocialCostAStarRobotController()
+        backend = _make_backend(path=[(0.0, 0.0), (5.0, 5.0)])
+        ctrl.reset(1, (0.0, 0.0), (5.0, 5.0), backend)
+
+        assert ctrl.robot_id == 1
+        assert ctrl.start == (0.0, 0.0)
+        assert ctrl.goal == (5.0, 5.0)
+        assert ctrl.backend is backend
+        assert ctrl.last_pref == (0.0, 0.0)
+        assert ctrl._human_positions == {}
+        assert ctrl._human_velocities == {}
+
+    def test_reset_plans_initial_path(self):
+        path = [(0.0, 0.0), (2.5, 2.5), (5.0, 5.0)]
+        backend = _make_backend(path=path)
+        ctrl = SocialCostAStarRobotController()
+        ctrl.reset(1, (0.0, 0.0), (5.0, 5.0), backend)
+
+        backend.shortest_path.assert_called_once_with((0.0, 0.0), (5.0, 5.0))
+        assert ctrl.path_idx == 0
+        assert len(ctrl.path) > 0
+
+    def test_reset_with_empty_path(self):
+        backend = _make_backend(path=[])
+        ctrl = SocialCostAStarRobotController()
+        ctrl.reset(1, (0.0, 0.0), (5.0, 5.0), backend)
+        # _plan falls back to [goal] when path is empty
+        assert ctrl.path == [(5.0, 5.0)]
+
+
+# ---------------------------------------------------------------------------
+# step tests
+# ---------------------------------------------------------------------------
+
+
+class TestStep:
+    def _setup_ctrl(self, cfg=None, path=None):
+        """Create a controller and reset it with a mock backend."""
+        ctrl = SocialCostAStarRobotController(cfg)
+        p = path or [(0.0, 0.0), (2.5, 0.0), (5.0, 0.0)]
+        backend = _make_backend(path=p)
+        ctrl.reset(0, (0.0, 0.0), (5.0, 0.0), backend)
+        return ctrl, backend
+
+    def test_goal_reached_returns_done(self):
+        ctrl, _ = self._setup_ctrl()
+        # Place robot at goal
+        states = {0: _make_state(agent_id=0, x=5.0, y=0.0, kind="robot")}
+        action = ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert action.behavior == "DONE"
+        assert action.pref_vx == pytest.approx(0.0)
+        assert action.pref_vy == pytest.approx(0.0)
+
+    def test_goal_within_tolerance_returns_done(self):
+        ctrl, _ = self._setup_ctrl()
+        # Place robot within goal_tolerance=0.2
+        states = {0: _make_state(agent_id=0, x=4.9, y=0.0, kind="robot")}
+        action = ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert action.behavior == "DONE"
+
+    def test_stationary_target_returns_wait(self):
+        # When dist_target < 1e-8, returns WAIT
+        ctrl, _ = self._setup_ctrl(
+            path=[(0.0, 0.0)],
+            cfg={"target_lookahead": 1, "goal_tolerance": 0.01},
+        )
+        # Robot at the only path point but not at goal (goal is at 5,0)
+        # _current_target returns (0,0), robot at (0,0), dist < 1e-8 -> WAIT
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+        action = ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert action.behavior == "WAIT"
+
+    def test_normal_navigation_returns_social_nav(self):
+        ctrl, _ = self._setup_ctrl()
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+        action = ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert action.behavior == "SOCIAL_NAV"
+        # Should have positive x velocity toward goal at (5, 0)
+        assert action.pref_vx > 0.0
+
+    def test_velocity_smoothing(self):
+        ctrl, _ = self._setup_ctrl(cfg={"velocity_smoothing": 0.5})
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+
+        # First step: last_pref = (0, 0), so smoothed = 0.5 * raw
+        action1 = ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        vx1 = action1.pref_vx
+
+        # Second step from same position: smoothed with previous velocity
+        action2 = ctrl.step(2, 0.2, 0.1, states, _emit_event)
+        vx2 = action2.pref_vx
+
+        # Second velocity should be larger because it builds on previous
+        assert vx2 > vx1
+
+    def test_social_cost_reduces_speed(self):
+        ctrl, _ = self._setup_ctrl()
+        # Step without humans nearby
+        states_no_human = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+        action_free = ctrl.step(1, 0.1, 0.1, states_no_human, _emit_event)
+
+        # Reset smoothing state
+        ctrl.last_pref = (0.0, 0.0)
+
+        # Step with a human very close (inside personal space)
+        states_crowded = {
+            0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot"),
+            1: _make_state(agent_id=1, x=0.3, y=0.0),
+        }
+        action_social = ctrl.step(2, 0.2, 0.1, states_crowded, _emit_event)
+
+        # Speed with social cost should be less
+        speed_free = math.hypot(action_free.pref_vx, action_free.pref_vy)
+        speed_social = math.hypot(action_social.pref_vx, action_social.pref_vy)
+        assert speed_social < speed_free
+
+    def test_replanning_at_interval(self):
+        ctrl, backend = self._setup_ctrl(cfg={"replan_interval": 5})
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+        emit = MagicMock()
+
+        # step=0 triggers replan (0 % 5 == 0)
+        ctrl.step(0, 0.0, 0.1, states, emit)
+        # shortest_path called once during reset + once during replan
+        assert backend.shortest_path.call_count == 2
+        emit.assert_called_once()
+        assert emit.call_args[0][0] == "robot_social_replan"
+
+    def test_no_replan_off_interval(self):
+        ctrl, backend = self._setup_ctrl(cfg={"replan_interval": 5})
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+        emit = MagicMock()
+
+        # step=1 does NOT trigger replan (1 % 5 != 0)
+        ctrl.step(1, 0.1, 0.1, states, emit)
+        # shortest_path only called during reset
+        assert backend.shortest_path.call_count == 1
+        emit.assert_not_called()
+
+    def test_waypoint_advance(self):
+        path = [(0.0, 0.0), (0.1, 0.0), (5.0, 0.0)]
+        ctrl, _ = self._setup_ctrl(
+            path=path,
+            cfg={"goal_tolerance": 0.2, "target_lookahead": 1},
+        )
+        # Robot very close to second waypoint -> should advance path_idx
+        states = {0: _make_state(agent_id=0, x=0.1, y=0.0, kind="robot")}
+        ctrl.path_idx = 1  # Currently targeting second point
+        ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert ctrl.path_idx >= 2
+
+    def test_human_positions_and_velocities_tracked(self):
+        ctrl, _ = self._setup_ctrl()
+        states = {
+            0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot"),
+            1: _make_state(agent_id=1, x=3.0, y=4.0, vx=0.5, vy=-0.5),
+        }
+        ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert 1 in ctrl._human_positions
+        assert ctrl._human_positions[1] == (3.0, 4.0)
+        assert ctrl._human_velocities[1] == (0.5, -0.5)
+        assert 0 not in ctrl._human_positions
+
+    def test_direction_toward_goal(self):
+        ctrl, _ = self._setup_ctrl()
+        # Goal at (5, 0), robot at (0, 0) -> velocity should be in +x direction
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+        action = ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert action.pref_vx > 0.0
+        # vy should be zero or near-zero
+        assert abs(action.pref_vy) < 0.01
+
+    def test_step_returns_action_type(self):
+        ctrl, _ = self._setup_ctrl()
+        states = {0: _make_state(agent_id=0, x=0.0, y=0.0, kind="robot")}
+        action = ctrl.step(1, 0.1, 0.1, states, _emit_event)
+        assert isinstance(action, Action)
+
+
+# ---------------------------------------------------------------------------
+# _social_astar tests
+# ---------------------------------------------------------------------------
+
+
+class TestSocialAstar:
+    def setup_method(self):
+        self.ctrl = SocialCostAStarRobotController()
+        self.ctrl.robot_id = 0
+        self.ctrl.backend = _make_backend()
+
+    def test_empty_path_returns_goal(self):
+        self.ctrl.backend.shortest_path.return_value = []
+        result = self.ctrl._social_astar((0, 0), (5, 5), {})
+        assert result == [(5, 5)]
+
+    def test_short_path_returned_unchanged(self):
+        path = [(0, 0), (5, 5)]
+        self.ctrl.backend.shortest_path.return_value = path
+        result = self.ctrl._social_astar((0, 0), (5, 5), {})
+        assert result == path
+
+    def test_longer_path_keeps_endpoints(self):
+        path = [(0, 0), (2, 2), (4, 4), (5, 5)]
+        self.ctrl.backend.shortest_path.return_value = path
+        self.ctrl.backend.check_obstacle_collision.return_value = False
+        result = self.ctrl._social_astar((0, 0), (5, 5), {})
+        assert result[0] == path[0]
+        assert result[-1] == path[-1]
+        assert len(result) == len(path)
+
+    def test_collision_alternatives_skipped(self):
+        path = [(0, 0), (2, 2), (5, 5)]
+        self.ctrl.backend.shortest_path.return_value = path
+        # All alternatives collide, so original waypoint is kept
+        self.ctrl.backend.check_obstacle_collision.return_value = True
+        result = self.ctrl._social_astar((0, 0), (5, 5), {})
+        assert result[1] == path[1]


### PR DESCRIPTION
## Summary
- Adds 242 tests covering 5 previously untested modules (~2,200 lines of source code)
- **navirl/ros/conversions.py** (55 tests): LaserScan, Odometry, person tracking, action-to-twist, image conversion
- **navirl/ros/costmap.py** (66 tests): CostmapManager, static/inflation/social/predictive layers
- **navirl/ros/tf_utils.py** (47 tests): rotation matrices, world↔robot transforms, TransformManager cache
- **navirl/ros/launch_helpers.py** (34 tests): launch file generation, param YAML, workspace scaffolding
- **navirl/robots/baselines/social_astar.py** (40 tests): social cost computation, path planning, velocity smoothing

## Test plan
- [x] All 242 new tests pass
- [x] Ruff lint clean
- [x] No changes to source code — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)