### PR TITLE
fix: improve error handling in routine compiler and schema

### DIFF
--- a/navirl/routines/behavior_integration.py
+++ b/navirl/routines/behavior_integration.py
@@ -7,10 +7,13 @@ used in scenarios.
 
 from __future__ import annotations
 
+import logging
 import math
 import os
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from navirl.core.types import Action, AgentState
 from navirl.humans.base import EventSink, HumanController
@@ -71,7 +74,7 @@ class CompiledRoutineController(HumanController):
                 plan = self.compiler.compile(routine_spec)
                 self.compiled_plans[agent_id] = plan
             except Exception as e:
-                print(f"Warning: Failed to compile routine for agent {agent_id}: {e}")
+                logger.warning("Failed to compile routine for agent %d: %s", agent_id, e)
                 # Agent will fall back to default behavior
 
     def add_routine(self, agent_id: int, routine_spec: RoutineSpec) -> None:
@@ -416,7 +419,9 @@ class RoutineControllerFactory:
                 routine_spec = RoutineSpec.from_yaml(content)
                 routines[agent_id] = routine_spec
             except Exception as e:
-                print(f"Warning: Failed to load routine for agent {agent_id} from {file_path}: {e}")
+                logger.warning(
+                    "Failed to load routine for agent %d from %s: %s", agent_id, file_path, e
+                )
 
         return CompiledRoutineController(routines)
 
@@ -456,7 +461,7 @@ class RoutineControllerFactory:
                 routine_spec = RoutineSpec.from_dict(routine_config)
                 routines[agent_id] = routine_spec
             except Exception as e:
-                print(f"Warning: Failed to parse routine for agent {agent_id_str}: {e}")
+                logger.warning("Failed to parse routine for agent %s: %s", agent_id_str, e)
 
         fallback_behavior = config.get("fallback_behavior", "goal_swap")
 

--- a/navirl/routines/compiler.py
+++ b/navirl/routines/compiler.py
@@ -299,10 +299,16 @@ class RoutineCompiler:
             A condition node that evaluates the condition.
         """
         if condition.type == ConditionType.TIME_ELAPSED:
+            if "seconds" not in condition.params:
+                raise ValueError("TIME_ELAPSED condition requires 'seconds' parameter")
             seconds = condition.params["seconds"]
             return TimeElapsedCondition(seconds)
 
         elif condition.type == ConditionType.LOCATION_REACHED:
+            if "x" not in condition.params or "y" not in condition.params:
+                raise ValueError(
+                    "LOCATION_REACHED condition requires 'x' and 'y' parameters"
+                )
             x = condition.params["x"]
             y = condition.params["y"]
             radius = condition.params.get("radius", 0.5)
@@ -314,7 +320,13 @@ class RoutineCompiler:
             return AgentNearbyCondition(agent_id, distance)
 
         elif condition.type == ConditionType.CUSTOM:
+            if "handler" not in condition.params:
+                raise ValueError("CUSTOM condition requires 'handler' parameter")
             handler_name = condition.params["handler"]
+            if handler_name not in self._custom_condition_handlers:
+                raise ValueError(
+                    f"No registered handler for custom condition '{handler_name}'"
+                )
             handler = self._custom_condition_handlers[handler_name]
             predicate = handler(condition)
             return Condition(predicate)

--- a/navirl/routines/compiler.py
+++ b/navirl/routines/compiler.py
@@ -306,9 +306,7 @@ class RoutineCompiler:
 
         elif condition.type == ConditionType.LOCATION_REACHED:
             if "x" not in condition.params or "y" not in condition.params:
-                raise ValueError(
-                    "LOCATION_REACHED condition requires 'x' and 'y' parameters"
-                )
+                raise ValueError("LOCATION_REACHED condition requires 'x' and 'y' parameters")
             x = condition.params["x"]
             y = condition.params["y"]
             radius = condition.params.get("radius", 0.5)
@@ -324,9 +322,7 @@ class RoutineCompiler:
                 raise ValueError("CUSTOM condition requires 'handler' parameter")
             handler_name = condition.params["handler"]
             if handler_name not in self._custom_condition_handlers:
-                raise ValueError(
-                    f"No registered handler for custom condition '{handler_name}'"
-                )
+                raise ValueError(f"No registered handler for custom condition '{handler_name}'")
             handler = self._custom_condition_handlers[handler_name]
             predicate = handler(condition)
             return Condition(predicate)

--- a/navirl/routines/schema.py
+++ b/navirl/routines/schema.py
@@ -136,7 +136,13 @@ class RoutineSpec:
         # Convert tasks
         tasks = []
         for task_data in data.get("tasks", []):
-            task_type = TaskType[task_data["type"].upper()]
+            try:
+                task_type = TaskType[task_data["type"].upper()]
+            except KeyError:
+                valid = ", ".join(t.name.lower() for t in TaskType)
+                raise ValueError(
+                    f"Unknown task type '{task_data.get('type')}'. Valid types: {valid}"
+                ) from None
             params = task_data.get("params", {})
             duration = task_data.get("duration")
             priority = task_data.get("priority", 1)
@@ -145,7 +151,13 @@ class RoutineSpec:
             completion_condition = None
             if "completion_condition" in task_data:
                 cc_data = task_data["completion_condition"]
-                condition_type = ConditionType[cc_data["type"].upper()]
+                try:
+                    condition_type = ConditionType[cc_data["type"].upper()]
+                except KeyError:
+                    valid = ", ".join(c.name.lower() for c in ConditionType)
+                    raise ValueError(
+                        f"Unknown condition type '{cc_data.get('type')}'. Valid types: {valid}"
+                    ) from None
                 completion_condition = Condition(condition_type, cc_data.get("params", {}))
 
             tasks.append(
@@ -162,12 +174,24 @@ class RoutineSpec:
         branches = []
         for branch_data in data.get("branches", []):
             condition_data = branch_data["condition"]
-            condition_type = ConditionType[condition_data["type"].upper()]
+            try:
+                condition_type = ConditionType[condition_data["type"].upper()]
+            except KeyError:
+                valid = ", ".join(c.name.lower() for c in ConditionType)
+                raise ValueError(
+                    f"Unknown condition type '{condition_data.get('type')}'. Valid types: {valid}"
+                ) from None
             condition = Condition(condition_type, condition_data.get("params", {}))
 
             branch_tasks = []
             for task_data in branch_data.get("tasks", []):
-                task_type = TaskType[task_data["type"].upper()]
+                try:
+                    task_type = TaskType[task_data["type"].upper()]
+                except KeyError:
+                    valid = ", ".join(t.name.lower() for t in TaskType)
+                    raise ValueError(
+                        f"Unknown task type '{task_data.get('type')}'. Valid types: {valid}"
+                    ) from None
                 branch_tasks.append(
                     Task(
                         type=task_type,

--- a/tests/test_routine_compiler.py
+++ b/tests/test_routine_compiler.py
@@ -348,6 +348,138 @@ class TestRoutineCompiler:
         with pytest.raises(ValueError, match="must have 'x' and 'y' parameters"):
             self.compiler.compile(invalid_goto)
 
+    def test_condition_validation_time_elapsed_missing_seconds(self):
+        """TIME_ELAPSED condition without 'seconds' param raises ValueError."""
+        from navirl.routines.schema import Condition as RoutineCondition
+
+        routine = RoutineSpec(
+            id="bad_cond",
+            description="Bad condition",
+            tasks=[Task.go_to(1.0, 2.0)],
+            branches=[
+                Branch(
+                    condition=RoutineCondition(ConditionType.TIME_ELAPSED, {}),
+                    tasks=[Task.go_to(3.0, 4.0)],
+                )
+            ],
+        )
+        with pytest.raises(ValueError, match="TIME_ELAPSED condition requires 'seconds'"):
+            self.compiler.compile(routine)
+
+    def test_condition_validation_location_reached_missing_coords(self):
+        """LOCATION_REACHED condition without x/y raises ValueError."""
+        from navirl.routines.schema import Condition as RoutineCondition
+
+        routine = RoutineSpec(
+            id="bad_loc",
+            description="Bad location condition",
+            tasks=[Task.go_to(1.0, 2.0)],
+            branches=[
+                Branch(
+                    condition=RoutineCondition(ConditionType.LOCATION_REACHED, {}),
+                    tasks=[Task.go_to(3.0, 4.0)],
+                )
+            ],
+        )
+        with pytest.raises(ValueError, match="LOCATION_REACHED condition requires 'x' and 'y'"):
+            self.compiler.compile(routine)
+
+    def test_condition_validation_custom_missing_handler(self):
+        """CUSTOM condition without 'handler' param raises ValueError."""
+        from navirl.routines.schema import Condition as RoutineCondition
+
+        routine = RoutineSpec(
+            id="bad_custom",
+            description="Bad custom condition",
+            tasks=[Task.go_to(1.0, 2.0)],
+            branches=[
+                Branch(
+                    condition=RoutineCondition(ConditionType.CUSTOM, {}),
+                    tasks=[Task.go_to(3.0, 4.0)],
+                )
+            ],
+        )
+        with pytest.raises(ValueError, match="CUSTOM condition requires 'handler'"):
+            self.compiler.compile(routine)
+
+    def test_condition_validation_custom_unregistered_handler(self):
+        """CUSTOM condition with unregistered handler raises ValueError."""
+        from navirl.routines.schema import Condition as RoutineCondition
+
+        routine = RoutineSpec(
+            id="unreg_handler",
+            description="Unregistered handler",
+            tasks=[Task.go_to(1.0, 2.0)],
+            branches=[
+                Branch(
+                    condition=RoutineCondition(
+                        ConditionType.CUSTOM, {"handler": "nonexistent"}
+                    ),
+                    tasks=[Task.go_to(3.0, 4.0)],
+                )
+            ],
+        )
+        with pytest.raises(ValueError, match=r"No registered handler.*nonexistent"):
+            self.compiler.compile(routine)
+
+    def test_schema_from_dict_invalid_task_type(self):
+        """from_dict with unknown task type raises ValueError."""
+        data = {
+            "id": "bad",
+            "description": "Bad type",
+            "tasks": [{"type": "fly_to", "params": {}}],
+        }
+        with pytest.raises(ValueError, match="Unknown task type 'fly_to'"):
+            RoutineSpec.from_dict(data)
+
+    def test_schema_from_dict_invalid_condition_type(self):
+        """from_dict with unknown condition type raises ValueError."""
+        data = {
+            "id": "bad",
+            "description": "Bad condition",
+            "tasks": [
+                {
+                    "type": "go_to",
+                    "params": {"x": 1, "y": 2},
+                    "completion_condition": {"type": "magic_detected", "params": {}},
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="Unknown condition type 'magic_detected'"):
+            RoutineSpec.from_dict(data)
+
+    def test_schema_from_dict_invalid_branch_condition_type(self):
+        """from_dict with unknown branch condition type raises ValueError."""
+        data = {
+            "id": "bad",
+            "description": "Bad branch",
+            "tasks": [{"type": "go_to", "params": {"x": 1, "y": 2}}],
+            "branches": [
+                {
+                    "condition": {"type": "telepathy", "params": {}},
+                    "tasks": [{"type": "wait", "params": {"duration": 1}}],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="Unknown condition type 'telepathy'"):
+            RoutineSpec.from_dict(data)
+
+    def test_schema_from_dict_invalid_branch_task_type(self):
+        """from_dict with unknown branch task type raises ValueError."""
+        data = {
+            "id": "bad",
+            "description": "Bad branch task",
+            "tasks": [{"type": "go_to", "params": {"x": 1, "y": 2}}],
+            "branches": [
+                {
+                    "condition": {"type": "time_elapsed", "params": {"seconds": 5}},
+                    "tasks": [{"type": "teleport", "params": {}}],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="Unknown task type 'teleport'"):
+            RoutineSpec.from_dict(data)
+
 
 class TestBehaviorNodes:
     """Tests for individual behavior tree nodes created by the compiler."""

--- a/tests/test_routine_compiler.py
+++ b/tests/test_routine_compiler.py
@@ -412,9 +412,7 @@ class TestRoutineCompiler:
             tasks=[Task.go_to(1.0, 2.0)],
             branches=[
                 Branch(
-                    condition=RoutineCondition(
-                        ConditionType.CUSTOM, {"handler": "nonexistent"}
-                    ),
+                    condition=RoutineCondition(ConditionType.CUSTOM, {"handler": "nonexistent"}),
                     tasks=[Task.go_to(3.0, 4.0)],
                 )
             ],


### PR DESCRIPTION
## Summary
- Replace cryptic `KeyError` exceptions with descriptive `ValueError` messages when parsing invalid task/condition types in `RoutineSpec.from_dict()`
- Add parameter validation for `TIME_ELAPSED`, `LOCATION_REACHED`, and `CUSTOM` conditions in the compiler before accessing params dict
- Replace `print()` warning calls with proper `logging.warning()` in `behavior_integration.py`
- Add 8 new tests covering all new error paths

## Test plan
- [x] All 4060 tests pass (8 new)
- [x] Ruff lint clean
- [x] `python -c "from navirl.routines.compiler import RoutineCompiler; print('OK')"` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)