### PR TITLE
fix: resolve 368 parallel test errors from shared matplotlib config dir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,23 @@ import tempfile
 from pathlib import Path
 
 os.environ.setdefault("MPLBACKEND", "Agg")
-_MPLCONFIGDIR = Path(tempfile.mkdtemp(prefix="navirl-mplconfig-"))
-atexit.register(shutil.rmtree, _MPLCONFIGDIR, ignore_errors=True)
-os.environ["MPLCONFIGDIR"] = str(_MPLCONFIGDIR)
-os.environ["NAVIRL_MPLCONFIGDIR"] = str(_MPLCONFIGDIR)
+
+
+def _make_mplconfigdir() -> Path:
+    """Create a per-process matplotlib config directory.
+
+    Each process (controller and every xdist worker) gets its own directory so
+    that atexit cleanup in one process does not remove the directory while
+    another process still needs it.
+    """
+    d = Path(tempfile.mkdtemp(prefix="navirl-mplconfig-"))
+    atexit.register(shutil.rmtree, d, ignore_errors=True)
+    os.environ["MPLCONFIGDIR"] = str(d)
+    os.environ["NAVIRL_MPLCONFIGDIR"] = str(d)
+    return d
+
+
+_MPLCONFIGDIR = _make_mplconfigdir()
 
 import matplotlib
 import pytest
@@ -19,9 +32,31 @@ import pytest
 matplotlib.use("Agg", force=True)
 
 
+def _is_xdist_worker(config) -> bool:
+    """Return True if running inside a pytest-xdist worker process."""
+    return hasattr(config, "workerinput")
+
+
+def pytest_configure(config) -> None:
+    """Give each xdist worker its own matplotlib config directory.
+
+    Module-level ``_make_mplconfigdir()`` only runs once in the controller.
+    Forked workers inherit the same path and atexit handler, so the first
+    worker to exit would delete the directory for all others.  Re-creating
+    the directory here ensures each worker has an independent copy.
+    """
+    if _is_xdist_worker(config):
+        _make_mplconfigdir()
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session) -> None:
-    _ = session
+    # Only prune artifact directories from the controller process (or when
+    # running without xdist). Workers inherit the cleaned state and should not
+    # race on directory removal.
+    if _is_xdist_worker(session.config):
+        return
+
     from navirl.artifacts import prune_old_run_dirs, resolve_retention_hours
 
     ttl_hours = resolve_retention_hours(

--- a/tests/test_ros_conversions.py
+++ b/tests/test_ros_conversions.py
@@ -140,9 +140,7 @@ class TestLaserScanToLidarObs:
         assert result[0] == pytest.approx(7.5)
 
     def test_all_invalid(self):
-        msg = _make_laser_scan(
-            [float("inf"), float("nan"), float("-inf")], range_max=5.0
-        )
+        msg = _make_laser_scan([float("inf"), float("nan"), float("-inf")], range_max=5.0)
         result = laser_scan_to_lidar_obs(msg)
         np.testing.assert_array_almost_equal(result, [5.0, 5.0, 5.0])
 
@@ -302,13 +300,13 @@ class TestActionToTwist:
     @pytest.mark.parametrize(
         "idx, expected_linear, expected_angular",
         [
-            (0, 0.0, 0.0),    # stop
-            (1, 0.5, 0.0),    # forward
-            (2, -0.3, 0.0),   # backward
-            (3, 0.2, 0.5),    # turn left
-            (4, 0.2, -0.5),   # turn right
-            (5, 0.5, 0.3),    # forward-left
-            (6, 0.5, -0.3),   # forward-right
+            (0, 0.0, 0.0),  # stop
+            (1, 0.5, 0.0),  # forward
+            (2, -0.3, 0.0),  # backward
+            (3, 0.2, 0.5),  # turn left
+            (4, 0.2, -0.5),  # turn right
+            (5, 0.5, 0.3),  # forward-left
+            (6, 0.5, -0.3),  # forward-right
         ],
     )
     def test_discrete_actions(self, idx, expected_linear, expected_angular):
@@ -355,9 +353,7 @@ class TestActionToTwist:
 class TestPoseToGoal:
     def test_pose_stamped_style(self):
         # PoseStamped: msg.pose.position.x
-        msg = SimpleNamespace(
-            pose=SimpleNamespace(position=SimpleNamespace(x=3.0, y=4.0))
-        )
+        msg = SimpleNamespace(pose=SimpleNamespace(position=SimpleNamespace(x=3.0, y=4.0)))
         result = pose_to_goal(msg)
         assert result == (pytest.approx(3.0), pytest.approx(4.0))
 
@@ -485,10 +481,18 @@ class TestImageToNumpy:
         # 4 BGR pixels
         data = bytes(
             [
-                10, 20, 30,  # (0,0)
-                40, 50, 60,  # (0,1)
-                70, 80, 90,  # (1,0)
-                100, 110, 120,  # (1,1)
+                10,
+                20,
+                30,  # (0,0)
+                40,
+                50,
+                60,  # (0,1)
+                70,
+                80,
+                90,  # (1,0)
+                100,
+                110,
+                120,  # (1,1)
             ]
         )
         msg = _make_image(height, width, data, encoding="bgr8")

--- a/tests/test_ros_costmap.py
+++ b/tests/test_ros_costmap.py
@@ -412,10 +412,12 @@ class TestSocialCostmapLayer:
 
     def test_multiple_pedestrians(self) -> None:
         mgr, layer = self._make_manager_with_social()
-        peds = np.array([
-            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
-            [2.0, 2.0, 0.0, 0.0, 0.0, 2.0, 1.0],
-        ])
+        peds = np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+                [2.0, 2.0, 0.0, 0.0, 0.0, 2.0, 1.0],
+            ]
+        )
         mgr.update(pedestrians=peds)
         master = mgr.master
         # Both pedestrian locations should have cost

--- a/tests/test_ros_launch_helpers.py
+++ b/tests/test_ros_launch_helpers.py
@@ -59,16 +59,12 @@ class TestGenerateLaunchDescription:
 
     def test_output_log(self):
         """Non-default output mode is reflected."""
-        src = generate_launch_description(
-            {"agent_type": "irl"}, output="log"
-        )
+        src = generate_launch_description({"agent_type": "irl"}, output="log")
         assert 'output="log"' in src
 
     def test_namespace(self):
         """Namespace argument appears in the Node constructor."""
-        src = generate_launch_description(
-            {"agent_type": "irl"}, namespace="robot1"
-        )
+        src = generate_launch_description({"agent_type": "irl"}, namespace="robot1")
         assert 'namespace="robot1"' in src
 
     def test_no_namespace_by_default(self):
@@ -79,9 +75,7 @@ class TestGenerateLaunchDescription:
     def test_extra_remappings(self):
         """Extra remappings are rendered as tuples in the Node call."""
         remaps = {"/cmd_vel": "/robot1/cmd_vel", "/scan": "/robot1/scan"}
-        src = generate_launch_description(
-            {"agent_type": "irl"}, extra_remappings=remaps
-        )
+        src = generate_launch_description({"agent_type": "irl"}, extra_remappings=remaps)
         assert "remappings=" in src
         assert '("/cmd_vel", "/robot1/cmd_vel")' in src
         assert '("/scan", "/robot1/scan")' in src

--- a/tests/test_social_astar.py
+++ b/tests/test_social_astar.py
@@ -12,6 +12,7 @@ from navirl.robots.baselines.social_astar import SocialCostAStarRobotController
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_backend(path=None, collision=False):
     """Return a mock backend with configurable shortest_path and collision."""
     backend = MagicMock()
@@ -195,7 +196,7 @@ class TestComputeSocialCost:
         states = {1: _make_state(agent_id=1, x=0.4, y=0.0)}
         cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
         expected_prox = 3.0 * (0.8 - 0.4) / 0.8
-        assert cost == pytest.approx(expected_prox ** 2)
+        assert cost == pytest.approx(expected_prox**2)
 
     def test_human_at_same_position(self):
         # Human at (0, 0) -> dist = 0, inside personal_space
@@ -244,7 +245,7 @@ class TestComputeSocialCost:
         cost = self.ctrl._compute_social_cost((0.0, 0.0), states)
         # Only proximity cost, dist = 0.5 < personal_space = 0.8
         prox = 3.0 * (0.8 - 0.5) / 0.8
-        assert cost == pytest.approx(prox ** 2)
+        assert cost == pytest.approx(prox**2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- pytest-xdist workers inherited the controller's `MPLCONFIGDIR` path and `atexit` cleanup handler via `fork()`. When any worker exited, it deleted the shared temp directory while other workers still needed it, causing `FileNotFoundError` across 5 test files (368 errors).
- Extract `_make_mplconfigdir()` so each xdist worker creates its own independent config dir via a `pytest_configure` hook.
- Guard `pytest_sessionstart` artifact pruning to controller-only to prevent concurrent directory removal.

## Test plan
- [x] Full suite with `-n auto`: 4294 passed, 0 errors (was 368 errors + 1 failure)
- [x] Full suite with `-n 0` (serial): 4294 passed, 0 errors
- [x] Individual test files that previously errored all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)