### PR TITLE
test: add 110 tests raising coverage for 4 under-tested modules

### DIFF
--- a/tests/test_callbacks_coverage.py
+++ b/tests/test_callbacks_coverage.py
@@ -1,0 +1,431 @@
+"""Tests for uncovered paths in navirl.training.callbacks.
+
+Focuses on WandbCallback, TensorBoardCallback, ProgressBarCallback,
+VideoRecordCallback, and edge cases in existing callbacks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from navirl.training.callbacks import (
+    Callback,
+    CallbackList,
+    CheckpointCallback,
+    CurriculumCallback,
+    EarlyStoppingCallback,
+    EvalCallback,
+    GradientMonitorCallback,
+    HyperparameterSearchCallback,
+    LoggingCallback,
+    ProgressBarCallback,
+    SchedulerCallback,
+    TensorBoardCallback,
+    VideoRecordCallback,
+    WandbCallback,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpace:
+    def __init__(self, shape=(2,)):
+        self.shape = shape
+
+    def sample(self):
+        import numpy as np
+
+        return np.zeros(self.shape)
+
+
+class _FakeEnv:
+    """Env that terminates after n_steps steps."""
+
+    def __init__(self, n_steps=3):
+        self.action_space = _FakeSpace()
+        self._n_steps = n_steps
+        self._step = 0
+
+    def reset(self):
+        self._step = 0
+        return [0.0, 0.0, 0.0, 0.0]
+
+    def step(self, action):
+        self._step += 1
+        obs = [float(self._step)] * 4
+        done = self._step >= self._n_steps
+        return obs, 1.0, done, {}
+
+    def render(self):
+        import numpy as np
+
+        return np.zeros((64, 64, 3), dtype=np.uint8)
+
+
+class _FakeEnvGymV26(_FakeEnv):
+    """Gym v26 style env returning 5-tuple."""
+
+    def step(self, action):
+        self._step += 1
+        obs = [float(self._step)] * 4
+        terminated = self._step >= self._n_steps
+        truncated = False
+        return obs, 1.0, terminated, truncated, {}
+
+
+# ---------------------------------------------------------------------------
+# WandbCallback
+# ---------------------------------------------------------------------------
+
+
+class TestWandbCallback:
+    """Cover WandbCallback (lines 567-610)."""
+
+    def test_training_lifecycle(self):
+        """WandbCallback should init and finish a run."""
+        mock_wandb = MagicMock()
+        mock_run = MagicMock()
+        mock_wandb.init.return_value = mock_run
+
+        cb = WandbCallback(project="test", entity="user", config={"lr": 0.01})
+        with patch.dict("sys.modules", {"wandb": mock_wandb}):
+            cb.on_training_start({})
+            assert cb._wandb is mock_wandb
+            assert cb._run is mock_run
+
+        cb.on_training_end({})
+        mock_run.finish.assert_called_once()
+
+    def test_on_step_logs_metrics(self):
+        """on_step should log metrics at the right frequency."""
+        mock_wandb = MagicMock()
+        cb = WandbCallback(log_freq=2)
+        cb._wandb = mock_wandb
+        cb._run = MagicMock()
+
+        locals_ = {"loss": 0.5, "episode_reward": 10.0}
+
+        # Step 1: no log
+        assert cb.on_step(locals_)
+        mock_wandb.log.assert_not_called()
+
+        # Step 2: should log
+        assert cb.on_step(locals_)
+        mock_wandb.log.assert_called_once()
+        logged = mock_wandb.log.call_args[0][0]
+        assert logged["loss"] == 0.5
+        assert logged["episode_reward"] == 10.0
+
+    def test_on_step_no_wandb(self):
+        """on_step without wandb initialized should not crash."""
+        cb = WandbCallback(log_freq=1)
+        cb._wandb = None
+        assert cb.on_step({"loss": 0.5})
+
+    def test_training_end_no_run(self):
+        """on_training_end with no run should not crash."""
+        cb = WandbCallback()
+        cb._run = None
+        cb.on_training_end({})  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# TensorBoardCallback
+# ---------------------------------------------------------------------------
+
+
+class TestTensorBoardCallback:
+    """Cover TensorBoardCallback (lines 631-664)."""
+
+    def test_lifecycle(self):
+        """TensorBoardCallback should create and close a writer."""
+        mock_writer = MagicMock()
+        mock_sw = MagicMock(return_value=mock_writer)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "torch": MagicMock(),
+                "torch.utils": MagicMock(),
+                "torch.utils.tensorboard": MagicMock(SummaryWriter=mock_sw),
+            },
+        ):
+            cb = TensorBoardCallback(log_dir="/tmp/tb_test", log_freq=1)
+            cb.on_training_start({})
+            assert cb._writer is mock_writer
+
+        cb.on_training_end({})
+        mock_writer.close.assert_called_once()
+
+    def test_on_step_logs_scalars(self):
+        """on_step should add scalar for known metric keys."""
+        mock_writer = MagicMock()
+        cb = TensorBoardCallback(log_freq=1)
+        cb._writer = mock_writer
+
+        locals_ = {"loss": 0.1, "entropy": 0.5}
+        assert cb.on_step(locals_)
+        assert mock_writer.add_scalar.call_count == 2
+
+    def test_on_step_no_writer(self):
+        """on_step without writer should not crash."""
+        cb = TensorBoardCallback(log_freq=1)
+        cb._writer = None
+        assert cb.on_step({"loss": 0.1})
+
+    def test_training_end_no_writer(self):
+        """on_training_end with no writer should not crash."""
+        cb = TensorBoardCallback()
+        cb._writer = None
+        cb.on_training_end({})
+
+
+# ---------------------------------------------------------------------------
+# ProgressBarCallback
+# ---------------------------------------------------------------------------
+
+
+class TestProgressBarCallback:
+    """Cover ProgressBarCallback (lines 679-704)."""
+
+    def test_lifecycle(self):
+        """ProgressBarCallback should create and close a pbar."""
+        mock_tqdm = MagicMock()
+        mock_pbar = MagicMock()
+        mock_tqdm.return_value = mock_pbar
+
+        with patch.dict("sys.modules", {"tqdm": MagicMock(tqdm=mock_tqdm)}):
+            cb = ProgressBarCallback(total_steps=100)
+            cb.on_training_start({})
+            assert cb._pbar is mock_pbar
+
+        cb.on_training_end({})
+        mock_pbar.close.assert_called_once()
+
+    def test_on_step_updates_pbar(self):
+        """on_step should update progress bar."""
+        mock_pbar = MagicMock()
+        cb = ProgressBarCallback(total_steps=100)
+        cb._pbar = mock_pbar
+
+        assert cb.on_step({})
+        mock_pbar.update.assert_called_once_with(1)
+
+    def test_on_step_shows_reward(self):
+        """on_step should show mean reward in postfix."""
+        mock_pbar = MagicMock()
+        cb = ProgressBarCallback(total_steps=100)
+        cb._pbar = mock_pbar
+        cb._episode_rewards = [1.0, 2.0, 3.0]
+
+        cb.on_step({})
+        mock_pbar.set_postfix.assert_called_once()
+
+    def test_on_episode_end_tracks_rewards(self):
+        cb = ProgressBarCallback(total_steps=100)
+        cb.on_episode_end({"episode_reward": 5.0})
+        assert cb._episode_rewards == [5.0]
+
+    def test_on_step_no_pbar(self):
+        """No pbar should not crash."""
+        cb = ProgressBarCallback(total_steps=100)
+        cb._pbar = None
+        assert cb.on_step({})
+
+    def test_training_end_no_pbar(self):
+        cb = ProgressBarCallback(total_steps=100)
+        cb._pbar = None
+        cb.on_training_end({})
+
+
+# ---------------------------------------------------------------------------
+# VideoRecordCallback
+# ---------------------------------------------------------------------------
+
+
+class TestVideoRecordCallback:
+    """Cover VideoRecordCallback (lines 735-791)."""
+
+    def test_records_video(self, tmp_path):
+        """VideoRecordCallback should capture frames and save video."""
+        mock_imageio = MagicMock()
+
+        cb = VideoRecordCallback(
+            eval_env=_FakeEnv(n_steps=2),
+            record_freq=1,
+            video_dir=str(tmp_path / "videos"),
+            n_episodes=1,
+        )
+        cb.on_training_start({})
+
+        with patch.dict("sys.modules", {"imageio": mock_imageio}):
+            assert cb.on_step({})
+
+        mock_imageio.mimsave.assert_called_once()
+
+    def test_records_with_model(self, tmp_path):
+        """Should use model.predict when available."""
+        model = MagicMock()
+        model.predict.return_value = ([0.0, 0.0], None)
+
+        cb = VideoRecordCallback(
+            eval_env=_FakeEnv(n_steps=2),
+            record_freq=1,
+            video_dir=str(tmp_path / "videos"),
+        )
+        cb.on_training_start({})
+
+        mock_imageio = MagicMock()
+        with patch.dict("sys.modules", {"imageio": mock_imageio}):
+            cb.on_step({"self": model})
+
+        model.predict.assert_called()
+
+    def test_gym_v26_env(self, tmp_path):
+        """Should handle 5-tuple step returns."""
+        cb = VideoRecordCallback(
+            eval_env=_FakeEnvGymV26(n_steps=2),
+            record_freq=1,
+            video_dir=str(tmp_path / "videos"),
+        )
+        cb.on_training_start({})
+
+        mock_imageio = MagicMock()
+        with patch.dict("sys.modules", {"imageio": mock_imageio}):
+            assert cb.on_step({})
+
+    def test_imageio_import_error(self, tmp_path):
+        """Missing imageio should log warning, not crash."""
+        import numpy as np
+
+        cb = VideoRecordCallback(
+            eval_env=_FakeEnv(n_steps=2),
+            record_freq=1,
+            video_dir=str(tmp_path / "videos"),
+        )
+        cb.on_training_start({})
+
+        with patch.dict("sys.modules", {"imageio": None}):
+            # Should not raise
+            assert cb.on_step({})
+
+    def test_callable_env(self, tmp_path):
+        """Should handle callable env factory."""
+        cb = VideoRecordCallback(
+            eval_env=lambda: _FakeEnv(n_steps=2),
+            record_freq=1,
+            video_dir=str(tmp_path / "videos"),
+        )
+        cb.on_training_start({})
+
+        mock_imageio = MagicMock()
+        with patch.dict("sys.modules", {"imageio": mock_imageio}):
+            assert cb.on_step({})
+
+    def test_no_frames_no_save(self, tmp_path):
+        """Env that returns None from render should not try to save."""
+        env = _FakeEnv(n_steps=1)
+        # Patch render to return None
+        env.render = lambda: None
+
+        cb = VideoRecordCallback(
+            eval_env=env,
+            record_freq=1,
+            video_dir=str(tmp_path / "videos"),
+        )
+        cb.on_training_start({})
+
+        mock_imageio = MagicMock()
+        with patch.dict("sys.modules", {"imageio": mock_imageio}):
+            cb.on_step({})
+        mock_imageio.mimsave.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CheckpointCallback edge case
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointCallbackEdge:
+    """Cover CheckpointCallback verbose logging (line 347)."""
+
+    def test_saves_and_logs(self, tmp_path):
+        model = MagicMock()
+        cb = CheckpointCallback(save_freq=1, save_path=str(tmp_path), verbose=1)
+        cb.on_training_start({})
+        cb.on_step({"self": model})
+        model.save.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# LoggingCallback edge case
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingCallbackEdge:
+    """Cover LoggingCallback file write path (line 419)."""
+
+    def test_writes_to_file(self, tmp_path):
+        log_file = str(tmp_path / "train.jsonl")
+        cb = LoggingCallback(log_freq=1, log_file=log_file, verbose=0)
+        cb.on_training_start({})
+
+        cb.on_episode_end({"episode_reward": 5.0})
+        cb.on_step({"loss": 0.1})
+        cb.on_training_end({})
+
+        lines = Path(log_file).read_text().strip().split("\n")
+        assert len(lines) >= 1
+        data = json.loads(lines[0])
+        assert "step" in data
+
+
+# ---------------------------------------------------------------------------
+# EarlyStoppingCallback edge case
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyStoppingCallbackEdge:
+    """Cover EarlyStoppingCallback verbose logging (line 479)."""
+
+    def test_verbose_logging_on_stop(self):
+        eval_cb = EvalCallback(eval_env=_FakeEnv(), eval_freq=1)
+        eval_cb.eval_results = [{"step": 1, "mean_reward": 1.0}]
+        eval_cb.last_mean_reward = 1.0
+
+        cb = EarlyStoppingCallback(eval_cb, patience=1, verbose=1)
+        # First eval — sets baseline
+        cb.on_step({})
+
+        # Second eval — no improvement
+        eval_cb.eval_results.append({"step": 2, "mean_reward": 0.5})
+        eval_cb.last_mean_reward = 0.5
+        result = cb.on_step({})
+        assert result is False  # should stop
+
+
+# ---------------------------------------------------------------------------
+# CurriculumCallback edge case
+# ---------------------------------------------------------------------------
+
+
+class TestCurriculumCallbackEdge:
+    """Cover CurriculumCallback level advancement with env (line 535)."""
+
+    def test_calls_update_fn(self):
+        update_fn = MagicMock()
+        env = MagicMock()
+        cb = CurriculumCallback(
+            metric_key="score",
+            thresholds=[(5.0, {"level": 1}), (10.0, {"level": 2})],
+            update_fn=update_fn,
+            verbose=1,
+        )
+        cb.on_episode_end({"score": 6.0, "env": env})
+        update_fn.assert_called_once_with(env, {"level": 1})

--- a/tests/test_constraints_coverage.py
+++ b/tests/test_constraints_coverage.py
@@ -303,28 +303,34 @@ class TestConstraintSet:
         assert cs.constraints[0] is sc
 
     def test_is_safe_all_pass(self):
-        cs = ConstraintSet(constraints=[
-            SpeedConstraint(max_speed=2.0),
-            BoundaryConstraint(x_min=-10, x_max=10, y_min=-10, y_max=10),
-        ])
+        cs = ConstraintSet(
+            constraints=[
+                SpeedConstraint(max_speed=2.0),
+                BoundaryConstraint(x_min=-10, x_max=10, y_min=-10, y_max=10),
+            ]
+        )
         state = np.array([0.0, 0.0])
         action = np.array([0.5, 0.0])
         assert cs.is_safe(state, action)
 
     def test_is_safe_one_fails(self):
-        cs = ConstraintSet(constraints=[
-            SpeedConstraint(max_speed=0.1),  # will fail
-            BoundaryConstraint(x_min=-10, x_max=10, y_min=-10, y_max=10),
-        ])
+        cs = ConstraintSet(
+            constraints=[
+                SpeedConstraint(max_speed=0.1),  # will fail
+                BoundaryConstraint(x_min=-10, x_max=10, y_min=-10, y_max=10),
+            ]
+        )
         state = np.array([0.0, 0.0])
         action = np.array([1.0, 0.0])
         assert not cs.is_safe(state, action)
 
     def test_project_satisfies_all(self):
-        cs = ConstraintSet(constraints=[
-            SpeedConstraint(max_speed=0.5),
-            BoundaryConstraint(x_min=-1, x_max=1, y_min=-1, y_max=1, dt=0.1),
-        ])
+        cs = ConstraintSet(
+            constraints=[
+                SpeedConstraint(max_speed=0.5),
+                BoundaryConstraint(x_min=-1, x_max=1, y_min=-1, y_max=1, dt=0.1),
+            ]
+        )
         state = np.array([0.0, 0.0])
         action = np.array([10.0, 10.0])
 

--- a/tests/test_constraints_coverage.py
+++ b/tests/test_constraints_coverage.py
@@ -1,0 +1,364 @@
+"""Tests for uncovered paths in navirl.safety.constraints."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from navirl.safety.constraints import (
+    AccelerationConstraint,
+    BoundaryConstraint,
+    CollisionConstraint,
+    ConstraintSet,
+    ProxemicsConstraint,
+    SpeedConstraint,
+)
+
+# ---------------------------------------------------------------------------
+# CollisionConstraint.project – bisection branch
+# ---------------------------------------------------------------------------
+
+
+class TestCollisionConstraintProject:
+    """Cover the bisection loop in CollisionConstraint.project (line 93+)."""
+
+    def test_project_reduces_speed_until_safe(self):
+        """When heading toward an obstacle, project should scale velocity down."""
+        obs_pos = np.array([[1.0, 0.0]])
+        cc = CollisionConstraint(
+            obstacle_positions=obs_pos,
+            obstacle_radii=0.3,
+            agent_radius=0.25,
+            time_horizon=2.0,
+            dt=0.1,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([2.0, 0.0])  # heading straight at obstacle
+
+        assert not cc.is_safe(state, action)
+        projected = cc.project(state, action)
+        # Projected action should have reduced speed
+        assert np.linalg.norm(projected[:2]) < np.linalg.norm(action[:2])
+
+    def test_project_finds_safe_scale(self):
+        """Bisection should find a reduced velocity that avoids collision."""
+        obs_pos = np.array([[0.8, 0.0]])
+        cc = CollisionConstraint(
+            obstacle_positions=obs_pos,
+            obstacle_radii=0.2,
+            agent_radius=0.2,
+            time_horizon=2.0,
+            dt=0.1,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([2.0, 0.0])  # will reach obstacle within horizon
+
+        assert not cc.is_safe(state, action)
+        projected = cc.project(state, action)
+        # Bisection found a safe scale
+        assert cc.is_safe(state, projected)
+        assert np.linalg.norm(projected[:2]) <= np.linalg.norm(action[:2])
+
+    def test_project_safe_action_unchanged(self):
+        """A safe action should be returned as-is (copy)."""
+        cc = CollisionConstraint(
+            obstacle_positions=np.array([[10.0, 10.0]]),
+            obstacle_radii=0.3,
+            agent_radius=0.25,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([0.1, 0.0])
+        projected = cc.project(state, action)
+        np.testing.assert_array_almost_equal(projected, action)
+
+
+# ---------------------------------------------------------------------------
+# AccelerationConstraint – jerk checking and clamping
+# ---------------------------------------------------------------------------
+
+
+class TestAccelerationConstraintJerk:
+    """Cover jerk limit paths in AccelerationConstraint (lines 168-171, 183-187)."""
+
+    def test_is_safe_jerk_violation(self):
+        """Large jerk should be flagged unsafe."""
+        ac = AccelerationConstraint(max_acceleration=100.0, max_jerk=1.0, dt=0.1)
+        state = np.array([0.0, 0.0, 0.0, 0.0])
+        # Set a previous acceleration to create a jerk reference
+        ac._prev_acceleration = np.array([0.0, 0.0])
+
+        # Action that creates huge acceleration (and therefore huge jerk)
+        action = np.array([5.0, 0.0])
+        assert not ac.is_safe(state, action)
+
+    def test_is_safe_jerk_within_limit(self):
+        """Small jerk should pass."""
+        ac = AccelerationConstraint(max_acceleration=100.0, max_jerk=1000.0, dt=0.1)
+        ac._prev_acceleration = np.array([0.0, 0.0])
+        state = np.array([0.0, 0.0, 0.0, 0.0])
+        action = np.array([0.01, 0.0])
+        assert ac.is_safe(state, action)
+
+    def test_is_safe_no_prev_acceleration_skips_jerk(self):
+        """Without previous acceleration, jerk check is skipped."""
+        ac = AccelerationConstraint(max_acceleration=100.0, max_jerk=0.001, dt=0.1)
+        state = np.array([0.0, 0.0, 0.0, 0.0])
+        action = np.array([0.5, 0.0])
+        # No _prev_acceleration set, jerk check skipped
+        assert ac.is_safe(state, action)
+
+    def test_project_clamps_jerk(self):
+        """Project should clamp jerk when it exceeds max_jerk."""
+        ac = AccelerationConstraint(max_acceleration=100.0, max_jerk=1.0, dt=0.1)
+        ac._prev_acceleration = np.array([0.0, 0.0])
+        state = np.array([0.0, 0.0, 0.0, 0.0])
+        action = np.array([10.0, 0.0])  # huge acceleration → huge jerk
+
+        projected = ac.project(state, action)
+        # Projected action should be reduced due to jerk clamping
+        assert np.linalg.norm(projected[:2]) < np.linalg.norm(action[:2])
+
+    def test_acceleration_with_short_state(self):
+        """State with fewer than 4 elements should default velocity to zero."""
+        ac = AccelerationConstraint(max_acceleration=5.0, dt=0.1)
+        state = np.array([1.0, 2.0])  # only position, no velocity
+        action = np.array([0.3, 0.0])
+        # Should not raise
+        assert isinstance(ac.is_safe(state, action), bool)
+        projected = ac.project(state, action)
+        assert projected.shape == action.shape
+
+
+# ---------------------------------------------------------------------------
+# ProxemicsConstraint
+# ---------------------------------------------------------------------------
+
+
+class TestProxemicsConstraint:
+    """Cover ProxemicsConstraint (lines 231-261)."""
+
+    def test_default_min_distance(self):
+        """min_distance should default to personal_radius."""
+        pc = ProxemicsConstraint(personal_radius=1.5)
+        assert pc.min_distance == 1.5
+
+    def test_explicit_min_distance(self):
+        """Explicit min_distance overrides default."""
+        pc = ProxemicsConstraint(personal_radius=1.5, min_distance=0.8)
+        assert pc.min_distance == 0.8
+
+    def test_is_safe_no_pedestrians(self):
+        """No pedestrians should always be safe."""
+        pc = ProxemicsConstraint()
+        state = np.array([0.0, 0.0])
+        action = np.array([1.0, 0.0])
+        assert pc.is_safe(state, action)
+
+    def test_is_safe_far_pedestrian(self):
+        """Pedestrian far away should be safe."""
+        pc = ProxemicsConstraint(
+            pedestrian_positions=np.array([[100.0, 100.0]]),
+            min_distance=1.2,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([0.5, 0.0])
+        assert pc.is_safe(state, action)
+
+    def test_is_safe_close_pedestrian(self):
+        """Moving toward a nearby pedestrian should be unsafe."""
+        pc = ProxemicsConstraint(
+            pedestrian_positions=np.array([[0.2, 0.0]]),
+            min_distance=1.2,
+            dt=0.1,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([1.0, 0.0])  # moves to (0.1, 0) — within 1.2 of (0.2, 0)
+        assert not pc.is_safe(state, action)
+
+    def test_project_pushes_away(self):
+        """Project should redirect velocity away from pedestrian."""
+        pc = ProxemicsConstraint(
+            pedestrian_positions=np.array([[0.5, 0.0]]),
+            min_distance=1.2,
+            dt=0.1,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([5.0, 0.0])
+
+        projected = pc.project(state, action)
+        # Should not be the same as original
+        assert not np.allclose(projected, action)
+
+    def test_project_safe_action_unchanged(self):
+        """Safe action should be returned as a copy."""
+        pc = ProxemicsConstraint(
+            pedestrian_positions=np.array([[100.0, 100.0]]),
+            min_distance=1.2,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([0.1, 0.0])
+        projected = pc.project(state, action)
+        np.testing.assert_array_almost_equal(projected, action)
+
+    def test_project_zero_repulsion_norm(self):
+        """When agent is exactly on top of pedestrian, should return zero action."""
+        pc = ProxemicsConstraint(
+            pedestrian_positions=np.array([[0.0, 0.0]]),
+            min_distance=1.2,
+            dt=0.1,
+        )
+        # Agent at origin, pedestrian at origin → next_pos is at action*dt
+        # next_pos - ped = action*dt, so diffs will be small
+        state = np.array([0.0, 0.0])
+        # Action that puts us exactly on the pedestrian: (0,0)*dt = (0,0)
+        action = np.array([0.0, 0.0])
+        # is_safe: next_pos = (0,0), dist = 0 < 1.2 → unsafe
+        assert not pc.is_safe(state, action)
+        projected = pc.project(state, action)
+        # With zero action the repulsion norm will be zero, so we get zero action
+        np.testing.assert_array_almost_equal(projected, np.zeros(2))
+
+    def test_project_multiple_pedestrians(self):
+        """Project with multiple pedestrians violating."""
+        pc = ProxemicsConstraint(
+            pedestrian_positions=np.array([[0.3, 0.0], [0.0, 0.3]]),
+            min_distance=1.0,
+            dt=0.1,
+        )
+        state = np.array([0.0, 0.0])
+        action = np.array([1.0, 1.0])
+        projected = pc.project(state, action)
+        assert projected.shape == action.shape
+
+
+# ---------------------------------------------------------------------------
+# BoundaryConstraint
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryConstraint:
+    """Cover BoundaryConstraint (lines 288-306)."""
+
+    def test_is_safe_inside(self):
+        bc = BoundaryConstraint(x_min=-5, x_max=5, y_min=-5, y_max=5, dt=0.1)
+        state = np.array([0.0, 0.0])
+        action = np.array([1.0, 1.0])
+        assert bc.is_safe(state, action)
+
+    def test_is_safe_outside_x(self):
+        bc = BoundaryConstraint(x_min=-5, x_max=5, y_min=-5, y_max=5, dt=0.1)
+        state = np.array([4.9, 0.0])
+        action = np.array([10.0, 0.0])  # next pos: 4.9 + 10*0.1 = 5.9 > 5
+        assert not bc.is_safe(state, action)
+
+    def test_is_safe_outside_y(self):
+        bc = BoundaryConstraint(x_min=-5, x_max=5, y_min=-5, y_max=5, dt=0.1)
+        state = np.array([0.0, -4.9])
+        action = np.array([0.0, -10.0])  # next pos: -4.9 - 1.0 = -5.9 < -5
+        assert not bc.is_safe(state, action)
+
+    def test_project_clamps_to_boundary(self):
+        bc = BoundaryConstraint(x_min=-5, x_max=5, y_min=-5, y_max=5, dt=0.1)
+        state = np.array([4.5, 0.0])
+        action = np.array([20.0, 0.0])  # next pos: 4.5 + 2.0 = 6.5 > 5
+
+        projected = bc.project(state, action)
+        # Verify next position after projection is within bounds
+        next_pos = state[:2] + projected[:2] * bc.dt
+        assert next_pos[0] <= 5.0 + 1e-8
+        assert next_pos[0] >= -5.0 - 1e-8
+
+    def test_project_safe_unchanged(self):
+        bc = BoundaryConstraint(x_min=-5, x_max=5, y_min=-5, y_max=5, dt=0.1)
+        state = np.array([0.0, 0.0])
+        action = np.array([1.0, 1.0])
+        projected = bc.project(state, action)
+        np.testing.assert_array_almost_equal(projected, action)
+
+    def test_project_corner_case(self):
+        """Both x and y exceed bounds."""
+        bc = BoundaryConstraint(x_min=-1, x_max=1, y_min=-1, y_max=1, dt=0.1)
+        state = np.array([0.9, 0.9])
+        action = np.array([20.0, 20.0])  # next: (2.9, 2.9) way out of bounds
+
+        projected = bc.project(state, action)
+        next_pos = state[:2] + projected[:2] * bc.dt
+        assert next_pos[0] <= 1.0 + 1e-8
+        assert next_pos[1] <= 1.0 + 1e-8
+
+
+# ---------------------------------------------------------------------------
+# ConstraintSet
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintSet:
+    """Cover ConstraintSet (lines 341, 348-360)."""
+
+    def test_add(self):
+        cs = ConstraintSet()
+        sc = SpeedConstraint(max_speed=1.0)
+        cs.add(sc)
+        assert len(cs.constraints) == 1
+        assert cs.constraints[0] is sc
+
+    def test_is_safe_all_pass(self):
+        cs = ConstraintSet(constraints=[
+            SpeedConstraint(max_speed=2.0),
+            BoundaryConstraint(x_min=-10, x_max=10, y_min=-10, y_max=10),
+        ])
+        state = np.array([0.0, 0.0])
+        action = np.array([0.5, 0.0])
+        assert cs.is_safe(state, action)
+
+    def test_is_safe_one_fails(self):
+        cs = ConstraintSet(constraints=[
+            SpeedConstraint(max_speed=0.1),  # will fail
+            BoundaryConstraint(x_min=-10, x_max=10, y_min=-10, y_max=10),
+        ])
+        state = np.array([0.0, 0.0])
+        action = np.array([1.0, 0.0])
+        assert not cs.is_safe(state, action)
+
+    def test_project_satisfies_all(self):
+        cs = ConstraintSet(constraints=[
+            SpeedConstraint(max_speed=0.5),
+            BoundaryConstraint(x_min=-1, x_max=1, y_min=-1, y_max=1, dt=0.1),
+        ])
+        state = np.array([0.0, 0.0])
+        action = np.array([10.0, 10.0])
+
+        projected = cs.project(state, action)
+        # Speed should be within limit
+        assert np.linalg.norm(projected[:2]) <= 0.5 + 1e-6
+
+    def test_project_empty_set(self):
+        """Empty constraint set should return action unchanged."""
+        cs = ConstraintSet()
+        state = np.array([0.0, 0.0])
+        action = np.array([5.0, 5.0])
+        projected = cs.project(state, action)
+        np.testing.assert_array_almost_equal(projected, action)
+
+    def test_project_converges(self):
+        """Fixed-point iteration should converge."""
+        cs = ConstraintSet(
+            constraints=[
+                SpeedConstraint(max_speed=1.0),
+                BoundaryConstraint(x_min=-2, x_max=2, y_min=-2, y_max=2, dt=0.1),
+            ],
+            max_iters=20,
+        )
+        state = np.array([1.9, 1.9])
+        action = np.array([50.0, 50.0])
+        projected = cs.project(state, action)
+        # After projection, all constraints should be satisfied
+        assert cs.is_safe(state, projected)
+
+    def test_project_already_safe(self):
+        """Already safe action is returned as-is."""
+        cs = ConstraintSet(constraints=[SpeedConstraint(max_speed=5.0)])
+        state = np.array([0.0, 0.0])
+        action = np.array([0.1, 0.0])
+        projected = cs.project(state, action)
+        np.testing.assert_array_almost_equal(projected, action)

--- a/tests/test_parallel_coverage.py
+++ b/tests/test_parallel_coverage.py
@@ -1,0 +1,445 @@
+"""Tests for uncovered paths in navirl.training.parallel.
+
+Focuses on RunningMeanStd, VecNormalize, VecFrameStack, VecMonitor,
+and the AsyncVecEnv / SubprocVecEnv worker logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from navirl.training.parallel import (
+    AsyncVecEnv,
+    BaseVecEnv,
+    DummyVecEnv,
+    RunningMeanStd,
+    VecEnvWrapper,
+    VecFrameStack,
+    VecMonitor,
+    VecNormalize,
+    _worker,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal fake environment
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpace:
+    """Minimal space mock with shape."""
+
+    def __init__(self, shape: tuple[int, ...] = (4,)) -> None:
+        self.shape = shape
+
+    def sample(self) -> np.ndarray:
+        return np.zeros(self.shape)
+
+
+class _FakeEnv:
+    """Minimal environment for testing vectorized wrappers."""
+
+    def __init__(self, obs_shape: tuple[int, ...] = (4,)) -> None:
+        self.observation_space = _FakeSpace(obs_shape)
+        self.action_space = _FakeSpace((2,))
+        self._step_count = 0
+
+    def reset(self) -> np.ndarray:
+        self._step_count = 0
+        return np.zeros(self.observation_space.shape)
+
+    def step(self, action: np.ndarray) -> tuple:
+        self._step_count += 1
+        obs = np.random.randn(*self.observation_space.shape).astype(np.float32)
+        reward = float(np.random.randn())
+        done = self._step_count >= 5
+        info = {}
+        return obs, reward, done, info
+
+    def close(self) -> None:
+        pass
+
+
+def _make_env(obs_shape: tuple[int, ...] = (4,)) -> Callable:
+    return lambda: _FakeEnv(obs_shape)
+
+
+# ---------------------------------------------------------------------------
+# RunningMeanStd
+# ---------------------------------------------------------------------------
+
+
+class TestRunningMeanStd:
+    """Cover RunningMeanStd.update (lines 611-631)."""
+
+    def test_initial_state(self):
+        rms = RunningMeanStd(shape=(3,))
+        np.testing.assert_array_equal(rms.mean, np.zeros(3))
+        np.testing.assert_array_equal(rms.var, np.ones(3))
+
+    def test_single_update(self):
+        rms = RunningMeanStd(shape=(2,))
+        batch = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        rms.update(batch)
+        # Mean should be close to [3, 4]
+        assert abs(rms.mean[0] - 3.0) < 0.1
+        assert abs(rms.mean[1] - 4.0) < 0.1
+
+    def test_multiple_updates_converge(self):
+        rms = RunningMeanStd(shape=())
+        np.random.seed(42)
+        for _ in range(100):
+            batch = np.random.randn(32) * 2.0 + 5.0
+            rms.update(batch)
+        # Should converge toward mean=5.0, var≈4.0
+        assert abs(rms.mean - 5.0) < 0.5
+        assert abs(rms.var - 4.0) < 1.0
+
+    def test_scalar_shape(self):
+        rms = RunningMeanStd(shape=())
+        rms.update(np.array([1.0, 2.0, 3.0]))
+        assert rms.mean.shape == ()
+
+
+# ---------------------------------------------------------------------------
+# VecNormalize
+# ---------------------------------------------------------------------------
+
+
+class TestVecNormalize:
+    """Cover VecNormalize step/reset/normalize (lines 679-701, 703-715)."""
+
+    def _make_vec_env(self, n: int = 2) -> DummyVecEnv:
+        return DummyVecEnv([_make_env() for _ in range(n)])
+
+    def test_step_normalizes_obs_and_rewards(self):
+        venv = self._make_vec_env()
+        norm = VecNormalize(venv)
+        obs = norm.reset()
+        assert obs.dtype == np.float32
+
+        actions = np.zeros((2, 2))
+        obs, rewards, dones, infos = norm.step(actions)
+        assert obs.dtype == np.float32
+        assert rewards.dtype == np.float32
+
+    def test_step_resets_returns_on_done(self):
+        venv = self._make_vec_env(1)
+        norm = VecNormalize(venv)
+        norm.reset()
+
+        # Step until done
+        actions = np.zeros((1, 2))
+        for _ in range(10):
+            obs, rewards, dones, infos = norm.step(actions)
+            if dones[0]:
+                break
+        # After done, returns should be reset
+        assert norm.returns[0] == 0.0
+
+    def test_training_mode_updates_stats(self):
+        venv = self._make_vec_env()
+        norm = VecNormalize(venv)
+        norm.reset()
+
+        initial_count = norm.obs_rms.count
+        actions = np.zeros((2, 2))
+        norm.step(actions)
+        assert norm.obs_rms.count > initial_count
+
+    def test_eval_mode_freezes_stats(self):
+        venv = self._make_vec_env()
+        norm = VecNormalize(venv)
+        norm.reset()
+
+        # Warm up stats
+        actions = np.zeros((2, 2))
+        for _ in range(3):
+            norm.step(actions)
+
+        norm.set_training(False)
+        count_before = norm.obs_rms.count
+        norm.step(actions)
+        assert norm.obs_rms.count == count_before
+
+    def test_no_normalization(self):
+        venv = self._make_vec_env()
+        norm = VecNormalize(venv, norm_obs=False, norm_reward=False)
+        norm.reset()
+        actions = np.zeros((2, 2))
+        obs, rewards, dones, infos = norm.step(actions)
+        # Should still return float32
+        assert obs.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# VecFrameStack
+# ---------------------------------------------------------------------------
+
+
+class TestVecFrameStack:
+    """Cover VecFrameStack step/reset (lines 776-807)."""
+
+    def _make_vec_env(self, n: int = 2) -> DummyVecEnv:
+        return DummyVecEnv([_make_env() for _ in range(n)])
+
+    def test_reset_stacks_frames(self):
+        venv = self._make_vec_env()
+        fs = VecFrameStack(venv, n_stack=3)
+        obs = fs.reset()
+        assert obs.shape == (2, 3, 4)  # (num_envs, n_stack, obs_dim)
+        # Only last frame should be non-zero
+        np.testing.assert_array_equal(obs[:, 0, :], 0.0)
+        np.testing.assert_array_equal(obs[:, 1, :], 0.0)
+
+    def test_step_shifts_frames(self):
+        venv = self._make_vec_env()
+        fs = VecFrameStack(venv, n_stack=3)
+        fs.reset()
+        actions = np.zeros((2, 2))
+
+        obs1, _, _, _ = fs.step(actions)
+        obs2, _, _, _ = fs.step(actions)
+
+        # After 2 steps, frames should have shifted
+        assert obs2.shape == (2, 3, 4)
+
+    def test_done_clears_stack(self):
+        venv = self._make_vec_env(1)
+        fs = VecFrameStack(venv, n_stack=3)
+        fs.reset()
+        actions = np.zeros((1, 2))
+
+        # Step until done
+        for _ in range(10):
+            obs, _, dones, _ = fs.step(actions)
+            if dones[0]:
+                # Stack should have been cleared for the done env
+                # (the new obs will be in the last slot after clearing)
+                break
+
+
+# ---------------------------------------------------------------------------
+# VecMonitor
+# ---------------------------------------------------------------------------
+
+
+class TestVecMonitor:
+    """Cover VecMonitor step (lines 836-875)."""
+
+    def _make_vec_env(self, n: int = 2) -> DummyVecEnv:
+        return DummyVecEnv([_make_env() for _ in range(n)])
+
+    def test_tracks_episode_stats(self):
+        venv = self._make_vec_env(1)
+        mon = VecMonitor(venv)
+        mon.reset()
+        actions = np.zeros((1, 2))
+
+        # Step until done to get an episode
+        for _ in range(10):
+            obs, rewards, dones, infos = mon.step(actions)
+            if dones[0]:
+                assert "episode" in infos[0]
+                assert "r" in infos[0]["episode"]
+                assert "l" in infos[0]["episode"]
+                break
+
+    def test_episode_count_increments(self):
+        venv = self._make_vec_env(1)
+        mon = VecMonitor(venv)
+        mon.reset()
+        actions = np.zeros((1, 2))
+
+        for _ in range(10):
+            obs, _, dones, _ = mon.step(actions)
+            if dones[0]:
+                break
+        assert mon.episode_count >= 1
+
+    def test_info_keywords_tracked(self):
+        """Info keywords from the env should be copied to episode info."""
+        venv = self._make_vec_env(1)
+        mon = VecMonitor(venv, info_keywords=("custom_metric",))
+        mon.reset()
+
+        # Inject a custom metric into the env's info
+        original_step = venv.envs[0].step
+
+        def patched_step(action):
+            obs, reward, done, info = original_step(action)
+            info["custom_metric"] = 42.0
+            return obs, reward, done, info
+
+        venv.envs[0].step = patched_step
+
+        actions = np.zeros((1, 2))
+        for _ in range(10):
+            obs, _, dones, infos = mon.step(actions)
+            if dones[0]:
+                assert infos[0]["episode"]["custom_metric"] == 42.0
+                break
+
+    def test_reward_history_bounded(self):
+        """Episode history should be bounded by maxlen=100."""
+        venv = self._make_vec_env(1)
+        mon = VecMonitor(venv)
+        mon.reset()
+        actions = np.zeros((1, 2))
+
+        for _ in range(200):
+            obs, _, dones, _ = mon.step(actions)
+        # History deque is bounded
+        assert len(mon._episode_reward_history) <= 100
+
+
+# ---------------------------------------------------------------------------
+# _worker function
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerFunction:
+    """Cover _worker subprocess function (lines 192-228)."""
+
+    def test_worker_step(self):
+        """Worker should handle step command."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+        env = _FakeEnv()
+
+        # Simulate commands: step then close
+        work_remote.recv.side_effect = [
+            ("step", np.zeros(2)),
+            ("close", None),
+        ]
+
+        _worker(work_remote, parent_remote, lambda: env)
+        parent_remote.close.assert_called_once()
+        assert work_remote.send.call_count >= 1
+
+    def test_worker_reset(self):
+        """Worker should handle reset command."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+        env = _FakeEnv()
+
+        work_remote.recv.side_effect = [
+            ("reset", None),
+            ("close", None),
+        ]
+
+        _worker(work_remote, parent_remote, lambda: env)
+        assert work_remote.send.call_count >= 1
+
+    def test_worker_get_attr(self):
+        """Worker should handle get_attr command."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+        env = _FakeEnv()
+
+        work_remote.recv.side_effect = [
+            ("get_attr", "observation_space"),
+            ("close", None),
+        ]
+
+        _worker(work_remote, parent_remote, lambda: env)
+        # Should have sent the observation_space
+        sent_value = work_remote.send.call_args_list[0][0][0]
+        assert hasattr(sent_value, "shape")
+
+    def test_worker_env_method(self):
+        """Worker should handle env_method command."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+        env = _FakeEnv()
+
+        work_remote.recv.side_effect = [
+            ("env_method", ("reset", (), {})),
+            ("close", None),
+        ]
+
+        _worker(work_remote, parent_remote, lambda: env)
+        assert work_remote.send.call_count >= 1
+
+    def test_worker_get_spaces(self):
+        """Worker should handle get_spaces command."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+        env = _FakeEnv()
+
+        work_remote.recv.side_effect = [
+            ("get_spaces", None),
+            ("close", None),
+        ]
+
+        _worker(work_remote, parent_remote, lambda: env)
+        sent = work_remote.send.call_args_list[0][0][0]
+        assert isinstance(sent, tuple)
+        assert len(sent) == 2
+
+    def test_worker_unknown_command_raises(self):
+        """Unknown command should raise ValueError."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+        env = _FakeEnv()
+
+        work_remote.recv.side_effect = [
+            ("unknown_cmd", None),
+        ]
+
+        with pytest.raises(ValueError, match="Unknown command"):
+            _worker(work_remote, parent_remote, lambda: env)
+
+    def test_worker_eof_exits(self):
+        """EOFError should cause clean exit."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+
+        work_remote.recv.side_effect = EOFError()
+
+        _worker(work_remote, parent_remote, lambda: _FakeEnv())
+        parent_remote.close.assert_called_once()
+
+    def test_worker_step_auto_resets_on_done(self):
+        """Step that returns done should auto-reset."""
+        parent_remote = MagicMock()
+        work_remote = MagicMock()
+        env = MagicMock()
+        env.step.return_value = (np.zeros(4), 1.0, True, {})
+        env.reset.return_value = np.zeros(4)
+
+        work_remote.recv.side_effect = [
+            ("step", np.zeros(2)),
+            ("close", None),
+        ]
+
+        _worker(work_remote, parent_remote, lambda: env)
+        env.reset.assert_called_once()
+        # Check terminal_observation was added to info
+        sent = work_remote.send.call_args_list[0][0][0]
+        assert "terminal_observation" in sent[3]
+
+
+# ---------------------------------------------------------------------------
+# VecEnvWrapper delegation
+# ---------------------------------------------------------------------------
+
+
+class TestVecEnvWrapper:
+    """Cover VecEnvWrapper delegation methods."""
+
+    def test_wrapper_delegates(self):
+        venv = DummyVecEnv([_make_env()])
+        wrapper = VecEnvWrapper(venv)
+
+        obs = wrapper.reset()
+        assert obs.shape == (1, 4)
+
+        actions = np.zeros((1, 2))
+        obs, rewards, dones, infos = wrapper.step(actions)
+        assert obs.shape == (1, 4)
+
+        wrapper.close()

--- a/tests/test_serialization_coverage.py
+++ b/tests/test_serialization_coverage.py
@@ -1,0 +1,357 @@
+"""Tests for uncovered paths in navirl.config.serialization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from navirl.config.serialization import (
+    _auto_cast,
+    _flatten_to_args,
+    _import_toml_read,
+    _import_toml_write,
+    _import_yaml,
+    _normalize_output_path,
+    _resolve_existing_path,
+    cli_args_to_config,
+    config_to_cli_args,
+    diff_configs,
+    load_config,
+    merge_configs,
+    save_config,
+)
+
+# ---------------------------------------------------------------------------
+# save_config error paths
+# ---------------------------------------------------------------------------
+
+
+class TestSaveConfigErrors:
+    """Cover error branches in save_config."""
+
+    def test_mkdir_os_error(self, tmp_path):
+        """OSError during directory creation should propagate."""
+        path = tmp_path / "sub" / "config.json"
+        with (
+            patch.object(Path, "mkdir", side_effect=OSError("permission denied")),
+            pytest.raises(OSError, match="Cannot create directory"),
+        ):
+            save_config({"key": "val"}, path)
+
+    def test_json_write_os_error(self, tmp_path):
+        """OSError writing JSON file."""
+        path = tmp_path / "config.json"
+        with (
+            patch("builtins.open", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="Cannot write JSON"),
+        ):
+            save_config({"key": "val"}, path)
+
+    def test_json_write_type_error(self, tmp_path):
+        """TypeError during JSON serialization."""
+        path = tmp_path / "config.json"
+        with (
+            patch("json.dump", side_effect=TypeError("not serializable")),
+            pytest.raises(ValueError, match="cannot be serialized to JSON"),
+        ):
+            save_config({"key": "val"}, path)
+
+    def test_yaml_write_os_error(self, tmp_path):
+        """OSError writing YAML file."""
+        path = tmp_path / "config.yaml"
+        mock_yaml = MagicMock()
+        with patch("builtins.open", side_effect=OSError("disk full")), patch(
+            "navirl.config.serialization._import_yaml", return_value=mock_yaml
+        ), pytest.raises(OSError, match="Cannot write YAML"):
+            save_config({"key": "val"}, path)
+
+    def test_yaml_write_value_error(self, tmp_path):
+        """ValueError during YAML serialization."""
+        path = tmp_path / "config.yaml"
+        mock_yaml = MagicMock()
+        mock_yaml.dump.side_effect = ValueError("bad value")
+        with patch(
+            "navirl.config.serialization._import_yaml", return_value=mock_yaml
+        ), pytest.raises(ValueError, match="cannot be serialized to YAML"):
+            save_config({"key": "val"}, path)
+
+    def test_yaml_write_generic_error(self, tmp_path):
+        """Generic exception during YAML serialization."""
+        path = tmp_path / "config.yaml"
+        mock_yaml = MagicMock()
+        mock_yaml.dump.side_effect = RuntimeError("yaml internal error")
+        with patch(
+            "navirl.config.serialization._import_yaml", return_value=mock_yaml
+        ), pytest.raises(ValueError, match="cannot be serialized to YAML"):
+            save_config({"key": "val"}, path)
+
+    def test_toml_write_os_error(self, tmp_path):
+        """OSError writing TOML file."""
+        path = tmp_path / "config.toml"
+        mock_toml = MagicMock()
+        with patch("builtins.open", side_effect=OSError("disk full")), patch(
+            "navirl.config.serialization._import_toml_write",
+            return_value=mock_toml,
+        ), pytest.raises(OSError, match="Cannot write TOML"):
+            save_config({"key": "val"}, path)
+
+    def test_toml_write_type_error(self, tmp_path):
+        """TypeError during TOML serialization."""
+        path = tmp_path / "config.toml"
+        mock_toml = MagicMock()
+        mock_toml.dump.side_effect = TypeError("not serializable")
+        with patch(
+            "navirl.config.serialization._import_toml_write",
+            return_value=mock_toml,
+        ), pytest.raises(ValueError, match="cannot be serialized to TOML"):
+            save_config({"key": "val"}, path)
+
+    def test_toml_write_generic_error(self, tmp_path):
+        """Generic exception during TOML serialization."""
+        path = tmp_path / "config.toml"
+        mock_toml = MagicMock()
+        mock_toml.dump.side_effect = RuntimeError("toml internal error")
+        with patch(
+            "navirl.config.serialization._import_toml_write",
+            return_value=mock_toml,
+        ), pytest.raises(ValueError, match="cannot be serialized to TOML"):
+            save_config({"key": "val"}, path)
+
+
+# ---------------------------------------------------------------------------
+# load_config error paths
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigErrors:
+    """Cover error branches in load_config."""
+
+    def test_json_read_os_error(self, tmp_path):
+        """OSError reading JSON file."""
+        path = tmp_path / "config.json"
+        path.write_text("{}")
+        with (
+            patch("builtins.open", side_effect=OSError("permission denied")),
+            pytest.raises(OSError, match="Cannot read JSON"),
+        ):
+            load_config(path)
+
+    def test_yaml_non_dict(self, tmp_path):
+        """YAML file containing non-dict should raise ValueError."""
+        path = tmp_path / "config.yaml"
+        path.write_text("- item1\n- item2\n")
+        with pytest.raises(ValueError, match="must contain a dictionary"):
+            load_config(path)
+
+    def test_yaml_read_os_error(self, tmp_path):
+        """OSError reading YAML file."""
+        path = tmp_path / "config.yaml"
+        path.write_text("key: val")
+        with patch("builtins.open", side_effect=OSError("read error")), patch(
+            "navirl.config.serialization._import_yaml",
+            return_value=MagicMock(),
+        ), pytest.raises(OSError, match="Cannot read YAML"):
+            load_config(path)
+
+    def test_yaml_read_value_error(self, tmp_path):
+        """ValueError reading YAML."""
+        path = tmp_path / "config.yaml"
+        path.write_text("key: val")
+        mock_yaml = MagicMock()
+        mock_yaml.safe_load.side_effect = ValueError("bad yaml")
+        with patch(
+            "navirl.config.serialization._import_yaml", return_value=mock_yaml
+        ), pytest.raises(ValueError, match="Invalid YAML"):
+            load_config(path)
+
+    def test_yaml_read_generic_yaml_error(self, tmp_path):
+        """Generic exception with 'yaml' in message during YAML read."""
+        path = tmp_path / "config.yaml"
+        path.write_text("key: val")
+        mock_yaml = MagicMock()
+        mock_yaml.safe_load.side_effect = RuntimeError("yaml parse failed")
+        with patch(
+            "navirl.config.serialization._import_yaml", return_value=mock_yaml
+        ), pytest.raises(ValueError, match="Invalid YAML"):
+            load_config(path)
+
+    def test_yaml_read_generic_non_yaml_error(self, tmp_path):
+        """Generic exception without 'yaml' in message during YAML read."""
+        path = tmp_path / "config.yaml"
+        path.write_text("key: val")
+        mock_yaml = MagicMock()
+        mock_yaml.safe_load.side_effect = RuntimeError("unknown failure")
+        with patch(
+            "navirl.config.serialization._import_yaml", return_value=mock_yaml
+        ), pytest.raises(OSError, match="Cannot read YAML"):
+            load_config(path)
+
+    def test_toml_non_dict(self, tmp_path):
+        """TOML loader returning non-dict should raise ValueError."""
+        path = tmp_path / "config.toml"
+        path.write_bytes(b"key = 'val'")
+        mock_loader = MagicMock(return_value=["not", "a", "dict"])
+        with patch(
+            "navirl.config.serialization._import_toml_read",
+            return_value=mock_loader,
+        ), pytest.raises(ValueError, match="must contain a dictionary"):
+            load_config(path)
+
+    def test_toml_read_os_error(self, tmp_path):
+        """OSError reading TOML file."""
+        path = tmp_path / "config.toml"
+        path.write_bytes(b"key = 'val'")
+        with patch("builtins.open", side_effect=OSError("read error")), patch(
+            "navirl.config.serialization._import_toml_read",
+            return_value=MagicMock(),
+        ), pytest.raises(OSError, match="Cannot read TOML"):
+            load_config(path)
+
+    def test_toml_read_value_error(self, tmp_path):
+        """ValueError reading TOML."""
+        path = tmp_path / "config.toml"
+        path.write_bytes(b"key = 'val'")
+        mock_loader = MagicMock(side_effect=ValueError("bad toml"))
+        with patch(
+            "navirl.config.serialization._import_toml_read",
+            return_value=mock_loader,
+        ), pytest.raises(ValueError, match="Invalid TOML"):
+            load_config(path)
+
+    def test_toml_read_generic_toml_error(self, tmp_path):
+        """Generic exception with 'toml' in message during TOML read."""
+        path = tmp_path / "config.toml"
+        path.write_bytes(b"key = 'val'")
+        mock_loader = MagicMock(side_effect=RuntimeError("toml parse failed"))
+        with patch(
+            "navirl.config.serialization._import_toml_read",
+            return_value=mock_loader,
+        ), pytest.raises(ValueError, match="Invalid TOML"):
+            load_config(path)
+
+    def test_toml_read_generic_non_toml_error(self, tmp_path):
+        """Generic exception without 'toml' in message during TOML read."""
+        path = tmp_path / "config.toml"
+        path.write_bytes(b"key = 'val'")
+        mock_loader = MagicMock(side_effect=RuntimeError("unknown"))
+        with patch(
+            "navirl.config.serialization._import_toml_read",
+            return_value=mock_loader,
+        ), pytest.raises(OSError, match="Cannot read TOML"):
+            load_config(path)
+
+
+# ---------------------------------------------------------------------------
+# Import helpers
+# ---------------------------------------------------------------------------
+
+
+class TestImportHelpers:
+    """Cover import fallback chains."""
+
+    def test_import_yaml_missing(self):
+        """Missing yaml should raise ImportError."""
+        import sys
+
+        with patch.dict(sys.modules, {"yaml": None}), pytest.raises(
+            ImportError, match="PyYAML"
+        ):
+            _import_yaml()
+
+    def test_import_toml_write_fallback_to_toml(self):
+        """When tomli_w is missing, fall back to toml."""
+        import sys
+
+        mock_toml = MagicMock()
+        with patch.dict(
+            sys.modules, {"tomli_w": None, "toml": mock_toml}
+        ):
+            result = _import_toml_write()
+            assert result is mock_toml
+
+    def test_import_toml_write_all_missing(self):
+        """When all toml writers are missing, raise ImportError."""
+        import sys
+
+        with patch.dict(sys.modules, {"tomli_w": None, "toml": None}), pytest.raises(
+            ImportError, match="tomli-w or toml"
+        ):
+            _import_toml_write()
+
+    def test_import_toml_read_fallback_to_tomli(self):
+        """When tomllib is missing, fall back to tomli."""
+        import sys
+
+        mock_tomli = MagicMock()
+        with patch.dict(
+            sys.modules, {"tomllib": None, "tomli": mock_tomli}
+        ):
+            result = _import_toml_read()
+            assert result is mock_tomli.load
+
+    def test_import_toml_read_fallback_to_toml(self):
+        """When tomllib and tomli are missing, fall back to toml wrapper."""
+        import sys
+
+        mock_toml = MagicMock()
+        mock_toml.loads.return_value = {"key": "val"}
+        with patch.dict(
+            sys.modules, {"tomllib": None, "tomli": None, "toml": mock_toml}
+        ):
+            loader = _import_toml_read()
+            # The loader should be a wrapper function
+            assert callable(loader)
+            # Test the wrapper reads and decodes
+            mock_fh = MagicMock()
+            mock_fh.read.return_value = b'key = "val"'
+            loader(mock_fh)
+            mock_toml.loads.assert_called_once()
+
+    def test_import_toml_read_all_missing(self):
+        """When all toml readers are missing, raise ImportError."""
+        import sys
+
+        with patch.dict(
+            sys.modules, {"tomllib": None, "tomli": None, "toml": None}
+        ), pytest.raises(ImportError, match="tomllib"):
+            _import_toml_read()
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    """Cover remaining helper function branches."""
+
+    def test_resolve_existing_path_no_suffix_no_match(self, tmp_path):
+        """Path without suffix that doesn't match any extension returns as-is."""
+        path = tmp_path / "nonexistent"
+        result = _resolve_existing_path(path)
+        assert result == path
+
+    def test_normalize_output_path_unknown_format(self):
+        """Unknown format returns path unchanged."""
+        path = Path("config")
+        result = _normalize_output_path(path, "xml")
+        assert result == path
+
+    def test_flatten_bool_false_omitted(self):
+        """Boolean False values should be omitted from CLI args."""
+        out: list[str] = []
+        _flatten_to_args({"flag": False}, "--", "", out)
+        assert out == []
+
+    def test_auto_cast_yes_no(self):
+        assert _auto_cast("yes") is True
+        assert _auto_cast("no") is False
+        assert _auto_cast("null") is None
+
+    def test_cli_args_non_flag_skipped(self):
+        """Tokens not starting with -- should be skipped."""
+        result = cli_args_to_config(["positional", "--key", "val", "other"])
+        assert result == {"key": "val"}

--- a/tests/test_serialization_coverage.py
+++ b/tests/test_serialization_coverage.py
@@ -63,9 +63,11 @@ class TestSaveConfigErrors:
         """OSError writing YAML file."""
         path = tmp_path / "config.yaml"
         mock_yaml = MagicMock()
-        with patch("builtins.open", side_effect=OSError("disk full")), patch(
-            "navirl.config.serialization._import_yaml", return_value=mock_yaml
-        ), pytest.raises(OSError, match="Cannot write YAML"):
+        with (
+            patch("builtins.open", side_effect=OSError("disk full")),
+            patch("navirl.config.serialization._import_yaml", return_value=mock_yaml),
+            pytest.raises(OSError, match="Cannot write YAML"),
+        ):
             save_config({"key": "val"}, path)
 
     def test_yaml_write_value_error(self, tmp_path):
@@ -73,9 +75,10 @@ class TestSaveConfigErrors:
         path = tmp_path / "config.yaml"
         mock_yaml = MagicMock()
         mock_yaml.dump.side_effect = ValueError("bad value")
-        with patch(
-            "navirl.config.serialization._import_yaml", return_value=mock_yaml
-        ), pytest.raises(ValueError, match="cannot be serialized to YAML"):
+        with (
+            patch("navirl.config.serialization._import_yaml", return_value=mock_yaml),
+            pytest.raises(ValueError, match="cannot be serialized to YAML"),
+        ):
             save_config({"key": "val"}, path)
 
     def test_yaml_write_generic_error(self, tmp_path):
@@ -83,19 +86,24 @@ class TestSaveConfigErrors:
         path = tmp_path / "config.yaml"
         mock_yaml = MagicMock()
         mock_yaml.dump.side_effect = RuntimeError("yaml internal error")
-        with patch(
-            "navirl.config.serialization._import_yaml", return_value=mock_yaml
-        ), pytest.raises(ValueError, match="cannot be serialized to YAML"):
+        with (
+            patch("navirl.config.serialization._import_yaml", return_value=mock_yaml),
+            pytest.raises(ValueError, match="cannot be serialized to YAML"),
+        ):
             save_config({"key": "val"}, path)
 
     def test_toml_write_os_error(self, tmp_path):
         """OSError writing TOML file."""
         path = tmp_path / "config.toml"
         mock_toml = MagicMock()
-        with patch("builtins.open", side_effect=OSError("disk full")), patch(
-            "navirl.config.serialization._import_toml_write",
-            return_value=mock_toml,
-        ), pytest.raises(OSError, match="Cannot write TOML"):
+        with (
+            patch("builtins.open", side_effect=OSError("disk full")),
+            patch(
+                "navirl.config.serialization._import_toml_write",
+                return_value=mock_toml,
+            ),
+            pytest.raises(OSError, match="Cannot write TOML"),
+        ):
             save_config({"key": "val"}, path)
 
     def test_toml_write_type_error(self, tmp_path):
@@ -103,10 +111,13 @@ class TestSaveConfigErrors:
         path = tmp_path / "config.toml"
         mock_toml = MagicMock()
         mock_toml.dump.side_effect = TypeError("not serializable")
-        with patch(
-            "navirl.config.serialization._import_toml_write",
-            return_value=mock_toml,
-        ), pytest.raises(ValueError, match="cannot be serialized to TOML"):
+        with (
+            patch(
+                "navirl.config.serialization._import_toml_write",
+                return_value=mock_toml,
+            ),
+            pytest.raises(ValueError, match="cannot be serialized to TOML"),
+        ):
             save_config({"key": "val"}, path)
 
     def test_toml_write_generic_error(self, tmp_path):
@@ -114,10 +125,13 @@ class TestSaveConfigErrors:
         path = tmp_path / "config.toml"
         mock_toml = MagicMock()
         mock_toml.dump.side_effect = RuntimeError("toml internal error")
-        with patch(
-            "navirl.config.serialization._import_toml_write",
-            return_value=mock_toml,
-        ), pytest.raises(ValueError, match="cannot be serialized to TOML"):
+        with (
+            patch(
+                "navirl.config.serialization._import_toml_write",
+                return_value=mock_toml,
+            ),
+            pytest.raises(ValueError, match="cannot be serialized to TOML"),
+        ):
             save_config({"key": "val"}, path)
 
 
@@ -150,10 +164,14 @@ class TestLoadConfigErrors:
         """OSError reading YAML file."""
         path = tmp_path / "config.yaml"
         path.write_text("key: val")
-        with patch("builtins.open", side_effect=OSError("read error")), patch(
-            "navirl.config.serialization._import_yaml",
-            return_value=MagicMock(),
-        ), pytest.raises(OSError, match="Cannot read YAML"):
+        with (
+            patch("builtins.open", side_effect=OSError("read error")),
+            patch(
+                "navirl.config.serialization._import_yaml",
+                return_value=MagicMock(),
+            ),
+            pytest.raises(OSError, match="Cannot read YAML"),
+        ):
             load_config(path)
 
     def test_yaml_read_value_error(self, tmp_path):
@@ -162,9 +180,10 @@ class TestLoadConfigErrors:
         path.write_text("key: val")
         mock_yaml = MagicMock()
         mock_yaml.safe_load.side_effect = ValueError("bad yaml")
-        with patch(
-            "navirl.config.serialization._import_yaml", return_value=mock_yaml
-        ), pytest.raises(ValueError, match="Invalid YAML"):
+        with (
+            patch("navirl.config.serialization._import_yaml", return_value=mock_yaml),
+            pytest.raises(ValueError, match="Invalid YAML"),
+        ):
             load_config(path)
 
     def test_yaml_read_generic_yaml_error(self, tmp_path):
@@ -173,9 +192,10 @@ class TestLoadConfigErrors:
         path.write_text("key: val")
         mock_yaml = MagicMock()
         mock_yaml.safe_load.side_effect = RuntimeError("yaml parse failed")
-        with patch(
-            "navirl.config.serialization._import_yaml", return_value=mock_yaml
-        ), pytest.raises(ValueError, match="Invalid YAML"):
+        with (
+            patch("navirl.config.serialization._import_yaml", return_value=mock_yaml),
+            pytest.raises(ValueError, match="Invalid YAML"),
+        ):
             load_config(path)
 
     def test_yaml_read_generic_non_yaml_error(self, tmp_path):
@@ -184,9 +204,10 @@ class TestLoadConfigErrors:
         path.write_text("key: val")
         mock_yaml = MagicMock()
         mock_yaml.safe_load.side_effect = RuntimeError("unknown failure")
-        with patch(
-            "navirl.config.serialization._import_yaml", return_value=mock_yaml
-        ), pytest.raises(OSError, match="Cannot read YAML"):
+        with (
+            patch("navirl.config.serialization._import_yaml", return_value=mock_yaml),
+            pytest.raises(OSError, match="Cannot read YAML"),
+        ):
             load_config(path)
 
     def test_toml_non_dict(self, tmp_path):
@@ -194,20 +215,27 @@ class TestLoadConfigErrors:
         path = tmp_path / "config.toml"
         path.write_bytes(b"key = 'val'")
         mock_loader = MagicMock(return_value=["not", "a", "dict"])
-        with patch(
-            "navirl.config.serialization._import_toml_read",
-            return_value=mock_loader,
-        ), pytest.raises(ValueError, match="must contain a dictionary"):
+        with (
+            patch(
+                "navirl.config.serialization._import_toml_read",
+                return_value=mock_loader,
+            ),
+            pytest.raises(ValueError, match="must contain a dictionary"),
+        ):
             load_config(path)
 
     def test_toml_read_os_error(self, tmp_path):
         """OSError reading TOML file."""
         path = tmp_path / "config.toml"
         path.write_bytes(b"key = 'val'")
-        with patch("builtins.open", side_effect=OSError("read error")), patch(
-            "navirl.config.serialization._import_toml_read",
-            return_value=MagicMock(),
-        ), pytest.raises(OSError, match="Cannot read TOML"):
+        with (
+            patch("builtins.open", side_effect=OSError("read error")),
+            patch(
+                "navirl.config.serialization._import_toml_read",
+                return_value=MagicMock(),
+            ),
+            pytest.raises(OSError, match="Cannot read TOML"),
+        ):
             load_config(path)
 
     def test_toml_read_value_error(self, tmp_path):
@@ -215,10 +243,13 @@ class TestLoadConfigErrors:
         path = tmp_path / "config.toml"
         path.write_bytes(b"key = 'val'")
         mock_loader = MagicMock(side_effect=ValueError("bad toml"))
-        with patch(
-            "navirl.config.serialization._import_toml_read",
-            return_value=mock_loader,
-        ), pytest.raises(ValueError, match="Invalid TOML"):
+        with (
+            patch(
+                "navirl.config.serialization._import_toml_read",
+                return_value=mock_loader,
+            ),
+            pytest.raises(ValueError, match="Invalid TOML"),
+        ):
             load_config(path)
 
     def test_toml_read_generic_toml_error(self, tmp_path):
@@ -226,10 +257,13 @@ class TestLoadConfigErrors:
         path = tmp_path / "config.toml"
         path.write_bytes(b"key = 'val'")
         mock_loader = MagicMock(side_effect=RuntimeError("toml parse failed"))
-        with patch(
-            "navirl.config.serialization._import_toml_read",
-            return_value=mock_loader,
-        ), pytest.raises(ValueError, match="Invalid TOML"):
+        with (
+            patch(
+                "navirl.config.serialization._import_toml_read",
+                return_value=mock_loader,
+            ),
+            pytest.raises(ValueError, match="Invalid TOML"),
+        ):
             load_config(path)
 
     def test_toml_read_generic_non_toml_error(self, tmp_path):
@@ -237,10 +271,13 @@ class TestLoadConfigErrors:
         path = tmp_path / "config.toml"
         path.write_bytes(b"key = 'val'")
         mock_loader = MagicMock(side_effect=RuntimeError("unknown"))
-        with patch(
-            "navirl.config.serialization._import_toml_read",
-            return_value=mock_loader,
-        ), pytest.raises(OSError, match="Cannot read TOML"):
+        with (
+            patch(
+                "navirl.config.serialization._import_toml_read",
+                return_value=mock_loader,
+            ),
+            pytest.raises(OSError, match="Cannot read TOML"),
+        ):
             load_config(path)
 
 
@@ -256,9 +293,7 @@ class TestImportHelpers:
         """Missing yaml should raise ImportError."""
         import sys
 
-        with patch.dict(sys.modules, {"yaml": None}), pytest.raises(
-            ImportError, match="PyYAML"
-        ):
+        with patch.dict(sys.modules, {"yaml": None}), pytest.raises(ImportError, match="PyYAML"):
             _import_yaml()
 
     def test_import_toml_write_fallback_to_toml(self):
@@ -266,9 +301,7 @@ class TestImportHelpers:
         import sys
 
         mock_toml = MagicMock()
-        with patch.dict(
-            sys.modules, {"tomli_w": None, "toml": mock_toml}
-        ):
+        with patch.dict(sys.modules, {"tomli_w": None, "toml": mock_toml}):
             result = _import_toml_write()
             assert result is mock_toml
 
@@ -276,8 +309,9 @@ class TestImportHelpers:
         """When all toml writers are missing, raise ImportError."""
         import sys
 
-        with patch.dict(sys.modules, {"tomli_w": None, "toml": None}), pytest.raises(
-            ImportError, match="tomli-w or toml"
+        with (
+            patch.dict(sys.modules, {"tomli_w": None, "toml": None}),
+            pytest.raises(ImportError, match="tomli-w or toml"),
         ):
             _import_toml_write()
 
@@ -286,9 +320,7 @@ class TestImportHelpers:
         import sys
 
         mock_tomli = MagicMock()
-        with patch.dict(
-            sys.modules, {"tomllib": None, "tomli": mock_tomli}
-        ):
+        with patch.dict(sys.modules, {"tomllib": None, "tomli": mock_tomli}):
             result = _import_toml_read()
             assert result is mock_tomli.load
 
@@ -298,9 +330,7 @@ class TestImportHelpers:
 
         mock_toml = MagicMock()
         mock_toml.loads.return_value = {"key": "val"}
-        with patch.dict(
-            sys.modules, {"tomllib": None, "tomli": None, "toml": mock_toml}
-        ):
+        with patch.dict(sys.modules, {"tomllib": None, "tomli": None, "toml": mock_toml}):
             loader = _import_toml_read()
             # The loader should be a wrapper function
             assert callable(loader)
@@ -314,9 +344,10 @@ class TestImportHelpers:
         """When all toml readers are missing, raise ImportError."""
         import sys
 
-        with patch.dict(
-            sys.modules, {"tomllib": None, "tomli": None, "toml": None}
-        ), pytest.raises(ImportError, match="tomllib"):
+        with (
+            patch.dict(sys.modules, {"tomllib": None, "tomli": None, "toml": None}),
+            pytest.raises(ImportError, match="tomllib"),
+        ):
             _import_toml_read()
 
 


### PR DESCRIPTION
## Summary
- **safety/constraints.py**: 74% → 99% — covers ProxemicsConstraint, BoundaryConstraint, ConstraintSet, AccelerationConstraint jerk limits, CollisionConstraint projection bisection
- **config/serialization.py**: 74% → 99% — covers all error paths (OSError, TypeError, ValueError), TOML/YAML import fallback chains, CLI argument edge cases
- **training/callbacks.py**: 75% → 99% — covers WandbCallback, TensorBoardCallback, ProgressBarCallback, VideoRecordCallback lifecycle and edge cases
- **training/parallel.py**: 73% → 80% — covers RunningMeanStd, VecNormalize, VecFrameStack, VecMonitor, and _worker subprocess function

## Test plan
- [x] All 110 new tests pass
- [x] Full suite: 4404 passed, 98 skipped, 2 xfailed
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)