### PR TITLE
feat: implement end_time/min_duration temporal constraints and validate custom conditions

### DIFF
--- a/navirl/routines/compiler.py
+++ b/navirl/routines/compiler.py
@@ -325,9 +325,7 @@ class RoutineCompiler:
                 raise ValueError("CUSTOM condition must have a 'handler' parameter")
             handler_name = condition.params["handler"]
             if handler_name not in self._custom_condition_handlers:
-                raise ValueError(
-                    f"CUSTOM condition handler '{handler_name}' is not registered"
-                )
+                raise ValueError(f"CUSTOM condition handler '{handler_name}' is not registered")
             handler = self._custom_condition_handlers[handler_name]
             predicate = handler(condition)
             return Condition(predicate)

--- a/navirl/routines/compiler.py
+++ b/navirl/routines/compiler.py
@@ -25,7 +25,14 @@ from navirl.models.behavior_tree import (
     Status,
     WaitInQueue,
 )
-from navirl.routines.schema import Branch, ConditionType, RoutineSpec, Task, TaskType
+from navirl.routines.schema import (
+    Branch,
+    ConditionType,
+    RoutineSpec,
+    Task,
+    TaskType,
+    TemporalConstraint,
+)
 from navirl.routines.schema import Condition as RoutineCondition
 
 
@@ -314,7 +321,13 @@ class RoutineCompiler:
             return AgentNearbyCondition(agent_id, distance)
 
         elif condition.type == ConditionType.CUSTOM:
+            if "handler" not in condition.params:
+                raise ValueError("CUSTOM condition must have a 'handler' parameter")
             handler_name = condition.params["handler"]
+            if handler_name not in self._custom_condition_handlers:
+                raise ValueError(
+                    f"CUSTOM condition handler '{handler_name}' is not registered"
+                )
             handler = self._custom_condition_handlers[handler_name]
             predicate = handler(condition)
             return Condition(predicate)
@@ -323,7 +336,7 @@ class RoutineCompiler:
             raise ValueError(f"Unsupported condition type: {condition.type}")
 
     def _apply_temporal_constraints(
-        self, node: Node, constraints, context: CompilationContext
+        self, node: Node, constraints: TemporalConstraint, context: CompilationContext
     ) -> Node:
         """Apply temporal constraints to a node.
 
@@ -335,10 +348,16 @@ class RoutineCompiler:
         Returns:
             A node with temporal constraints applied.
         """
-        if constraints.max_duration:
+        if constraints.min_duration is not None:
+            node = MinDurationDecorator(node, constraints.min_duration)
+
+        if constraints.max_duration is not None:
             node = TimeoutDecorator(node, constraints.max_duration)
 
-        if constraints.start_time:
+        if constraints.end_time is not None:
+            node = EndTimeDecorator(node, constraints.end_time)
+
+        if constraints.start_time is not None:
             node = DelayedStartDecorator(node, constraints.start_time)
 
         return node
@@ -632,6 +651,73 @@ class DelayedStartDecorator(Node):
         return self.child.tick(bb)
 
     def reset_state(self) -> None:
+        self.child.reset_state()
+
+
+class EndTimeDecorator(Node):
+    """Decorator that fails execution after a wall-clock end time."""
+
+    def __init__(self, child: Node, end_time: float) -> None:
+        self.child = child
+        self.end_time = end_time
+
+    def tick(self, bb: Blackboard) -> Status:
+        current_time = bb.metadata.get("sim_time", 0.0)
+
+        if current_time >= self.end_time:
+            return Status.FAILURE  # Past end time
+
+        return self.child.tick(bb)
+
+    def reset_state(self) -> None:
+        self.child.reset_state()
+
+
+class MinDurationDecorator(Node):
+    """Decorator that enforces a minimum execution time.
+
+    If the child succeeds before min_duration has elapsed, this decorator
+    keeps returning RUNNING until the minimum time is met, then returns SUCCESS.
+    """
+
+    def __init__(self, child: Node, min_duration: float) -> None:
+        self.child = child
+        self.min_duration = min_duration
+        self._start_time: float | None = None
+        self._child_done = False
+
+    def tick(self, bb: Blackboard) -> Status:
+        if self._start_time is None:
+            self._start_time = bb.metadata.get("sim_time", 0.0)
+
+        current_time = bb.metadata.get("sim_time", 0.0)
+        elapsed = current_time - self._start_time
+
+        if not self._child_done:
+            result = self.child.tick(bb)
+            if result == Status.FAILURE:
+                return Status.FAILURE  # Propagate failure immediately
+            if result == Status.SUCCESS:
+                self._child_done = True
+
+        if elapsed >= self.min_duration:
+            if self._child_done:
+                return Status.SUCCESS
+            # min_duration met but child still running — delegate to child
+            return self.child.tick(bb)
+
+        # min_duration not yet met
+        if self._child_done:
+            # Child done but we need to wait — hold position
+            bb.pref_vx = 0.0
+            bb.pref_vy = 0.0
+            return Status.RUNNING
+
+        return Status.RUNNING
+
+    def reset_state(self) -> None:
+        self._start_time = None
+        self._child_done = False
         self.child.reset_state()
 
 

--- a/navirl/routines/schema.py
+++ b/navirl/routines/schema.py
@@ -110,6 +110,25 @@ class TemporalConstraint:
     max_duration: float | None = None
     min_duration: float | None = None
 
+    def __post_init__(self) -> None:
+        """Validate semantic consistency of temporal constraints."""
+        if (
+            self.start_time is not None
+            and self.end_time is not None
+            and self.start_time >= self.end_time
+        ):
+            raise ValueError(
+                f"start_time ({self.start_time}) must be less than end_time ({self.end_time})"
+            )
+        if (
+            self.min_duration is not None
+            and self.max_duration is not None
+            and self.min_duration > self.max_duration
+        ):
+            raise ValueError(
+                f"min_duration ({self.min_duration}) must not exceed max_duration ({self.max_duration})"
+            )
+
 
 @dataclass
 class RoutineSpec:

--- a/tests/test_routine_compiler.py
+++ b/tests/test_routine_compiler.py
@@ -17,9 +17,11 @@ from navirl.routines.behavior_integration import CompiledRoutineController, Rout
 from navirl.routines.compiler import (
     AgentNearbyCondition,
     AvoidArea,
+    EndTimeDecorator,
     GoToTarget,
     InteractAtLocation,
     LocationReachedCondition,
+    MinDurationDecorator,
     RoutineCompiler,
     TimeElapsedCondition,
     WaitForDuration,
@@ -669,3 +671,200 @@ class TestRoutineControllerFactory:
         assert isinstance(controller, CompiledRoutineController)
         assert len(controller.routines) == 2
         assert all(spec.loop for spec in controller.routines.values())
+
+
+class TestTemporalConstraintValidation:
+    """Tests for semantic validation of temporal constraints."""
+
+    def test_valid_constraints(self):
+        """Valid constraints should not raise."""
+        TemporalConstraint(start_time=0.0, end_time=10.0)
+        TemporalConstraint(min_duration=1.0, max_duration=5.0)
+        TemporalConstraint(start_time=0.0, end_time=10.0, min_duration=1.0, max_duration=5.0)
+
+    def test_start_time_after_end_time_raises(self):
+        with pytest.raises(ValueError, match="start_time.*must be less than end_time"):
+            TemporalConstraint(start_time=10.0, end_time=5.0)
+
+    def test_start_time_equals_end_time_raises(self):
+        with pytest.raises(ValueError, match="start_time.*must be less than end_time"):
+            TemporalConstraint(start_time=5.0, end_time=5.0)
+
+    def test_min_duration_exceeds_max_duration_raises(self):
+        with pytest.raises(ValueError, match="min_duration.*must not exceed max_duration"):
+            TemporalConstraint(min_duration=10.0, max_duration=5.0)
+
+    def test_equal_min_max_duration_allowed(self):
+        tc = TemporalConstraint(min_duration=5.0, max_duration=5.0)
+        assert tc.min_duration == 5.0
+        assert tc.max_duration == 5.0
+
+
+class TestEndTimeDecorator:
+    """Tests for the EndTimeDecorator."""
+
+    def _make_bb(self, sim_time: float) -> Blackboard:
+        agent = Mock()
+        agent.x, agent.y = 0.0, 0.0
+        agent.max_speed = 1.0
+        bb = Blackboard(agent=agent)
+        bb.neighbours = []
+        bb.metadata = {"sim_time": sim_time}
+        return bb
+
+    def test_before_end_time_delegates_to_child(self):
+        child = Mock()
+        child.tick.return_value = Status.RUNNING
+        node = EndTimeDecorator(child, end_time=10.0)
+        bb = self._make_bb(5.0)
+        assert node.tick(bb) == Status.RUNNING
+        child.tick.assert_called_once_with(bb)
+
+    def test_at_end_time_returns_failure(self):
+        child = Mock()
+        node = EndTimeDecorator(child, end_time=10.0)
+        bb = self._make_bb(10.0)
+        assert node.tick(bb) == Status.FAILURE
+        child.tick.assert_not_called()
+
+    def test_past_end_time_returns_failure(self):
+        child = Mock()
+        node = EndTimeDecorator(child, end_time=10.0)
+        bb = self._make_bb(15.0)
+        assert node.tick(bb) == Status.FAILURE
+        child.tick.assert_not_called()
+
+    def test_reset_resets_child(self):
+        child = Mock()
+        node = EndTimeDecorator(child, end_time=10.0)
+        node.reset_state()
+        child.reset_state.assert_called_once()
+
+
+class TestMinDurationDecorator:
+    """Tests for the MinDurationDecorator."""
+
+    def _make_bb(self, sim_time: float) -> Blackboard:
+        agent = Mock()
+        agent.x, agent.y = 0.0, 0.0
+        agent.max_speed = 1.0
+        bb = Blackboard(agent=agent)
+        bb.neighbours = []
+        bb.metadata = {"sim_time": sim_time}
+        bb.pref_vx = 1.0
+        bb.pref_vy = 1.0
+        return bb
+
+    def test_child_running_within_min_duration(self):
+        child = Mock()
+        child.tick.return_value = Status.RUNNING
+        node = MinDurationDecorator(child, min_duration=5.0)
+        bb = self._make_bb(0.0)
+        assert node.tick(bb) == Status.RUNNING
+
+    def test_child_succeeds_before_min_duration_holds(self):
+        child = Mock()
+        child.tick.return_value = Status.SUCCESS
+        node = MinDurationDecorator(child, min_duration=5.0)
+
+        bb = self._make_bb(0.0)
+        result = node.tick(bb)
+        assert result == Status.RUNNING  # Must wait for min_duration
+
+        # Now advance past min_duration
+        bb2 = self._make_bb(6.0)
+        result2 = node.tick(bb2)
+        assert result2 == Status.SUCCESS
+
+    def test_child_failure_propagates_immediately(self):
+        child = Mock()
+        child.tick.return_value = Status.FAILURE
+        node = MinDurationDecorator(child, min_duration=5.0)
+        bb = self._make_bb(0.0)
+        assert node.tick(bb) == Status.FAILURE
+
+    def test_child_succeeds_after_min_duration(self):
+        child = Mock()
+        child.tick.return_value = Status.SUCCESS
+        node = MinDurationDecorator(child, min_duration=1.0)
+        bb = self._make_bb(0.0)
+        node.tick(bb)  # Start timer at t=0, child succeeds
+
+        bb2 = self._make_bb(2.0)
+        assert node.tick(bb2) == Status.SUCCESS
+
+    def test_reset_clears_state(self):
+        child = Mock()
+        child.tick.return_value = Status.SUCCESS
+        node = MinDurationDecorator(child, min_duration=5.0)
+
+        bb = self._make_bb(0.0)
+        node.tick(bb)
+        node.reset_state()
+
+        assert node._start_time is None
+        assert node._child_done is False
+        child.reset_state.assert_called_once()
+
+
+class TestCustomConditionValidation:
+    """Tests for custom condition parameter validation in the compiler."""
+
+    def test_custom_condition_missing_handler_raises(self):
+        compiler = RoutineCompiler()
+        condition = Condition(ConditionType.CUSTOM, params={})
+        with pytest.raises(ValueError, match="must have a 'handler' parameter"):
+            compiler._compile_condition(condition)
+
+    def test_custom_condition_unregistered_handler_raises(self):
+        compiler = RoutineCompiler()
+        condition = Condition(ConditionType.CUSTOM, params={"handler": "nonexistent"})
+        with pytest.raises(ValueError, match="not registered"):
+            compiler._compile_condition(condition)
+
+
+class TestTemporalConstraintCompilation:
+    """Tests for full compilation with end_time and min_duration constraints."""
+
+    def test_compile_with_end_time(self):
+        spec = RoutineSpec(
+            id="test",
+            description="test",
+            tasks=[Task.go_to(1.0, 1.0)],
+            temporal_constraints=TemporalConstraint(end_time=100.0),
+        )
+        compiler = RoutineCompiler()
+        plan = compiler.compile(spec)
+        assert isinstance(plan.root_node, EndTimeDecorator)
+        assert plan.root_node.end_time == 100.0
+
+    def test_compile_with_min_duration(self):
+        spec = RoutineSpec(
+            id="test",
+            description="test",
+            tasks=[Task.go_to(1.0, 1.0)],
+            temporal_constraints=TemporalConstraint(min_duration=5.0),
+        )
+        compiler = RoutineCompiler()
+        plan = compiler.compile(spec)
+        assert isinstance(plan.root_node, MinDurationDecorator)
+        assert plan.root_node.min_duration == 5.0
+
+    def test_compile_with_all_temporal_constraints(self):
+        spec = RoutineSpec(
+            id="test",
+            description="test",
+            tasks=[Task.go_to(1.0, 1.0)],
+            temporal_constraints=TemporalConstraint(
+                start_time=1.0, end_time=100.0, min_duration=2.0, max_duration=50.0
+            ),
+        )
+        compiler = RoutineCompiler()
+        plan = compiler.compile(spec)
+        # Outermost should be DelayedStart (applied last)
+        from navirl.routines.compiler import DelayedStartDecorator, TimeoutDecorator
+
+        assert isinstance(plan.root_node, DelayedStartDecorator)
+        assert isinstance(plan.root_node.child, EndTimeDecorator)
+        assert isinstance(plan.root_node.child.child, TimeoutDecorator)
+        assert isinstance(plan.root_node.child.child.child, MinDurationDecorator)

--- a/tests/test_routine_compiler.py
+++ b/tests/test_routine_compiler.py
@@ -683,15 +683,15 @@ class TestTemporalConstraintValidation:
         TemporalConstraint(start_time=0.0, end_time=10.0, min_duration=1.0, max_duration=5.0)
 
     def test_start_time_after_end_time_raises(self):
-        with pytest.raises(ValueError, match="start_time.*must be less than end_time"):
+        with pytest.raises(ValueError, match=r"start_time.*must be less than end_time"):
             TemporalConstraint(start_time=10.0, end_time=5.0)
 
     def test_start_time_equals_end_time_raises(self):
-        with pytest.raises(ValueError, match="start_time.*must be less than end_time"):
+        with pytest.raises(ValueError, match=r"start_time.*must be less than end_time"):
             TemporalConstraint(start_time=5.0, end_time=5.0)
 
     def test_min_duration_exceeds_max_duration_raises(self):
-        with pytest.raises(ValueError, match="min_duration.*must not exceed max_duration"):
+        with pytest.raises(ValueError, match=r"min_duration.*must not exceed max_duration"):
             TemporalConstraint(min_duration=10.0, max_duration=5.0)
 
     def test_equal_min_max_duration_allowed(self):


### PR DESCRIPTION
## Summary
- **EndTimeDecorator**: new behavior tree decorator that fails execution past a wall-clock end time — `end_time` field on `TemporalConstraint` was previously parsed/serialized but never compiled
- **MinDurationDecorator**: new decorator ensuring minimum execution time before reporting success — `min_duration` was also unused
- **Custom condition validation**: `_compile_condition` now validates `handler` key exists and is registered before dict access, preventing `KeyError` at runtime
- **Semantic validation**: `TemporalConstraint.__post_init__` rejects `start_time >= end_time` and `min_duration > max_duration`
- **Type annotation fix**: `_apply_temporal_constraints` parameter typed as `TemporalConstraint`

## Test plan
- [x] 44 routine compiler tests pass (19 new)
- [x] 81 total routine tests pass (coverage, performance, security)
- [x] 206 broader tests pass
- [x] `python -c "from navirl.routines.compiler import RoutineCompiler, EndTimeDecorator, MinDurationDecorator; print('OK')"` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)