### PR TITLE
test: add 188 tests for 6 under-tested modules

### DIFF
--- a/tests/test_grid_map.py
+++ b/tests/test_grid_map.py
@@ -1,0 +1,509 @@
+"""Tests for navirl.maps.grid_map module."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# The navirl.maps package __init__ imports map_utils which may not exist;
+# load the submodule directly from its file path to avoid the cascade.
+_spec = importlib.util.spec_from_file_location(
+    "navirl.maps.grid_map",
+    Path(__file__).resolve().parent.parent / "navirl" / "maps" / "grid_map.py",
+)
+_grid_map = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _grid_map
+_spec.loader.exec_module(_grid_map)
+GridMap = _grid_map.GridMap
+FREE = _grid_map.FREE
+OCCUPIED = _grid_map.OCCUPIED
+UNKNOWN = _grid_map.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Construction & properties
+# ---------------------------------------------------------------------------
+
+
+class TestGridMapConstruction:
+    def test_default_values(self):
+        gm = GridMap()
+        assert gm.width == 100
+        assert gm.height == 100
+        assert gm.resolution == 0.1
+        assert np.array_equal(gm.origin, [0.0, 0.0])
+        assert gm.data.shape == (100, 100)
+        assert np.all(gm.data == FREE)
+
+    def test_custom_values(self):
+        gm = GridMap(50, 30, 0.05, (1.0, 2.0), OCCUPIED)
+        assert gm.width == 50
+        assert gm.height == 30
+        assert gm.resolution == 0.05
+        assert np.allclose(gm.origin, [1.0, 2.0])
+        assert np.all(gm.data == OCCUPIED)
+
+    def test_world_dimensions(self):
+        gm = GridMap(200, 100, 0.05)
+        assert gm.world_width == pytest.approx(10.0)
+        assert gm.world_height == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Coordinate transforms
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinateTransforms:
+    def test_world_to_grid_origin(self):
+        gm = GridMap(100, 100, 0.1)
+        r, c = gm.world_to_grid(0.0, 0.0)
+        assert r == 0
+        assert c == 0
+
+    def test_world_to_grid_interior(self):
+        gm = GridMap(100, 100, 0.1)
+        r, c = gm.world_to_grid(5.0, 3.0)
+        assert c == 50
+        assert r == 30
+
+    def test_world_to_grid_clips_negative(self):
+        gm = GridMap(100, 100, 0.1)
+        r, c = gm.world_to_grid(-10.0, -10.0)
+        assert r == 0
+        assert c == 0
+
+    def test_world_to_grid_clips_large(self):
+        gm = GridMap(100, 100, 0.1)
+        r, c = gm.world_to_grid(100.0, 100.0)
+        assert r == 99
+        assert c == 99
+
+    def test_grid_to_world_center(self):
+        gm = GridMap(100, 100, 0.1)
+        x, y = gm.grid_to_world(0, 0)
+        assert x == pytest.approx(0.05)
+        assert y == pytest.approx(0.05)
+
+    def test_world_to_grid_float(self):
+        gm = GridMap(100, 100, 0.1)
+        r, c = gm.world_to_grid_float(5.0, 3.0)
+        assert c == pytest.approx(50.0)
+        assert r == pytest.approx(30.0)
+
+    def test_roundtrip_transform(self):
+        gm = GridMap(100, 100, 0.1)
+        x_orig, y_orig = 3.25, 7.85
+        r, c = gm.world_to_grid(x_orig, y_orig)
+        x_back, y_back = gm.grid_to_world(r, c)
+        # Should be within one cell of original
+        assert abs(x_back - x_orig) < gm.resolution
+        assert abs(y_back - y_orig) < gm.resolution
+
+    def test_world_to_grid_with_offset_origin(self):
+        gm = GridMap(100, 100, 0.1, (-5.0, -5.0))
+        r, c = gm.world_to_grid(0.0, 0.0)
+        assert c == 50
+        assert r == 50
+
+
+# ---------------------------------------------------------------------------
+# Bounds checking
+# ---------------------------------------------------------------------------
+
+
+class TestBoundsChecking:
+    def test_in_bounds_valid(self):
+        gm = GridMap(10, 10)
+        assert gm.in_bounds(0, 0)
+        assert gm.in_bounds(9, 9)
+        assert gm.in_bounds(5, 5)
+
+    def test_in_bounds_invalid(self):
+        gm = GridMap(10, 10)
+        assert not gm.in_bounds(-1, 0)
+        assert not gm.in_bounds(0, -1)
+        assert not gm.in_bounds(10, 0)
+        assert not gm.in_bounds(0, 10)
+
+
+# ---------------------------------------------------------------------------
+# Cell access
+# ---------------------------------------------------------------------------
+
+
+class TestCellAccess:
+    def test_get_set(self):
+        gm = GridMap(10, 10)
+        gm.set(5, 5, OCCUPIED)
+        assert gm.get(5, 5) == OCCUPIED
+        assert gm.is_occupied(5, 5)
+        assert not gm.is_free(5, 5)
+
+    def test_get_out_of_bounds_returns_unknown(self):
+        gm = GridMap(10, 10)
+        assert gm.get(-1, 0) == UNKNOWN
+        assert gm.get(100, 100) == UNKNOWN
+
+    def test_set_out_of_bounds_no_op(self):
+        gm = GridMap(10, 10)
+        gm.set(-1, 0, OCCUPIED)  # Should not crash
+
+    def test_set_world_get_world(self):
+        gm = GridMap(100, 100, 0.1)
+        gm.set_world(3.0, 4.0, OCCUPIED)
+        assert gm.get_world(3.0, 4.0) == OCCUPIED
+
+    def test_is_free_default(self):
+        gm = GridMap(10, 10)
+        assert gm.is_free(0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Bresenham line
+# ---------------------------------------------------------------------------
+
+
+class TestBresenham:
+    def test_horizontal_line(self):
+        cells = GridMap.bresenham(0, 0, 0, 5)
+        assert len(cells) == 6
+        for r, _c in cells:
+            assert r == 0
+
+    def test_vertical_line(self):
+        cells = GridMap.bresenham(0, 0, 5, 0)
+        assert len(cells) == 6
+        for _r, c in cells:
+            assert c == 0
+
+    def test_diagonal_line(self):
+        cells = GridMap.bresenham(0, 0, 5, 5)
+        assert (0, 0) in cells
+        assert (5, 5) in cells
+        assert len(cells) >= 6
+
+    def test_single_point(self):
+        cells = GridMap.bresenham(3, 3, 3, 3)
+        assert cells == [(3, 3)]
+
+    def test_line_cells_world(self):
+        gm = GridMap(100, 100, 0.1)
+        cells = gm.line_cells(0.0, 0.0, 1.0, 0.0)
+        assert len(cells) > 1
+        # All on the same row
+        rows = {r for r, c in cells}
+        assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Ray casting
+# ---------------------------------------------------------------------------
+
+
+class TestRayCasting:
+    def test_ray_hits_wall(self):
+        gm = GridMap(100, 100, 0.1)
+        # Place a wall at column 50 (x = 5.0)
+        for r in range(100):
+            gm.set(r, 50, OCCUPIED)
+
+        dist, (hr, hc) = gm.ray_cast(0.0, 5.0, 0.0, max_range=10.0)  # East
+        assert dist < 10.0
+        assert hc == 50
+
+    def test_ray_misses(self):
+        gm = GridMap(100, 100, 0.1)
+        dist, hit = gm.ray_cast(5.0, 5.0, 0.0, max_range=2.0)
+        assert dist == 2.0
+        assert hit == (-1, -1)
+
+    def test_ray_cast_fan(self):
+        gm = GridMap(100, 100, 0.1)
+        results = gm.ray_cast_fan(5.0, 5.0, 0.0, math.pi, n_rays=5, max_range=3.0)
+        assert len(results) == 5
+        for angle, _dist, _hit_x in results:
+            assert 0.0 <= angle <= math.pi + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Flood fill
+# ---------------------------------------------------------------------------
+
+
+class TestFloodFill:
+    def test_basic_fill(self):
+        gm = GridMap(10, 10)
+        filled = gm.flood_fill(0, 0, OCCUPIED)
+        assert filled == 100  # Entire 10x10 grid
+        assert np.all(gm.data == OCCUPIED)
+
+    def test_fill_blocked_by_wall(self):
+        gm = GridMap(10, 10)
+        # Create a wall dividing the grid
+        for r in range(10):
+            gm.set(r, 5, OCCUPIED)
+        filled = gm.flood_fill(0, 0, 2)
+        # Should fill left half minus the wall
+        assert filled == 50
+
+    def test_fill_same_value_no_op(self):
+        gm = GridMap(10, 10)
+        filled = gm.flood_fill(0, 0, FREE)
+        assert filled == 0
+
+    def test_fill_out_of_bounds(self):
+        gm = GridMap(10, 10)
+        filled = gm.flood_fill(-1, -1, OCCUPIED)
+        assert filled == 0
+
+    def test_connected_component(self):
+        gm = GridMap(10, 10)
+        for r in range(10):
+            gm.set(r, 5, OCCUPIED)
+        mask = gm.connected_component(0, 0)
+        assert mask[0, 0]
+        assert mask[0, 4]
+        assert not mask[0, 5]  # Wall
+        assert not mask[0, 6]  # Other side
+
+    def test_connected_component_out_of_bounds(self):
+        gm = GridMap(10, 10)
+        mask = gm.connected_component(-1, -1)
+        assert not mask.any()
+
+
+# ---------------------------------------------------------------------------
+# Distance transform
+# ---------------------------------------------------------------------------
+
+
+class TestDistanceTransform:
+    def test_no_obstacles(self):
+        gm = GridMap(5, 5)
+        dt = gm.distance_transform()
+        assert np.all(dt == np.inf)
+
+    def test_single_obstacle(self):
+        gm = GridMap(5, 5)
+        gm.set(2, 2, OCCUPIED)
+        dt = gm.distance_transform()
+        assert dt[2, 2] == 0.0
+        assert dt[2, 3] == 1.0
+        assert dt[3, 2] == 1.0
+        assert dt[0, 2] == 2.0
+
+    def test_world_distance_transform(self):
+        gm = GridMap(5, 5, 0.5)
+        gm.set(2, 2, OCCUPIED)
+        dt = gm.distance_transform_world()
+        assert dt[2, 2] == 0.0
+        assert dt[2, 3] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Inflation
+# ---------------------------------------------------------------------------
+
+
+class TestInflation:
+    def test_inflate_single_cell(self):
+        gm = GridMap(20, 20, 0.1)
+        gm.set(10, 10, OCCUPIED)
+        inflated = gm.inflate(0.2)  # 2 cells radius
+        assert inflated.is_occupied(10, 10)
+        assert inflated.is_occupied(10, 11)
+        assert inflated.is_occupied(11, 10)
+        assert inflated.count_occupied() > 1
+
+    def test_inflate_preserves_original(self):
+        gm = GridMap(20, 20, 0.1)
+        gm.set(10, 10, OCCUPIED)
+        original_count = gm.count_occupied()
+        _ = gm.inflate(0.2)
+        assert gm.count_occupied() == original_count
+
+    def test_inflate_inplace(self):
+        gm = GridMap(20, 20, 0.1)
+        gm.set(10, 10, OCCUPIED)
+        gm.inflate_inplace(0.2)
+        assert gm.count_occupied() > 1
+
+
+# ---------------------------------------------------------------------------
+# Map merging
+# ---------------------------------------------------------------------------
+
+
+class TestMapMerging:
+    def test_merge_overwrite(self):
+        gm1 = GridMap(10, 10)
+        gm2 = GridMap(10, 10, default_value=UNKNOWN)
+        gm2.set(5, 5, OCCUPIED)
+        gm1.merge(gm2, mode="overwrite")
+        assert gm1.is_occupied(5, 5)
+        # Unknown cells shouldn't overwrite
+        assert gm1.is_free(0, 0)
+
+    def test_merge_max(self):
+        gm1 = GridMap(10, 10)
+        gm2 = GridMap(10, 10)
+        gm2.set(5, 5, OCCUPIED)
+        gm1.merge(gm2, mode="max")
+        assert gm1.is_occupied(5, 5)
+
+    def test_merge_min(self):
+        gm1 = GridMap(10, 10, default_value=OCCUPIED)
+        gm2 = GridMap(10, 10)
+        gm1.merge(gm2, mode="min")
+        assert gm1.is_free(0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Submap
+# ---------------------------------------------------------------------------
+
+
+class TestSubmap:
+    def test_basic_submap(self):
+        gm = GridMap(20, 20, 0.1)
+        gm.set(5, 5, OCCUPIED)
+        sub = gm.submap(0, 0, 10, 10)
+        assert sub.width == 10
+        assert sub.height == 10
+        assert sub.is_occupied(5, 5)
+
+    def test_submap_empty(self):
+        gm = GridMap(20, 20, 0.1)
+        sub = gm.submap(5, 5, 3, 3)  # end < start
+        assert sub.width == 0
+        assert sub.height == 0
+
+    def test_submap_world(self):
+        gm = GridMap(100, 100, 0.1)
+        gm.set_world(3.0, 4.0, OCCUPIED)
+        sub = gm.submap_world(2.0, 3.0, 4.0, 5.0)
+        assert sub.width > 0
+        assert sub.height > 0
+
+
+# ---------------------------------------------------------------------------
+# Drawing
+# ---------------------------------------------------------------------------
+
+
+class TestDrawing:
+    def test_draw_line(self):
+        gm = GridMap(100, 100, 0.1)
+        gm.draw_line(0.0, 0.0, 5.0, 0.0)
+        assert gm.count_occupied() > 0
+
+    def test_draw_rect_filled(self):
+        gm = GridMap(100, 100, 0.1)
+        gm.draw_rect(1.0, 1.0, 2.0, 2.0, filled=True)
+        assert gm.count_occupied() > 0
+
+    def test_draw_rect_outline(self):
+        gm = GridMap(100, 100, 0.1)
+        gm.draw_rect(1.0, 1.0, 2.0, 2.0, filled=False)
+        assert gm.count_occupied() > 0
+
+    def test_draw_circle_filled(self):
+        gm = GridMap(100, 100, 0.1)
+        gm.draw_circle(5.0, 5.0, 1.0, filled=True)
+        occ = gm.count_occupied()
+        assert occ > 0
+        # Approximate area check: pi * r^2 / resolution^2
+        expected_cells = math.pi * (1.0 / 0.1) ** 2
+        assert abs(occ - expected_cells) / expected_cells < 0.3
+
+    def test_draw_circle_outline(self):
+        gm = GridMap(100, 100, 0.1)
+        gm.draw_circle(5.0, 5.0, 1.0, filled=False)
+        assert gm.count_occupied() > 0
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+
+class TestStatistics:
+    def test_counts_default(self):
+        gm = GridMap(10, 10)
+        assert gm.count_free() == 100
+        assert gm.count_occupied() == 0
+        assert gm.count_unknown() == 0
+
+    def test_occupancy_ratio(self):
+        gm = GridMap(10, 10)
+        for c in range(5):
+            gm.set(0, c, OCCUPIED)
+        ratio = gm.occupancy_ratio()
+        assert ratio == pytest.approx(5.0 / 100.0)
+
+    def test_occupancy_ratio_all_unknown(self):
+        gm = GridMap(10, 10, default_value=UNKNOWN)
+        assert gm.occupancy_ratio() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Copy, clear, interop
+# ---------------------------------------------------------------------------
+
+
+class TestCopyAndInterop:
+    def test_copy_is_independent(self):
+        gm = GridMap(10, 10)
+        gm.set(0, 0, OCCUPIED)
+        gm2 = gm.copy()
+        gm2.set(0, 0, FREE)
+        assert gm.is_occupied(0, 0)
+        assert gm2.is_free(0, 0)
+
+    def test_clear(self):
+        gm = GridMap(10, 10)
+        gm.set(5, 5, OCCUPIED)
+        gm.clear()
+        assert np.all(gm.data == FREE)
+
+    def test_clear_with_value(self):
+        gm = GridMap(10, 10)
+        gm.clear(UNKNOWN)
+        assert np.all(gm.data == UNKNOWN)
+
+    def test_as_binary(self):
+        gm = GridMap(10, 10)
+        gm.set(5, 5, OCCUPIED)
+        binary = gm.as_binary()
+        assert binary[5, 5]
+        assert not binary[0, 0]
+
+    def test_as_float(self):
+        gm = GridMap(10, 10)
+        gm.set(0, 0, OCCUPIED)
+        gm.set(1, 1, UNKNOWN)
+        flt = gm.as_float()
+        assert flt[0, 0] == pytest.approx(1.0)
+        assert flt[1, 1] == pytest.approx(0.5)
+        assert flt[2, 2] == pytest.approx(0.0)
+
+    def test_from_array(self):
+        arr = np.zeros((10, 10))
+        arr[5, 5] = 1.0
+        gm = GridMap.from_array(arr, resolution=0.2)
+        assert gm.width == 10
+        assert gm.height == 10
+        assert gm.is_occupied(5, 5)
+        assert gm.is_free(0, 0)
+
+    def test_repr(self):
+        gm = GridMap(10, 10)
+        s = repr(gm)
+        assert "GridMap" in s
+        assert "10x10" in s

--- a/tests/test_navigation_rewards.py
+++ b/tests/test_navigation_rewards.py
@@ -1,0 +1,483 @@
+"""Tests for navirl.rewards.navigation module."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Import the submodule directly from file to avoid the package __init__
+# which tries to import navirl.rewards.learned (may not exist).
+# First ensure the base module is loadable.
+_base_path = Path(__file__).resolve().parent.parent / "navirl" / "rewards" / "base.py"
+_base_spec = importlib.util.spec_from_file_location("navirl.rewards.base", _base_path)
+if "navirl.rewards.base" not in sys.modules:
+    _base_mod = importlib.util.module_from_spec(_base_spec)
+    sys.modules[_base_spec.name] = _base_mod
+    _base_spec.loader.exec_module(_base_mod)
+
+_nav_path = Path(__file__).resolve().parent.parent / "navirl" / "rewards" / "navigation.py"
+_nav_spec = importlib.util.spec_from_file_location("navirl.rewards.navigation", _nav_path)
+_nav = importlib.util.module_from_spec(_nav_spec)
+sys.modules[_nav_spec.name] = _nav
+_nav_spec.loader.exec_module(_nav)
+BoundaryPenalty = _nav.BoundaryPenalty
+CollisionPenalty = _nav.CollisionPenalty
+GoalReward = _nav.GoalReward
+PathFollowingReward = _nav.PathFollowingReward
+ProgressReward = _nav.ProgressReward
+SmoothnessReward = _nav.SmoothnessReward
+TimePenaltyReward = _nav.TimePenaltyReward
+VelocityReward = _nav.VelocityReward
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _state(pos=(0.0, 0.0), goal=(10.0, 0.0), vel=(1.0, 0.0), **kw):
+    """Build a minimal state dict."""
+    s = {"position": np.array(pos), "goal": np.array(goal), "velocity": np.array(vel)}
+    s.update(kw)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# GoalReward
+# ---------------------------------------------------------------------------
+
+
+class TestGoalReward:
+    def test_sparse_not_at_goal(self):
+        r = GoalReward(mode="sparse", threshold=0.3)
+        s1 = _state(pos=(0, 0))
+        s2 = _state(pos=(5, 0))
+        assert r.compute(s1, None, s2) == 0.0
+
+    def test_sparse_at_goal(self):
+        r = GoalReward(mode="sparse", threshold=0.5, success_reward=10.0)
+        s1 = _state(pos=(0, 0))
+        s2 = _state(pos=(9.8, 0), goal=(10, 0))
+        assert r.compute(s1, None, s2) == 10.0
+
+    def test_dense_reward_closer_is_better(self):
+        r = GoalReward(mode="dense", max_distance=10.0, dense_scale=1.0)
+        close = r.compute(_state(), None, _state(pos=(8, 0)))
+        far = r.compute(_state(), None, _state(pos=(2, 0)))
+        assert close > far
+
+    def test_shaped_first_step_no_progress(self):
+        r = GoalReward(mode="shaped")
+        r.reset()
+        # First step: no previous distance cached
+        v = r.compute(_state(), None, _state(pos=(5, 0)))
+        # _prev_distance was None, so only arrival bonus if within threshold
+        assert isinstance(v, float)
+
+    def test_shaped_progress(self):
+        r = GoalReward(mode="shaped", shaped_scale=1.0, success_reward=0.0)
+        r.reset()
+        r.compute(_state(), None, _state(pos=(0, 0)))  # prime
+        v = r.compute(_state(), None, _state(pos=(5, 0)))  # closer to goal at (10,0)
+        assert v > 0  # Made progress
+
+    def test_shaped_regression(self):
+        r = GoalReward(mode="shaped", shaped_scale=1.0, success_reward=0.0)
+        r.reset()
+        r.compute(_state(), None, _state(pos=(5, 0)))  # prime at d=5
+        v = r.compute(_state(), None, _state(pos=(0, 0)))  # farther from goal at d=10
+        assert v < 0
+
+    def test_invalid_mode(self):
+        with pytest.raises(ValueError, match="mode must be"):
+            GoalReward(mode="invalid")
+
+    def test_reset_clears_state(self):
+        r = GoalReward(mode="shaped")
+        r.compute(_state(), None, _state())
+        r.reset()
+        assert r._prev_distance is None
+
+
+# ---------------------------------------------------------------------------
+# PathFollowingReward
+# ---------------------------------------------------------------------------
+
+
+class TestPathFollowingReward:
+    def test_no_path_returns_zero(self):
+        r = PathFollowingReward()
+        assert r.compute(_state(), None, _state()) == 0.0
+
+    def test_on_path_high_reward(self):
+        path = [(0, 0), (10, 0)]
+        r = PathFollowingReward(path=path, tolerance=1.0, scale=1.0)
+        v = r.compute(_state(), None, _state(pos=(5, 0)))
+        assert v > 0.5
+
+    def test_far_from_path_low_reward(self):
+        path = [(0, 0), (10, 0)]
+        r = PathFollowingReward(path=path, tolerance=0.5, falloff=2.0, scale=1.0)
+        v = r.compute(_state(), None, _state(pos=(5, 10)))
+        assert v < 0.1
+
+    def test_advance_bonus(self):
+        path = [(0, 0), (5, 0), (10, 0)]
+        r = PathFollowingReward(path=path, advance_bonus=1.0)
+        r.compute(_state(), None, _state(pos=(0, 0)))  # seg 0
+        v2 = r.compute(_state(), None, _state(pos=(7.5, 0)))  # seg 1
+        assert v2 > r.compute(_state(), None, _state(pos=(2.5, 0)))
+
+    def test_invalid_path_shape(self):
+        with pytest.raises(ValueError, match="shape"):
+            PathFollowingReward(path=[(0,), (1,)])
+
+    def test_too_few_waypoints(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            PathFollowingReward(path=[(0, 0)])
+
+    def test_set_path(self):
+        r = PathFollowingReward()
+        r.set_path([(0, 0), (10, 0)])
+        assert r._path is not None
+
+    def test_reset(self):
+        r = PathFollowingReward(path=[(0, 0), (10, 0)])
+        r._furthest_segment = 5
+        r.reset()
+        assert r._furthest_segment == 0
+
+    def test_point_segment_distance(self):
+        p = np.array([1.0, 1.0])
+        a = np.array([0.0, 0.0])
+        b = np.array([2.0, 0.0])
+        d = PathFollowingReward._point_segment_distance(p, a, b)
+        assert d == pytest.approx(1.0)
+
+    def test_point_segment_distance_degenerate(self):
+        p = np.array([1.0, 1.0])
+        a = np.array([0.0, 0.0])
+        b = np.array([0.0, 0.0])  # zero-length segment
+        d = PathFollowingReward._point_segment_distance(p, a, b)
+        assert d == pytest.approx(math.sqrt(2))
+
+
+# ---------------------------------------------------------------------------
+# TimePenaltyReward
+# ---------------------------------------------------------------------------
+
+
+class TestTimePenaltyReward:
+    def test_constant_penalty(self):
+        r = TimePenaltyReward(penalty=-0.1)
+        assert r.compute(_state(), None, _state()) == pytest.approx(-0.1)
+
+    def test_positive_penalty_is_negated(self):
+        r = TimePenaltyReward(penalty=0.1)
+        assert r.compute(_state(), None, _state()) == pytest.approx(-0.1)
+
+    def test_dt_scaling(self):
+        r = TimePenaltyReward(penalty=-1.0, use_dt=True)
+        s = _state(dt=0.04)
+        v = r.compute(s, None, _state())
+        assert v == pytest.approx(-0.04)
+
+    def test_max_cumulative(self):
+        r = TimePenaltyReward(penalty=-1.0, max_cumulative=2.0)
+        r.compute(_state(), None, _state())  # -1.0
+        r.compute(_state(), None, _state())  # -2.0, at limit
+        v = r.compute(_state(), None, _state())
+        assert v == 0.0  # Capped
+
+    def test_reset(self):
+        r = TimePenaltyReward(penalty=-1.0, max_cumulative=1.0)
+        r.compute(_state(), None, _state())
+        r.reset()
+        # Should be able to accumulate again
+        v = r.compute(_state(), None, _state())
+        assert v == pytest.approx(-1.0)
+
+
+# ---------------------------------------------------------------------------
+# CollisionPenalty
+# ---------------------------------------------------------------------------
+
+
+class TestCollisionPenalty:
+    def test_no_collisions(self):
+        r = CollisionPenalty()
+        s = _state(pos=(5, 5), pedestrians=[], obstacles=[])
+        assert r.compute(s, None, s) == 0.0
+
+    def test_pedestrian_collision(self):
+        r = CollisionPenalty(agent_radius=0.2, pedestrian_penalty=-10.0)
+        s = _state(
+            pos=(0, 0),
+            pedestrians=[{"position": [0.1, 0.0], "radius": 0.18}],
+        )
+        v = r.compute(_state(), None, s)
+        assert v == pytest.approx(-10.0)
+
+    def test_no_pedestrian_collision_when_far(self):
+        r = CollisionPenalty(agent_radius=0.2, pedestrian_penalty=-10.0)
+        s = _state(
+            pos=(0, 0),
+            pedestrians=[{"position": [5.0, 5.0], "radius": 0.18}],
+        )
+        assert r.compute(_state(), None, s) == 0.0
+
+    def test_obstacle_collision_dict(self):
+        r = CollisionPenalty(agent_radius=0.2, obstacle_penalty=-5.0)
+        s = _state(
+            pos=(0, 0),
+            obstacles=[{"position": [0.1, 0.0], "radius": 0.1}],
+        )
+        v = r.compute(_state(), None, s)
+        assert v == pytest.approx(-5.0)
+
+    def test_obstacle_collision_ndarray_points(self):
+        r = CollisionPenalty(agent_radius=0.5, obstacle_penalty=-5.0)
+        s = _state(
+            pos=(0, 0),
+            obstacles=np.array([[0.1, 0.0], [10.0, 10.0]]),
+        )
+        v = r.compute(_state(), None, s)
+        assert v == pytest.approx(-5.0)  # One collision
+
+    def test_obstacle_collision_ndarray_segments(self):
+        r = CollisionPenalty(agent_radius=0.5, obstacle_penalty=-5.0)
+        s = _state(
+            pos=(0, 0),
+            obstacles=np.array([[0.0, -1.0, 0.0, 1.0]]),  # line segment through origin
+        )
+        v = r.compute(_state(), None, s)
+        assert v == pytest.approx(-5.0)
+
+    def test_cumulative_mode(self):
+        r = CollisionPenalty(agent_radius=0.5, pedestrian_penalty=-10.0, cumulative=True)
+        s = _state(
+            pos=(0, 0),
+            pedestrians=[
+                {"position": [0.1, 0.0], "radius": 0.18},
+                {"position": [-0.1, 0.0], "radius": 0.18},
+            ],
+        )
+        v = r.compute(_state(), None, s)
+        assert v == pytest.approx(-20.0)
+
+    def test_non_cumulative_mode(self):
+        r = CollisionPenalty(agent_radius=0.5, pedestrian_penalty=-10.0, cumulative=False)
+        s = _state(
+            pos=(0, 0),
+            pedestrians=[
+                {"position": [0.1, 0.0], "radius": 0.18},
+                {"position": [-0.1, 0.0], "radius": 0.18},
+            ],
+        )
+        v = r.compute(_state(), None, s)
+        assert v == pytest.approx(-10.0)
+
+    def test_get_info(self):
+        r = CollisionPenalty(agent_radius=0.5, pedestrian_penalty=-10.0)
+        s = _state(
+            pos=(0, 0),
+            pedestrians=[{"position": [0.1, 0.0], "radius": 0.18}],
+        )
+        r.compute(_state(), None, s)
+        info = r.get_info()
+        assert info["n_collisions"] == 1
+
+
+# ---------------------------------------------------------------------------
+# ProgressReward
+# ---------------------------------------------------------------------------
+
+
+class TestProgressReward:
+    def test_first_step_returns_zero(self):
+        r = ProgressReward()
+        v = r.compute(_state(), None, _state(pos=(5, 0)))
+        assert v == 0.0
+
+    def test_progress_positive(self):
+        r = ProgressReward(scale=1.0, max_reward=10.0)
+        r.reset()
+        r.compute(_state(), None, _state(pos=(0, 0)))  # d=10
+        v = r.compute(_state(), None, _state(pos=(5, 0)))  # d=5, progress=5
+        assert v > 0
+
+    def test_regression_negative(self):
+        r = ProgressReward(scale=1.0, regression_scale=2.0)
+        r.reset()
+        r.compute(_state(), None, _state(pos=(5, 0)))  # d=5
+        v = r.compute(_state(), None, _state(pos=(0, 0)))  # d=10, regressed
+        assert v < 0
+
+    def test_distance_gain(self):
+        r = ProgressReward(scale=1.0, distance_gain=True)
+        r.reset()
+        r.compute(_state(), None, _state(pos=(9, 0), goal=(10, 0)))
+        v_near = r.compute(_state(), None, _state(pos=(9.5, 0), goal=(10, 0)))
+        r.reset()
+        r.compute(_state(), None, _state(pos=(0, 0), goal=(10, 0)))
+        v_far = r.compute(_state(), None, _state(pos=(0.5, 0), goal=(10, 0)))
+        # Progress near goal should be worth more
+        assert v_near > v_far
+
+    def test_max_reward_clamp(self):
+        r = ProgressReward(scale=100.0, max_reward=5.0)
+        r.reset()
+        r.compute(_state(), None, _state(pos=(0, 0)))
+        v = r.compute(_state(), None, _state(pos=(9, 0)))
+        assert abs(v) <= 5.0
+
+    def test_reset(self):
+        r = ProgressReward()
+        r.compute(_state(), None, _state())
+        r.reset()
+        assert r._prev_dist is None
+
+
+# ---------------------------------------------------------------------------
+# VelocityReward
+# ---------------------------------------------------------------------------
+
+
+class TestVelocityReward:
+    def test_at_target_speed(self):
+        r = VelocityReward(target_speed=1.0, tolerance=0.1, mode="penalty_only")
+        v = r.compute(_state(), None, _state(vel=(1.0, 0.0)))
+        assert v == pytest.approx(0.0)
+
+    def test_stopped_penalty(self):
+        r = VelocityReward(stop_threshold=0.05, stop_penalty=-0.5)
+        v = r.compute(_state(), None, _state(vel=(0.0, 0.0)))
+        assert v == pytest.approx(-0.5)
+
+    def test_too_fast_penalty(self):
+        r = VelocityReward(target_speed=1.0, tolerance=0.1, penalty_weight=1.0, mode="penalty_only")
+        v = r.compute(_state(), None, _state(vel=(3.0, 0.0)))
+        assert v < 0
+
+    def test_reward_match_mode(self):
+        r = VelocityReward(target_speed=1.0, mode="reward_match")
+        v_good = r.compute(_state(), None, _state(vel=(1.0, 0.0)))
+        v_bad = r.compute(_state(), None, _state(vel=(3.0, 0.0)))
+        assert v_good > v_bad
+
+    def test_speed_key(self):
+        r = VelocityReward(target_speed=1.0, tolerance=0.1, mode="penalty_only")
+        v = r.compute(_state(), None, {"speed": 1.0})
+        assert v == pytest.approx(0.0)
+
+    def test_invalid_mode(self):
+        with pytest.raises(ValueError):
+            VelocityReward(mode="bad")
+
+
+# ---------------------------------------------------------------------------
+# SmoothnessReward
+# ---------------------------------------------------------------------------
+
+
+class TestSmoothnessReward:
+    def test_constant_velocity_no_penalty(self):
+        r = SmoothnessReward(max_accel=2.0)
+        s1 = _state(vel=(1, 0), dt=0.1)
+        s2 = _state(vel=(1, 0), dt=0.1)
+        r.compute(s1, None, s1)  # prime
+        v = r.compute(s1, None, s2)
+        assert v == pytest.approx(0.0)
+
+    def test_high_accel_penalty(self):
+        r = SmoothnessReward(accel_weight=1.0, max_accel=1.0)
+        s1 = _state(vel=(0, 0), dt=0.1)
+        s2 = _state(vel=(10, 0), dt=0.1)
+        r.compute(s1, None, s1)  # prime
+        v = r.compute(s1, None, s2)
+        assert v < 0
+
+    def test_heading_penalty(self):
+        r = SmoothnessReward(heading_weight=1.0, max_heading_change=0.1)
+        s1 = _state(vel=(1, 0), heading=0.0, dt=0.1)
+        s2 = _state(vel=(1, 0), heading=math.pi, dt=0.1)
+        r.compute(_state(), None, s1)  # prime
+        v = r.compute(s1, None, s2)
+        assert v < 0
+
+    def test_linear_mode(self):
+        r = SmoothnessReward(accel_weight=1.0, max_accel=1.0, linear=True)
+        s1 = _state(vel=(0, 0), dt=0.1)
+        s2 = _state(vel=(5, 0), dt=0.1)
+        r.compute(s1, None, s1)
+        v = r.compute(s1, None, s2)
+        assert v < 0
+
+    def test_reset(self):
+        r = SmoothnessReward()
+        r.compute(_state(), None, _state(vel=(1, 0)))
+        r.reset()
+        assert r._prev_velocity is None
+        assert r._prev_heading is None
+
+    def test_angle_diff_wrapping(self):
+        d = SmoothnessReward._angle_diff(0.1, 2 * math.pi - 0.1)
+        assert abs(d) < 0.3  # Should wrap to ~0.2
+
+
+# ---------------------------------------------------------------------------
+# BoundaryPenalty
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryPenalty:
+    def test_well_inside_no_penalty(self):
+        r = BoundaryPenalty(x_min=0, x_max=10, y_min=0, y_max=10, margin=1.0)
+        v = r.compute(_state(), None, _state(pos=(5, 5)))
+        assert v == 0.0
+
+    def test_near_boundary_penalty(self):
+        r = BoundaryPenalty(x_min=0, x_max=10, y_min=0, y_max=10, margin=1.0, penalty_scale=1.0)
+        v = r.compute(_state(), None, _state(pos=(0.5, 5)))
+        assert v < 0
+
+    def test_outside_boundary_hard_penalty(self):
+        r = BoundaryPenalty(x_min=0, x_max=10, y_min=0, y_max=10, hard_penalty=-5.0)
+        v = r.compute(_state(), None, _state(pos=(-1, 5)))
+        assert v == pytest.approx(-5.0)
+
+    def test_circular_boundary(self):
+        r = BoundaryPenalty(center=(5, 5), radius=3.0, margin=1.0, hard_penalty=-5.0)
+        # Inside
+        v_in = r.compute(_state(), None, _state(pos=(5, 5)))
+        assert v_in == 0.0
+        # Outside
+        v_out = r.compute(_state(), None, _state(pos=(10, 10)))
+        assert v_out == pytest.approx(-5.0)
+
+    def test_quadratic_mode(self):
+        r = BoundaryPenalty(
+            x_min=0,
+            x_max=10,
+            y_min=0,
+            y_max=10,
+            margin=2.0,
+            mode="quadratic",
+            penalty_scale=1.0,
+        )
+        v = r.compute(_state(), None, _state(pos=(1.0, 5)))
+        assert v < 0
+
+    def test_invalid_mode(self):
+        with pytest.raises(ValueError):
+            BoundaryPenalty(mode="cubic")
+
+    def test_no_bounds_no_penalty(self):
+        r = BoundaryPenalty()
+        v = r.compute(_state(), None, _state(pos=(100, 100)))
+        assert v == 0.0

--- a/tests/test_pack_schema.py
+++ b/tests/test_pack_schema.py
@@ -1,0 +1,154 @@
+"""Tests for navirl.packs.schema module."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from navirl.packs.schema import (
+    PackManifest,
+    PackResult,
+    PackRunResult,
+    PackScenarioEntry,
+)
+
+# ---------------------------------------------------------------------------
+# PackScenarioEntry
+# ---------------------------------------------------------------------------
+
+
+class TestPackScenarioEntry:
+    def test_defaults(self):
+        e = PackScenarioEntry(id="test", path="test.yaml")
+        assert e.id == "test"
+        assert e.path == "test.yaml"
+        assert e.seeds == [42]
+
+    def test_custom_seeds(self):
+        e = PackScenarioEntry(id="test", path="test.yaml", seeds=[1, 2, 3])
+        assert e.seeds == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# PackManifest
+# ---------------------------------------------------------------------------
+
+
+class TestPackManifest:
+    def _manifest(self, n_scenarios=2, seeds_per=3):
+        entries = [
+            PackScenarioEntry(id=f"s{i}", path=f"s{i}.yaml", seeds=list(range(seeds_per)))
+            for i in range(n_scenarios)
+        ]
+        return PackManifest(
+            name="test-pack",
+            version="1.0",
+            description="Test pack",
+            scenarios=entries,
+            metrics=["success_rate"],
+        )
+
+    def test_total_runs(self):
+        m = self._manifest(n_scenarios=3, seeds_per=5)
+        assert m.total_runs == 15
+
+    def test_checksum_deterministic(self):
+        m1 = self._manifest()
+        m2 = self._manifest()
+        assert m1.checksum() == m2.checksum()
+
+    def test_checksum_changes_with_content(self):
+        m1 = self._manifest(n_scenarios=2)
+        m2 = self._manifest(n_scenarios=3)
+        assert m1.checksum() != m2.checksum()
+
+    def test_defaults(self):
+        m = PackManifest(name="test")
+        assert m.version == "1.0"
+        assert m.description == ""
+        assert m.scenarios == []
+        assert m.metrics == []
+        assert m.metadata == {}
+
+    def test_total_runs_empty(self):
+        m = PackManifest(name="empty")
+        assert m.total_runs == 0
+
+
+# ---------------------------------------------------------------------------
+# PackRunResult
+# ---------------------------------------------------------------------------
+
+
+class TestPackRunResult:
+    def test_defaults(self):
+        r = PackRunResult(entry_id="test", seed=42)
+        assert r.status == "completed"
+        assert r.error is None
+        assert r.metrics == {}
+
+
+# ---------------------------------------------------------------------------
+# PackResult
+# ---------------------------------------------------------------------------
+
+
+class TestPackResult:
+    def _result(self):
+        return PackResult(
+            manifest_name="test",
+            manifest_version="1.0",
+            manifest_checksum="abc123",
+            runs=[
+                PackRunResult(entry_id="s0", seed=0, metrics={"acc": 0.9, "loss": 0.1}),
+                PackRunResult(entry_id="s0", seed=1, metrics={"acc": 0.8, "loss": 0.2}),
+                PackRunResult(entry_id="s1", seed=0, metrics={"acc": 0.95}),
+                PackRunResult(entry_id="fail", seed=0, status="failed", error="boom"),
+            ],
+        )
+
+    def test_aggregate_basic(self):
+        r = self._result()
+        agg = r.aggregate(["acc", "loss"])
+        assert agg["acc"]["mean"] == pytest.approx((0.9 + 0.8 + 0.95) / 3)
+        assert agg["acc"]["min"] == pytest.approx(0.8)
+        assert agg["acc"]["max"] == pytest.approx(0.95)
+        # loss only has 2 values (s1/seed0 doesn't have loss)
+        assert agg["loss"]["mean"] == pytest.approx(0.15)
+
+    def test_aggregate_missing_metric(self):
+        r = self._result()
+        agg = r.aggregate(["nonexistent"])
+        assert math.isnan(agg["nonexistent"]["mean"])
+
+    def test_aggregate_excludes_failed(self):
+        r = self._result()
+        agg = r.aggregate(["acc"])
+        # Only 3 completed runs
+        assert agg["acc"]["mean"] == pytest.approx((0.9 + 0.8 + 0.95) / 3)
+
+    def test_to_dict(self):
+        r = self._result()
+        d = r.to_dict()
+        assert d["manifest_name"] == "test"
+        assert d["total_runs"] == 4
+        assert d["completed_runs"] == 3
+        assert d["failed_runs"] == 1
+        assert len(d["runs"]) == 4
+
+    def test_to_dict_run_structure(self):
+        r = self._result()
+        d = r.to_dict()
+        run = d["runs"][0]
+        assert "entry_id" in run
+        assert "seed" in run
+        assert "metrics" in run
+        assert "status" in run
+        assert "error" in run
+
+    def test_empty_result(self):
+        r = PackResult(manifest_name="x", manifest_version="1", manifest_checksum="c")
+        d = r.to_dict()
+        assert d["total_runs"] == 0
+        assert d["completed_runs"] == 0

--- a/tests/test_plugin_validation.py
+++ b/tests/test_plugin_validation.py
@@ -1,0 +1,317 @@
+"""Tests for navirl.core.plugin_validation module."""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from unittest.mock import MagicMock
+
+import pytest
+
+from navirl.core.plugin_validation import (
+    ConfigValidationError,
+    PluginPerformanceError,
+    PluginSecurityError,
+    PluginValidationError,
+    performance_monitor,
+    safe_plugin_call,
+    validate_controller_config,
+    validate_plugin_api_version,
+    validate_plugin_factory,
+    validate_plugin_interface,
+    validate_plugin_security,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+class BaseController(ABC):
+    @abstractmethod
+    def step(self): ...
+
+    @abstractmethod
+    def reset(self): ...
+
+
+class GoodController(BaseController):
+    def step(self):
+        return "step"
+
+    def reset(self):
+        return "reset"
+
+
+class BadController:
+    """Not a subclass of BaseController."""
+
+
+class PartialController(BaseController):
+    """Implements only one abstract method — but Python ABC mechanism
+    prevents instantiation; the class itself still has both methods from
+    the partial impl."""
+
+    def step(self):
+        return "step"
+
+    def reset(self):
+        return "reset"
+
+
+class DangerousController(BaseController):
+    """Has a dangerous method name."""
+
+    def step(self):
+        return "step"
+
+    def reset(self):
+        return "reset"
+
+    def exec(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# validate_plugin_interface
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePluginInterface:
+    def test_valid_plugin(self):
+        validate_plugin_interface(GoodController, BaseController, "good")
+
+    def test_not_a_class(self):
+        with pytest.raises(PluginValidationError, match="must be a class"):
+            validate_plugin_interface("not_a_class", BaseController, "bad")
+
+    def test_wrong_base(self):
+        with pytest.raises(PluginValidationError, match="must inherit"):
+            validate_plugin_interface(BadController, BaseController, "bad")
+
+
+# ---------------------------------------------------------------------------
+# validate_plugin_factory
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePluginFactory:
+    def test_valid_factory(self):
+        def factory(cfg):
+            return GoodController()
+
+        validate_plugin_factory(factory, "test")
+
+    def test_not_callable(self):
+        with pytest.raises(PluginValidationError, match="must be callable"):
+            validate_plugin_factory("not_callable", "test")
+
+    def test_no_params_warns(self, caplog):
+        def factory():
+            return GoodController()
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            validate_plugin_factory(factory, "test")
+        assert "no parameters" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# validate_controller_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateControllerConfig:
+    def test_none_returns_empty(self):
+        assert validate_controller_config(None, "test") == {}
+
+    def test_not_dict_raises(self):
+        with pytest.raises(ConfigValidationError, match="must be a dictionary"):
+            validate_controller_config("not_a_dict", "test")
+
+    def test_dangerous_key(self):
+        with pytest.raises(ConfigValidationError, match="dangerous key"):
+            validate_controller_config({"__class__": "evil"}, "test")
+
+    def test_valid_numeric_params(self):
+        cfg = {"goal_tolerance": 0.5, "max_speed": 1.5}
+        result = validate_controller_config(cfg, "test")
+        assert result["goal_tolerance"] == pytest.approx(0.5)
+        assert result["max_speed"] == pytest.approx(1.5)
+
+    def test_out_of_range_param(self):
+        with pytest.raises(ConfigValidationError, match="must be between"):
+            validate_controller_config({"max_speed": 100.0}, "test")
+
+    def test_non_numeric_param(self):
+        with pytest.raises(ConfigValidationError, match="must be numeric"):
+            validate_controller_config({"max_speed": "fast"}, "test")
+
+    def test_integer_conversion(self):
+        cfg = {"lookahead": 5}
+        result = validate_controller_config(cfg, "test")
+        assert result["lookahead"] == 5
+        assert isinstance(result["lookahead"], int)
+
+    def test_velocity_smoothing_bounds(self):
+        cfg = {"velocity_smoothing": 0.5}
+        result = validate_controller_config(cfg, "test")
+        assert result["velocity_smoothing"] == pytest.approx(0.5)
+
+    def test_extra_keys_preserved(self):
+        cfg = {"custom_key": "value", "max_speed": 1.0}
+        result = validate_controller_config(cfg, "test")
+        assert result["custom_key"] == "value"
+
+
+# ---------------------------------------------------------------------------
+# validate_plugin_security
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePluginSecurity:
+    def test_safe_plugin(self):
+        validate_plugin_security(GoodController, "good")
+
+    def test_dangerous_method(self):
+        with pytest.raises(PluginSecurityError, match="dangerous methods"):
+            validate_plugin_security(DangerousController, "dangerous")
+
+    def test_risky_imports_warning(self, caplog):
+        import logging
+
+        # Create a class in a module that has 'os' imported
+        # GoodController's module has 'abc' but not 'os'
+        with caplog.at_level(logging.WARNING):
+            validate_plugin_security(GoodController, "good")
+        # Should NOT warn for GoodController
+
+
+# ---------------------------------------------------------------------------
+# performance_monitor
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceMonitor:
+    def test_fast_function_no_warning(self, caplog):
+        import logging
+
+        @performance_monitor(max_time_s=1.0)
+        def fast():
+            return 42
+
+        with caplog.at_level(logging.WARNING):
+            result = fast()
+        assert result == 42
+        assert "took" not in caplog.text
+
+    def test_slow_function_warns(self, caplog):
+        import logging
+
+        @performance_monitor(max_time_s=0.001)
+        def slow():
+            time.sleep(0.01)
+            return 42
+
+        with caplog.at_level(logging.WARNING):
+            result = slow()
+        assert result == 42
+        assert "took" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# safe_plugin_call
+# ---------------------------------------------------------------------------
+
+
+class TestSafePluginCall:
+    def test_successful_call(self):
+        def method():
+            return 42
+
+        result = safe_plugin_call(method, plugin_name="test", method_name="test")
+        assert result == 42
+
+    def test_exception_wraps(self):
+        def method():
+            raise RuntimeError("boom")
+
+        with pytest.raises(PluginValidationError, match="failed"):
+            safe_plugin_call(method, plugin_name="test", method_name="test")
+
+    def test_timeout_exceeded(self):
+        def slow():
+            time.sleep(0.1)
+            return 42
+
+        with pytest.raises(PluginPerformanceError, match="exceeded timeout"):
+            safe_plugin_call(slow, plugin_name="test", method_name="test", timeout_s=0.001)
+
+    def test_performance_error_reraise(self):
+        def method():
+            raise PluginPerformanceError("custom")
+
+        with pytest.raises(PluginPerformanceError, match="custom"):
+            safe_plugin_call(method, plugin_name="test", method_name="test")
+
+
+# ---------------------------------------------------------------------------
+# validate_plugin_api_version
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePluginApiVersion:
+    def test_compatible_version(self):
+        class Plugin:
+            __navirl_api_version__ = "1.0"
+
+        validate_plugin_api_version(Plugin, "test", "1.0")
+
+    def test_too_old_version(self):
+        class Plugin:
+            __navirl_api_version__ = "0.5"
+
+        with pytest.raises(PluginValidationError, match="too old"):
+            validate_plugin_api_version(Plugin, "test", "1.0")
+
+    def test_default_version(self):
+        class Plugin:
+            pass
+
+        # Default version is "0.9", should be too old for "1.0"
+        with pytest.raises(PluginValidationError, match="too old"):
+            validate_plugin_api_version(Plugin, "test", "1.0")
+
+    def test_newer_version_warns(self, caplog):
+        import logging
+
+        class Plugin:
+            __navirl_api_version__ = "3.0"
+
+        with caplog.at_level(logging.WARNING):
+            validate_plugin_api_version(Plugin, "test", "1.0")
+        assert "too new" in caplog.text
+
+    def test_invalid_version_format(self):
+        class Plugin:
+            __navirl_api_version__ = "abc"
+
+        with pytest.raises(PluginValidationError, match="invalid API version"):
+            validate_plugin_api_version(Plugin, "test", "1.0")
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionHierarchy:
+    def test_config_is_plugin_error(self):
+        assert issubclass(ConfigValidationError, PluginValidationError)
+
+    def test_security_is_plugin_error(self):
+        assert issubclass(PluginSecurityError, PluginValidationError)
+
+    def test_performance_is_plugin_error(self):
+        assert issubclass(PluginPerformanceError, PluginValidationError)

--- a/tests/test_power_law.py
+++ b/tests/test_power_law.py
@@ -1,0 +1,272 @@
+"""Tests for navirl.models.power_law module."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from navirl.core.types import Action, AgentState
+from navirl.models.power_law import (
+    PowerLawConfig,
+    PowerLawHumanController,
+    PowerLawModel,
+    _time_to_collision,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _agent(
+    agent_id=0,
+    x=0.0,
+    y=0.0,
+    vx=0.0,
+    vy=0.0,
+    goal_x=10.0,
+    goal_y=0.0,
+    radius=0.18,
+    max_speed=1.5,
+    kind="human",
+):
+    return AgentState(
+        agent_id=agent_id,
+        kind=kind,
+        x=x,
+        y=y,
+        vx=vx,
+        vy=vy,
+        goal_x=goal_x,
+        goal_y=goal_y,
+        radius=radius,
+        max_speed=max_speed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PowerLawConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPowerLawConfig:
+    def test_defaults(self):
+        cfg = PowerLawConfig()
+        assert cfg.k == 1.5
+        assert cfg.tau_0 == 3.0
+        assert cfg.sigma == 0.1
+        assert cfg.max_force == 40.0
+
+    def test_custom(self):
+        cfg = PowerLawConfig(k=2.0, tau_0=5.0, sigma=0.0)
+        assert cfg.k == 2.0
+        assert cfg.tau_0 == 5.0
+        assert cfg.sigma == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _time_to_collision
+# ---------------------------------------------------------------------------
+
+
+class TestTimeToCollision:
+    def test_head_on_collision(self):
+        # px,py = other-self, vx,vy = self-other
+        # Agents approaching: relative position (5,0), relative velocity
+        # that closes the gap. |p + v*t|^2 shrinks when v opposes p.
+        # So vx = -2 (closing), px = 5
+        tau = _time_to_collision(5.0, 0.0, -2.0, 0.0, 0.36)
+        assert tau > 0
+        assert tau < 5.0
+
+    def test_no_relative_motion(self):
+        tau = _time_to_collision(5.0, 0.0, 0.0, 0.0, 0.36)
+        assert tau == float("inf")
+
+    def test_already_overlapping(self):
+        tau = _time_to_collision(0.1, 0.0, 1.0, 0.0, 0.5)
+        assert tau == 0.0
+
+    def test_moving_apart(self):
+        # Relative velocity points same direction as relative position (moving apart)
+        tau = _time_to_collision(5.0, 0.0, 2.0, 0.0, 0.36)
+        assert tau == float("inf")
+
+    def test_no_collision_miss(self):
+        # Moving perpendicular, will miss
+        tau = _time_to_collision(5.0, 0.0, 0.0, 1.0, 0.36)
+        assert tau == float("inf")
+
+
+# ---------------------------------------------------------------------------
+# PowerLawModel
+# ---------------------------------------------------------------------------
+
+
+class TestPowerLawModel:
+    def test_desired_force_at_goal(self):
+        model = PowerLawModel(PowerLawConfig(relaxation_time=0.5))
+        state = _agent(x=10.0, y=0.0, vx=0.0, vy=0.0, goal_x=10.0, goal_y=0.0)
+        fx, fy = model.compute_desired_force(state, (10.0, 0.0))
+        # At goal, force should decelerate
+        assert abs(fx) < 1e-6 and abs(fy) < 1e-6
+
+    def test_desired_force_toward_goal(self):
+        model = PowerLawModel(PowerLawConfig(relaxation_time=0.5))
+        state = _agent(x=0.0, y=0.0, vx=0.0, vy=0.0, goal_x=10.0, goal_y=0.0)
+        fx, fy = model.compute_desired_force(state, (10.0, 0.0))
+        assert fx > 0  # Should push toward goal (positive x)
+        assert abs(fy) < 1e-6  # No y-force
+
+    def test_anticipatory_force_no_neighbors(self):
+        model = PowerLawModel(PowerLawConfig(sigma=0.0))
+        state = _agent(agent_id=0)
+        fx, fy = model.compute_anticipatory_force(state, [state])
+        # Only self in the list, should skip
+        assert abs(fx) < 1e-6
+        assert abs(fy) < 1e-6
+
+    def test_anticipatory_force_with_approaching_agent(self):
+        model = PowerLawModel(PowerLawConfig(sigma=0.0))
+        # rel_px = other.x - state.x = 3, rel_vx = state.vx - other.vx
+        # For collision: need vx such that rel_vx is negative (closing)
+        # a1 stationary, a2 approaching from right
+        a1 = _agent(agent_id=0, x=0.0, y=0.0, vx=0.0, vy=0.0)
+        a2 = _agent(agent_id=1, x=3.0, y=0.0, vx=-2.0, vy=0.0)
+        # rel_vx = 0 - (-2) = 2, rel_px = 3 → |3 + 2t| shrinks? No, grows.
+        # Actually in the code: vx = self - other, and eq is |p + v*t|^2
+        # p=(3,0), v=(2,0) → grows. Need v negative.
+        # a1 moving toward a2: vx=2, a2 stationary
+        a1 = _agent(agent_id=0, x=0.0, y=0.0, vx=2.0, vy=0.0)
+        a2 = _agent(agent_id=1, x=3.0, y=0.0, vx=2.0, vy=0.0)
+        # rel_vx = 2-2 = 0, no relative motion. Try differently:
+        # a1 fast toward a2, a2 slower
+        a1 = _agent(agent_id=0, x=0.0, y=0.0, vx=3.0, vy=0.0)
+        a2 = _agent(agent_id=1, x=3.0, y=0.0, vx=0.0, vy=0.0)
+        # rel_vx = 3-0 = 3, rel_px = 3, |3+3t| = 3(1+t) → grows → no collision
+        # The math: solve (3+3t)^2 = r^2 → t = (r-3)/3 or (-r-3)/3 both negative
+        # So we need rel_vx negative. That means other.vx > state.vx
+        a1 = _agent(agent_id=0, x=0.0, y=0.0, vx=0.0, vy=0.0)
+        a2 = _agent(agent_id=1, x=3.0, y=0.0, vx=3.0, vy=0.0)
+        # rel_vx = 0-3 = -3, rel_px = 3, |3-3t| → hits 0 at t=1
+        fx, fy = model.compute_anticipatory_force(a1, [a1, a2])
+        # Force should push agent 0 away from predicted collision (negative x)
+        assert fx != 0.0
+
+    def test_anticipatory_force_far_away_ignored(self):
+        model = PowerLawModel(PowerLawConfig(sigma=0.0, neighbor_distance=5.0))
+        a1 = _agent(agent_id=0, x=0.0, y=0.0, vx=0.0, vy=0.0)
+        a2 = _agent(agent_id=1, x=100.0, y=0.0, vx=0.0, vy=0.0)
+        fx, fy = model.compute_anticipatory_force(a1, [a1, a2])
+        assert abs(fx) < 1e-6
+        assert abs(fy) < 1e-6
+
+    def test_total_force_combines(self):
+        model = PowerLawModel(PowerLawConfig(sigma=0.0))
+        state = _agent(x=0.0, y=0.0, vx=0.0, vy=0.0, goal_x=10.0, goal_y=0.0)
+        fx, fy = model.compute_total_force(state, [state])
+        # Should have desired force toward goal
+        assert fx > 0
+
+    def test_step_produces_velocities(self):
+        model = PowerLawModel(PowerLawConfig(sigma=0.0))
+        a1 = _agent(agent_id=0, x=0.0, y=0.0, vx=0.0, vy=0.0)
+        a2 = _agent(agent_id=1, x=5.0, y=5.0, vx=0.0, vy=0.0, goal_x=0.0, goal_y=0.0)
+        goals = {0: (10.0, 0.0), 1: (0.0, 0.0)}
+        vels = model.step([a1, a2], goals, dt=0.04)
+        assert 0 in vels
+        assert 1 in vels
+        assert len(vels[0]) == 2
+        assert len(vels[1]) == 2
+
+    def test_step_clamps_speed(self):
+        cfg = PowerLawConfig(sigma=0.0, relaxation_time=0.01)
+        model = PowerLawModel(cfg)
+        state = _agent(x=0.0, y=0.0, vx=0.0, vy=0.0, max_speed=1.0)
+        vels = model.step([state], {0: (100.0, 0.0)}, dt=1.0)
+        vx, vy = vels[0]
+        speed = math.hypot(vx, vy)
+        assert speed <= 1.0 + 1e-6
+
+    def test_noise_adds_variation(self):
+        model = PowerLawModel(PowerLawConfig(sigma=1.0))
+        state = _agent(agent_id=0)
+        results = set()
+        for _ in range(10):
+            fx, fy = model.compute_anticipatory_force(state, [state])
+            results.add(round(fx, 4))
+        # With noise, we should get different values
+        assert len(results) > 1
+
+
+# ---------------------------------------------------------------------------
+# PowerLawHumanController
+# ---------------------------------------------------------------------------
+
+
+class TestPowerLawHumanController:
+    def _make_controller(self):
+        ctrl = PowerLawHumanController(PowerLawConfig(sigma=0.0))
+        starts = {0: (0.0, 0.0), 1: (10.0, 0.0)}
+        goals = {0: (10.0, 0.0), 1: (0.0, 0.0)}
+        ctrl.reset([0, 1], starts, goals)
+        return ctrl
+
+    def test_reset_stores_ids(self):
+        ctrl = self._make_controller()
+        assert ctrl.human_ids == [0, 1]
+        assert ctrl.goals[0] == (10.0, 0.0)
+
+    def test_step_returns_actions(self):
+        ctrl = self._make_controller()
+        states = {
+            0: _agent(agent_id=0, x=0, y=0, vx=0, vy=0),
+            1: _agent(agent_id=1, x=10, y=0, vx=0, vy=0),
+        }
+
+        def emit(event_type, agent_id, data):
+            pass
+
+        actions = ctrl.step(0, 0.0, 0.04, states, robot_id=-1, emit_event=emit)
+        assert 0 in actions
+        assert 1 in actions
+        assert isinstance(actions[0], Action)
+        assert actions[0].behavior == "GO_TO"
+        assert actions[0].metadata["model"] == "power_law"
+
+    def test_goal_swap_on_arrival(self):
+        ctrl = PowerLawHumanController(PowerLawConfig(sigma=0.0))
+        ctrl.reset([0], {0: (0.0, 0.0)}, {0: (1.0, 0.0)})
+        ctrl.goal_tolerance = 0.5
+
+        states = {
+            0: _agent(agent_id=0, x=0.8, y=0.0, vx=0.5, vy=0.0, goal_x=1.0, goal_y=0.0),
+        }
+
+        events = []
+
+        def emit(event_type, agent_id, data):
+            events.append((event_type, agent_id, data))
+
+        ctrl.step(0, 0.0, 0.04, states, robot_id=-1, emit_event=emit)
+        # Should have swapped goals
+        assert len(events) == 1
+        assert events[0][0] == "goal_swap"
+        assert ctrl.goals[0] == (0.0, 0.0)
+
+    def test_missing_state_skipped(self):
+        ctrl = PowerLawHumanController(PowerLawConfig(sigma=0.0))
+        ctrl.reset([0, 1], {0: (0, 0), 1: (10, 0)}, {0: (10, 0), 1: (0, 0)})
+        states = {0: _agent(agent_id=0)}  # Agent 1 missing
+        actions = ctrl.step(0, 0.0, 0.04, states, robot_id=-1, emit_event=lambda *a: None)
+        assert 0 in actions
+        assert 1 not in actions
+
+    def test_speed_clamping(self):
+        ctrl = PowerLawHumanController(PowerLawConfig(sigma=0.0, relaxation_time=0.001))
+        ctrl.reset([0], {0: (0, 0)}, {0: (100, 0)})
+        states = {0: _agent(agent_id=0, x=0, y=0, vx=0, vy=0, max_speed=1.0)}
+        actions = ctrl.step(0, 0.0, 1.0, states, robot_id=-1, emit_event=lambda *a: None)
+        speed = math.hypot(actions[0].pref_vx, actions[0].pref_vy)
+        assert speed <= 1.0 + 1e-6

--- a/tests/test_seeds.py
+++ b/tests/test_seeds.py
@@ -1,0 +1,45 @@
+"""Tests for navirl.core.seeds module."""
+
+from __future__ import annotations
+
+import os
+import random
+
+import numpy as np
+import pytest
+
+from navirl.core.seeds import set_global_seed
+
+
+class TestSetGlobalSeed:
+    def test_python_random_deterministic(self):
+        set_global_seed(42)
+        a = [random.random() for _ in range(10)]
+        set_global_seed(42)
+        b = [random.random() for _ in range(10)]
+        assert a == b
+
+    def test_numpy_random_deterministic(self):
+        set_global_seed(42)
+        a = np.random.rand(10).tolist()
+        set_global_seed(42)
+        b = np.random.rand(10).tolist()
+        assert a == b
+
+    def test_env_var_set(self):
+        set_global_seed(123)
+        assert os.environ["PYTHONHASHSEED"] == "123"
+
+    def test_different_seeds_differ(self):
+        set_global_seed(42)
+        a = random.random()
+        set_global_seed(99)
+        b = random.random()
+        assert a != b
+
+    def test_zero_seed(self):
+        set_global_seed(0)
+        a = random.random()
+        set_global_seed(0)
+        b = random.random()
+        assert a == b


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for 6 previously under-tested modules: `grid_map`, `navigation rewards`, `plugin_validation`, `power_law`, `seeds`, and `pack_schema`
- 188 new tests bringing total from 4675 to 4863 (all passing)
- Tests cover coordinate transforms, ray casting, flood fill, all 8 reward function types, plugin validation/security, collision avoidance physics, deterministic seeding, and experiment pack schema

## Test plan
- [x] All 188 new tests pass
- [x] Full test suite passes: 4863 passed, 98 skipped, 2 xfailed
- [x] ruff lint and format clean
- [x] No changes to source code, only new test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)