### PR TITLE
feat: add reproducibility package builder and checklist (ROADMAP #11)

### DIFF
--- a/navirl/cli.py
+++ b/navirl/cli.py
@@ -20,6 +20,7 @@ from navirl.orchestration import Orchestrator, OrchestratorConfig
 from navirl.overseer import apply_layout_to_scenario, suggest_layout
 from navirl.packs import load_pack, run_pack, write_pack_json, write_pack_markdown
 from navirl.pipeline import expand_state_paths, run_batch, run_scenario_file
+from navirl.repro import build_repro_package, run_checklist, verify_repro_package
 from navirl.scenarios import load_scenario
 from navirl.scenarios.validate import validate_scenario_dict
 from navirl.tune import run_tuning
@@ -467,6 +468,108 @@ def _create_orchestrate_parser(subparsers) -> None:
     p_orch.set_defaults(func=_cmd_orchestrate)
 
 
+def _cmd_repro_build(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir)
+    if not run_dir.is_dir():
+        raise FileNotFoundError(f"Run directory not found: {run_dir}")
+
+    scenario_paths = None
+    if args.scenarios:
+        scenario_paths = [Path(s) for s in args.scenarios]
+
+    pack_result_path = Path(args.pack_results) if args.pack_results else None
+    metadata = {}
+    if args.author:
+        metadata["author"] = args.author
+    if args.study:
+        metadata["study"] = args.study
+
+    package = build_repro_package(
+        name=args.name,
+        version=args.version,
+        description=args.description or "",
+        run_dir=run_dir,
+        scenario_paths=scenario_paths,
+        pack_result_path=pack_result_path,
+        out_dir=Path(args.out),
+        metadata=metadata,
+    )
+    print(f"Reproducibility package '{package.name}' v{package.version}")
+    print(f"  Artifacts: {len(package.artifacts)}")
+    print(f"  Checksum: {package.checksum()[:16]}...")
+    print(f"  Output: {args.out}/MANIFEST.json")
+    return 0
+
+
+def _cmd_repro_check(args: argparse.Namespace) -> int:
+    package_dir = Path(args.package_dir)
+    if not package_dir.is_dir():
+        raise FileNotFoundError(f"Package directory not found: {package_dir}")
+
+    report = run_checklist(package_dir)
+
+    if args.format == "markdown":
+        print(report.to_markdown())
+    else:
+        print(json.dumps(report.to_dict(), indent=2))
+
+    return 0 if report.passed else 1
+
+
+def _cmd_repro_verify(args: argparse.Namespace) -> int:
+    package_dir = Path(args.package_dir)
+    if not package_dir.is_dir():
+        raise FileNotFoundError(f"Package directory not found: {package_dir}")
+
+    ok, issues = verify_repro_package(package_dir)
+
+    if ok:
+        print("All artifact checksums verified.")
+        return 0
+
+    print(f"Integrity check failed ({len(issues)} issue(s)):")
+    for issue in issues:
+        print(f"  - {issue}")
+    return 1
+
+
+def _create_repro_parser(subparsers) -> None:
+    """Create the 'repro' command parser with build/check/verify subcommands."""
+    p_repro = subparsers.add_parser(
+        "repro",
+        help="Build and verify reproducibility packages",
+    )
+    repro_sub = p_repro.add_subparsers(dest="repro_command", required=True)
+
+    # repro build
+    p_build = repro_sub.add_parser("build", help="Build a reproducibility package")
+    p_build.add_argument("name", type=str, help="Package name")
+    p_build.add_argument("run_dir", type=str, help="Directory with experiment run outputs")
+    p_build.add_argument("--out", type=str, default="out/repro")
+    p_build.add_argument("--version", type=str, default="1.0")
+    p_build.add_argument("--description", type=str, default=None)
+    p_build.add_argument(
+        "--scenarios", nargs="*", default=None, help="Explicit scenario YAML paths"
+    )
+    p_build.add_argument("--pack-results", type=str, default=None, help="pack_results.json path")
+    p_build.add_argument("--author", type=str, default=None)
+    p_build.add_argument("--study", type=str, default=None)
+    p_build.set_defaults(func=_cmd_repro_build)
+
+    # repro check
+    p_check = repro_sub.add_parser("check", help="Run publication readiness checklist")
+    p_check.add_argument("package_dir", type=str, help="Path to reproducibility package")
+    p_check.add_argument(
+        "--format", choices=["json", "markdown"], default="markdown", help="Output format"
+    )
+    p_check.set_defaults(func=_cmd_repro_check)
+
+    # repro verify
+    p_verify = repro_sub.add_parser("verify", help="Verify artifact integrity")
+    p_verify.add_argument("package_dir", type=str, help="Path to reproducibility package")
+    p_verify.set_defaults(func=_cmd_repro_verify)
+
+
 def _create_layout_parser(subparsers) -> None:
     """Create the 'overseer-layout' command parser."""
     p_layout = subparsers.add_parser(
@@ -508,6 +611,7 @@ def build_parser() -> argparse.ArgumentParser:
     _create_experiment_parser(subparsers)
     _create_pack_parser(subparsers)
     _create_orchestrate_parser(subparsers)
+    _create_repro_parser(subparsers)
     _create_layout_parser(subparsers)
 
     return parser

--- a/navirl/repro/__init__.py
+++ b/navirl/repro/__init__.py
@@ -1,0 +1,28 @@
+"""Reproducibility package tools for NavIRL.
+
+Provides utilities to bundle validated experiment runs into publishable
+reproducibility packages with environment pins, checksums, and
+publication readiness checklists.
+"""
+
+from __future__ import annotations
+
+from navirl.repro.checklist import ChecklistReport, CheckResult, run_checklist
+from navirl.repro.package import (
+    ArtifactEntry,
+    EnvironmentPin,
+    ReproPackage,
+    build_repro_package,
+    verify_repro_package,
+)
+
+__all__ = [
+    "ArtifactEntry",
+    "ChecklistReport",
+    "CheckResult",
+    "EnvironmentPin",
+    "ReproPackage",
+    "build_repro_package",
+    "run_checklist",
+    "verify_repro_package",
+]

--- a/navirl/repro/checklist.py
+++ b/navirl/repro/checklist.py
@@ -47,8 +47,7 @@ class ChecklistReport:
             "total_checks": self.total,
             "passed_checks": self.passed_count,
             "results": [
-                {"name": r.name, "passed": r.passed, "message": r.message}
-                for r in self.results
+                {"name": r.name, "passed": r.passed, "message": r.message} for r in self.results
             ],
         }
 
@@ -193,9 +192,7 @@ def run_checklist(package_dir: Path) -> ChecklistReport:
         CheckResult(
             "package_checksum",
             has_checksum,
-            f"checksum={data.get('checksum', '?')[:16]}..."
-            if has_checksum
-            else "no checksum",
+            f"checksum={data.get('checksum', '?')[:16]}..." if has_checksum else "no checksum",
         )
     )
 

--- a/navirl/repro/checklist.py
+++ b/navirl/repro/checklist.py
@@ -1,0 +1,202 @@
+"""Publication readiness checklist for reproducibility packages.
+
+Automates verification of whether a reproducibility package meets
+the minimum requirements for publication alongside a study.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CheckResult:
+    """Result of a single checklist item."""
+
+    name: str
+    passed: bool
+    message: str
+
+
+@dataclass
+class ChecklistReport:
+    """Complete checklist evaluation report."""
+
+    package_name: str
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(r.passed for r in self.results)
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def passed_count(self) -> int:
+        return sum(1 for r in self.results if r.passed)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "package_name": self.package_name,
+            "passed": self.passed,
+            "total_checks": self.total,
+            "passed_checks": self.passed_count,
+            "results": [
+                {"name": r.name, "passed": r.passed, "message": r.message}
+                for r in self.results
+            ],
+        }
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"# Reproducibility Checklist: {self.package_name}",
+            "",
+            f"**Status**: {'PASS' if self.passed else 'FAIL'} "
+            f"({self.passed_count}/{self.total} checks passed)",
+            "",
+            "| Check | Status | Details |",
+            "|-------|--------|---------|",
+        ]
+        for r in self.results:
+            icon = "PASS" if r.passed else "FAIL"
+            lines.append(f"| {r.name} | {icon} | {r.message} |")
+        lines.append("")
+        return "\n".join(lines)
+
+
+def run_checklist(package_dir: Path) -> ChecklistReport:
+    """Run the full publication readiness checklist.
+
+    Parameters
+    ----------
+    package_dir:
+        Root directory of the reproducibility package.
+
+    Returns
+    -------
+    ChecklistReport with all check results.
+    """
+    manifest_path = package_dir / "MANIFEST.json"
+    if not manifest_path.is_file():
+        return ChecklistReport(
+            package_name=package_dir.name,
+            results=[CheckResult("manifest_exists", False, "MANIFEST.json not found")],
+        )
+
+    with manifest_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    name = data.get("name", package_dir.name)
+    results: list[CheckResult] = []
+
+    # 1. Manifest exists and is valid JSON
+    results.append(CheckResult("manifest_exists", True, "MANIFEST.json present and valid"))
+
+    # 2. Package has a name and version
+    has_name = bool(data.get("name"))
+    has_version = bool(data.get("version"))
+    results.append(
+        CheckResult(
+            "identity",
+            has_name and has_version,
+            f"name={data.get('name', '?')}, version={data.get('version', '?')}",
+        )
+    )
+
+    # 3. Environment pins captured
+    env = data.get("environment", {})
+    has_python = bool(env.get("python_version"))
+    has_platform = bool(env.get("platform_system"))
+    has_packages = bool(env.get("packages"))
+    results.append(
+        CheckResult(
+            "environment_pins",
+            has_python and has_platform,
+            f"python={'yes' if has_python else 'missing'}, "
+            f"platform={'yes' if has_platform else 'missing'}, "
+            f"packages={len(env.get('packages', {}))} pinned",
+        )
+    )
+
+    # 4. Scenarios included
+    scenarios_dir = package_dir / "scenarios"
+    scenario_files = list(scenarios_dir.glob("*.yaml")) if scenarios_dir.is_dir() else []
+    results.append(
+        CheckResult(
+            "scenarios_included",
+            len(scenario_files) > 0,
+            f"{len(scenario_files)} scenario file(s) found",
+        )
+    )
+
+    # 5. Results present
+    results_dir = package_dir / "results"
+    result_files = list(results_dir.glob("*.json")) if results_dir.is_dir() else []
+    results.append(
+        CheckResult(
+            "results_present",
+            len(result_files) > 0,
+            f"{len(result_files)} result file(s) found",
+        )
+    )
+
+    # 6. Artifact checksums recorded
+    artifacts = data.get("artifacts", [])
+    all_have_hash = all(bool(a.get("sha256")) for a in artifacts)
+    results.append(
+        CheckResult(
+            "artifact_checksums",
+            len(artifacts) > 0 and all_have_hash,
+            f"{len(artifacts)} artifact(s) with checksums",
+        )
+    )
+
+    # 7. Expected metrics documented
+    expected = data.get("expected_metrics", {})
+    results.append(
+        CheckResult(
+            "expected_metrics",
+            len(expected) > 0,
+            f"{len(expected)} metric(s) with expected values",
+        )
+    )
+
+    # 8. Package-level description provided
+    has_desc = bool(data.get("description"))
+    results.append(
+        CheckResult(
+            "description",
+            has_desc,
+            "description provided" if has_desc else "no description",
+        )
+    )
+
+    # 9. Package includes pinned package list
+    results.append(
+        CheckResult(
+            "package_pins",
+            has_packages,
+            f"{len(env.get('packages', {}))} packages pinned"
+            if has_packages
+            else "no package pins",
+        )
+    )
+
+    # 10. Checksum is present
+    has_checksum = bool(data.get("checksum"))
+    results.append(
+        CheckResult(
+            "package_checksum",
+            has_checksum,
+            f"checksum={data.get('checksum', '?')[:16]}..."
+            if has_checksum
+            else "no checksum",
+        )
+    )
+
+    return ChecklistReport(package_name=name, results=results)

--- a/navirl/repro/package.py
+++ b/navirl/repro/package.py
@@ -1,0 +1,335 @@
+"""Reproducibility package builder.
+
+Bundles validated experiment runs into a self-contained, publishable
+reproducibility package containing configs, environment pins, expected
+outputs, and checksums.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import shutil
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class EnvironmentPin:
+    """Frozen snapshot of the execution environment."""
+
+    python_version: str = ""
+    platform_system: str = ""
+    platform_machine: str = ""
+    platform_release: str = ""
+    packages: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def capture(cls) -> EnvironmentPin:
+        """Capture current environment information."""
+        packages: dict[str, str] = {}
+        try:
+            from importlib.metadata import distributions
+
+            for dist in distributions():
+                packages[dist.metadata["Name"]] = dist.metadata["Version"]
+        except Exception:
+            pass
+
+        return cls(
+            python_version=sys.version,
+            platform_system=platform.system(),
+            platform_machine=platform.machine(),
+            platform_release=platform.release(),
+            packages=dict(sorted(packages.items())),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "python_version": self.python_version,
+            "platform_system": self.platform_system,
+            "platform_machine": self.platform_machine,
+            "platform_release": self.platform_release,
+            "packages": self.packages,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EnvironmentPin:
+        return cls(
+            python_version=data.get("python_version", ""),
+            platform_system=data.get("platform_system", ""),
+            platform_machine=data.get("platform_machine", ""),
+            platform_release=data.get("platform_release", ""),
+            packages=data.get("packages", {}),
+        )
+
+
+@dataclass
+class ArtifactEntry:
+    """A tracked artifact within the reproducibility package."""
+
+    relative_path: str
+    sha256: str
+    size_bytes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "relative_path": self.relative_path,
+            "sha256": self.sha256,
+            "size_bytes": self.size_bytes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactEntry:
+        return cls(
+            relative_path=data["relative_path"],
+            sha256=data["sha256"],
+            size_bytes=data["size_bytes"],
+        )
+
+
+@dataclass
+class ReproPackage:
+    """A self-contained reproducibility package.
+
+    Bundles scenario configs, result summaries, environment pins,
+    and artifact checksums into a publishable directory.
+    """
+
+    name: str
+    version: str = "1.0"
+    description: str = ""
+    created_at: str = ""
+    environment: EnvironmentPin = field(default_factory=EnvironmentPin)
+    artifacts: list[ArtifactEntry] = field(default_factory=list)
+    expected_metrics: dict[str, dict[str, float]] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def checksum(self) -> str:
+        """Compute deterministic SHA-256 of the package definition."""
+        obj = {
+            "name": self.name,
+            "version": self.version,
+            "artifacts": [a.to_dict() for a in self.artifacts],
+            "expected_metrics": self.expected_metrics,
+        }
+        blob = json.dumps(obj, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "created_at": self.created_at,
+            "checksum": self.checksum(),
+            "environment": self.environment.to_dict(),
+            "artifacts": [a.to_dict() for a in self.artifacts],
+            "expected_metrics": self.expected_metrics,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ReproPackage:
+        return cls(
+            name=data["name"],
+            version=data.get("version", "1.0"),
+            description=data.get("description", ""),
+            created_at=data.get("created_at", ""),
+            environment=EnvironmentPin.from_dict(data.get("environment", {})),
+            artifacts=[ArtifactEntry.from_dict(a) for a in data.get("artifacts", [])],
+            expected_metrics=data.get("expected_metrics", {}),
+            metadata=data.get("metadata", {}),
+        )
+
+
+def _hash_file(path: Path) -> str:
+    """Compute SHA-256 of a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(65536)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_repro_package(
+    *,
+    name: str,
+    version: str = "1.0",
+    description: str = "",
+    run_dir: Path,
+    scenario_paths: list[Path] | None = None,
+    pack_result_path: Path | None = None,
+    out_dir: Path,
+    metadata: dict[str, Any] | None = None,
+) -> ReproPackage:
+    """Build a reproducibility package from validated experiment outputs.
+
+    Parameters
+    ----------
+    name:
+        Package name (e.g. ``"hallway-study-2024"``).
+    version:
+        Semantic version for the package.
+    description:
+        Human-readable description.
+    run_dir:
+        Directory containing experiment run outputs (state logs, summaries).
+    scenario_paths:
+        Optional explicit list of scenario YAML files to include.
+        If not provided, discovers ``*.yaml`` files in run_dir.
+    pack_result_path:
+        Optional path to a pack_results.json to embed expected metrics from.
+    out_dir:
+        Output directory for the reproducibility package.
+    metadata:
+        Free-form metadata dict.
+
+    Returns
+    -------
+    ReproPackage:
+        The assembled package descriptor.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Capture environment
+    env = EnvironmentPin.capture()
+
+    # Collect scenario files
+    scenarios_dir = out_dir / "scenarios"
+    scenarios_dir.mkdir(exist_ok=True)
+
+    if scenario_paths:
+        for sp in scenario_paths:
+            if sp.is_file():
+                shutil.copy2(sp, scenarios_dir / sp.name)
+    else:
+        # Discover scenarios from run_dir
+        for sp in sorted(run_dir.glob("**/scenario.yaml")):
+            dest_name = f"{sp.parent.name}_scenario.yaml"
+            shutil.copy2(sp, scenarios_dir / dest_name)
+
+    # Copy run summaries
+    results_dir = out_dir / "results"
+    results_dir.mkdir(exist_ok=True)
+
+    for summary in sorted(run_dir.glob("**/summary.json")):
+        dest_name = f"{summary.parent.name}_summary.json"
+        shutil.copy2(summary, results_dir / dest_name)
+
+    # Load expected metrics from pack results if available
+    expected_metrics: dict[str, dict[str, float]] = {}
+    if pack_result_path and pack_result_path.is_file():
+        with pack_result_path.open("r", encoding="utf-8") as f:
+            pack_data = json.load(f)
+        # Extract aggregated metrics if present
+        if "runs" in pack_data:
+            from navirl.packs.schema import PackResult, PackRunResult
+
+            runs = [
+                PackRunResult(
+                    entry_id=r["entry_id"],
+                    seed=r["seed"],
+                    metrics=r.get("metrics", {}),
+                    status=r.get("status", "completed"),
+                    error=r.get("error"),
+                )
+                for r in pack_data["runs"]
+            ]
+            pr = PackResult(
+                manifest_name=pack_data.get("manifest_name", name),
+                manifest_version=pack_data.get("manifest_version", version),
+                manifest_checksum=pack_data.get("manifest_checksum", ""),
+                runs=runs,
+                timestamp=pack_data.get("timestamp", ""),
+            )
+            metric_keys = list(
+                {k for r in runs if r.status == "completed" for k in r.metrics}
+            )
+            expected_metrics = pr.aggregate(sorted(metric_keys))
+        shutil.copy2(pack_result_path, results_dir / "pack_results.json")
+
+    # Hash all files in the package
+    artifacts: list[ArtifactEntry] = []
+    for fpath in sorted(out_dir.rglob("*")):
+        if fpath.is_file() and fpath.name != "MANIFEST.json":
+            rel = str(fpath.relative_to(out_dir))
+            artifacts.append(
+                ArtifactEntry(
+                    relative_path=rel,
+                    sha256=_hash_file(fpath),
+                    size_bytes=fpath.stat().st_size,
+                )
+            )
+
+    now = datetime.now(UTC).isoformat()
+    package = ReproPackage(
+        name=name,
+        version=version,
+        description=description,
+        created_at=now,
+        environment=env,
+        artifacts=artifacts,
+        expected_metrics=expected_metrics,
+        metadata=metadata or {},
+    )
+
+    # Write manifest
+    manifest_path = out_dir / "MANIFEST.json"
+    with manifest_path.open("w", encoding="utf-8") as f:
+        json.dump(package.to_dict(), f, indent=2, sort_keys=True)
+
+    return package
+
+
+def verify_repro_package(package_dir: Path) -> tuple[bool, list[str]]:
+    """Verify integrity of a reproducibility package.
+
+    Checks that all artifacts exist and their checksums match.
+
+    Parameters
+    ----------
+    package_dir:
+        Root directory of the reproducibility package.
+
+    Returns
+    -------
+    tuple[bool, list[str]]:
+        (all_ok, list_of_issues). If all_ok is True, list is empty.
+    """
+    manifest_path = package_dir / "MANIFEST.json"
+    if not manifest_path.is_file():
+        return False, ["MANIFEST.json not found"]
+
+    with manifest_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    package = ReproPackage.from_dict(data)
+    issues: list[str] = []
+
+    for artifact in package.artifacts:
+        fpath = package_dir / artifact.relative_path
+        if not fpath.is_file():
+            issues.append(f"Missing artifact: {artifact.relative_path}")
+            continue
+        actual_hash = _hash_file(fpath)
+        if actual_hash != artifact.sha256:
+            issues.append(
+                f"Checksum mismatch: {artifact.relative_path} "
+                f"(expected {artifact.sha256[:16]}..., got {actual_hash[:16]}...)"
+            )
+        actual_size = fpath.stat().st_size
+        if actual_size != artifact.size_bytes:
+            issues.append(
+                f"Size mismatch: {artifact.relative_path} "
+                f"(expected {artifact.size_bytes}, got {actual_size})"
+            )
+
+    return len(issues) == 0, issues

--- a/navirl/repro/package.py
+++ b/navirl/repro/package.py
@@ -250,9 +250,7 @@ def build_repro_package(
                 runs=runs,
                 timestamp=pack_data.get("timestamp", ""),
             )
-            metric_keys = list(
-                {k for r in runs if r.status == "completed" for k in r.metrics}
-            )
+            metric_keys = list({k for r in runs if r.status == "completed" for k in r.metrics})
             expected_metrics = pr.aggregate(sorted(metric_keys))
         shutil.copy2(pack_result_path, results_dir / "pack_results.json")
 

--- a/tests/test_repro_package.py
+++ b/tests/test_repro_package.py
@@ -1,0 +1,496 @@
+"""Tests for the reproducibility package module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from navirl.repro import (
+    ArtifactEntry,
+    ChecklistReport,
+    CheckResult,
+    EnvironmentPin,
+    ReproPackage,
+    build_repro_package,
+    run_checklist,
+    verify_repro_package,
+)
+
+# ---------------------------------------------------------------------------
+# EnvironmentPin
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentPin:
+    def test_capture_returns_populated_pin(self):
+        pin = EnvironmentPin.capture()
+        assert pin.python_version
+        assert pin.platform_system
+        assert pin.platform_machine
+
+    def test_to_dict_roundtrip(self):
+        pin = EnvironmentPin(
+            python_version="3.11.0",
+            platform_system="Linux",
+            platform_machine="x86_64",
+            platform_release="6.0",
+            packages={"numpy": "1.25.0", "navirl": "0.1.0"},
+        )
+        data = pin.to_dict()
+        restored = EnvironmentPin.from_dict(data)
+        assert restored.python_version == pin.python_version
+        assert restored.packages == pin.packages
+
+    def test_from_dict_defaults(self):
+        pin = EnvironmentPin.from_dict({})
+        assert pin.python_version == ""
+        assert pin.packages == {}
+
+    def test_capture_includes_packages(self):
+        pin = EnvironmentPin.capture()
+        # At minimum, pytest should be installed
+        assert isinstance(pin.packages, dict)
+        assert len(pin.packages) > 0
+
+
+# ---------------------------------------------------------------------------
+# ArtifactEntry
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactEntry:
+    def test_to_dict(self):
+        entry = ArtifactEntry(relative_path="scenarios/a.yaml", sha256="abc123", size_bytes=100)
+        d = entry.to_dict()
+        assert d["relative_path"] == "scenarios/a.yaml"
+        assert d["sha256"] == "abc123"
+        assert d["size_bytes"] == 100
+
+    def test_from_dict(self):
+        d = {"relative_path": "results/x.json", "sha256": "def456", "size_bytes": 200}
+        entry = ArtifactEntry.from_dict(d)
+        assert entry.relative_path == "results/x.json"
+        assert entry.sha256 == "def456"
+
+
+# ---------------------------------------------------------------------------
+# ReproPackage
+# ---------------------------------------------------------------------------
+
+
+class TestReproPackage:
+    def test_checksum_deterministic(self):
+        pkg = ReproPackage(name="test", version="1.0")
+        c1 = pkg.checksum()
+        c2 = pkg.checksum()
+        assert c1 == c2
+        assert len(c1) == 64  # SHA-256 hex
+
+    def test_checksum_changes_with_content(self):
+        pkg1 = ReproPackage(name="a", version="1.0")
+        pkg2 = ReproPackage(name="b", version="1.0")
+        assert pkg1.checksum() != pkg2.checksum()
+
+    def test_to_dict_includes_all_fields(self):
+        pkg = ReproPackage(
+            name="study-x",
+            version="2.0",
+            description="A test study",
+            created_at="2024-01-01T00:00:00",
+            metadata={"author": "tester"},
+        )
+        d = pkg.to_dict()
+        assert d["name"] == "study-x"
+        assert d["version"] == "2.0"
+        assert d["description"] == "A test study"
+        assert d["checksum"]
+        assert d["metadata"]["author"] == "tester"
+
+    def test_from_dict_roundtrip(self):
+        pkg = ReproPackage(
+            name="rt",
+            version="1.0",
+            description="roundtrip test",
+            expected_metrics={"success_rate": {"mean": 0.9, "std": 0.05}},
+        )
+        data = pkg.to_dict()
+        restored = ReproPackage.from_dict(data)
+        assert restored.name == pkg.name
+        assert restored.expected_metrics == pkg.expected_metrics
+
+    def test_from_dict_defaults(self):
+        pkg = ReproPackage.from_dict({"name": "minimal"})
+        assert pkg.version == "1.0"
+        assert pkg.artifacts == []
+
+
+# ---------------------------------------------------------------------------
+# build_repro_package
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReproPackage:
+    def test_build_from_run_dir(self, tmp_path: Path):
+        # Create fake run directory structure
+        run_dir = tmp_path / "runs"
+        run1 = run_dir / "run_001"
+        run1.mkdir(parents=True)
+        (run1 / "scenario.yaml").write_text("grid: {rows: 10, cols: 10}\n")
+        (run1 / "summary.json").write_text('{"success_rate": 1.0}\n')
+
+        out = tmp_path / "package"
+        pkg = build_repro_package(
+            name="test-pkg",
+            run_dir=run_dir,
+            out_dir=out,
+            description="test build",
+        )
+
+        assert pkg.name == "test-pkg"
+        assert len(pkg.artifacts) > 0
+        assert (out / "MANIFEST.json").is_file()
+        assert (out / "scenarios").is_dir()
+        assert (out / "results").is_dir()
+
+    def test_build_with_explicit_scenarios(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+
+        scenario = tmp_path / "my_scenario.yaml"
+        scenario.write_text("grid: {rows: 5, cols: 5}\n")
+
+        out = tmp_path / "package"
+        pkg = build_repro_package(
+            name="explicit-scenarios",
+            run_dir=run_dir,
+            scenario_paths=[scenario],
+            out_dir=out,
+        )
+
+        assert (out / "scenarios" / "my_scenario.yaml").is_file()
+        # Find the scenario in artifacts
+        scenario_artifacts = [a for a in pkg.artifacts if "my_scenario" in a.relative_path]
+        assert len(scenario_artifacts) == 1
+
+    def test_build_with_pack_results(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+
+        pack_results = tmp_path / "pack_results.json"
+        pack_data = {
+            "manifest_name": "test",
+            "manifest_version": "1.0",
+            "manifest_checksum": "abc",
+            "timestamp": "2024-01-01",
+            "runs": [
+                {
+                    "entry_id": "s1",
+                    "seed": 42,
+                    "metrics": {"success_rate": 1.0, "collisions": 0},
+                    "status": "completed",
+                    "error": None,
+                },
+                {
+                    "entry_id": "s1",
+                    "seed": 43,
+                    "metrics": {"success_rate": 0.8, "collisions": 1},
+                    "status": "completed",
+                    "error": None,
+                },
+            ],
+        }
+        pack_results.write_text(json.dumps(pack_data))
+
+        out = tmp_path / "package"
+        pkg = build_repro_package(
+            name="with-metrics",
+            run_dir=run_dir,
+            pack_result_path=pack_results,
+            out_dir=out,
+        )
+
+        assert len(pkg.expected_metrics) > 0
+        assert "success_rate" in pkg.expected_metrics
+
+    def test_build_metadata(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+
+        out = tmp_path / "package"
+        pkg = build_repro_package(
+            name="meta-test",
+            run_dir=run_dir,
+            out_dir=out,
+            metadata={"author": "Alice", "study": "hallway-2024"},
+        )
+
+        assert pkg.metadata["author"] == "Alice"
+        assert pkg.metadata["study"] == "hallway-2024"
+
+    def test_build_empty_run_dir(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+
+        out = tmp_path / "package"
+        pkg = build_repro_package(name="empty", run_dir=run_dir, out_dir=out)
+
+        assert pkg.name == "empty"
+        assert (out / "MANIFEST.json").is_file()
+
+    def test_manifest_json_is_valid(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+
+        out = tmp_path / "package"
+        build_repro_package(name="valid-json", run_dir=run_dir, out_dir=out)
+
+        with (out / "MANIFEST.json").open() as f:
+            data = json.load(f)
+
+        assert data["name"] == "valid-json"
+        assert "checksum" in data
+        assert "environment" in data
+
+
+# ---------------------------------------------------------------------------
+# verify_repro_package
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyReproPackage:
+    def test_verify_valid_package(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run1 = run_dir / "run_001"
+        run1.mkdir(parents=True)
+        (run1 / "scenario.yaml").write_text("grid: {rows: 10}\n")
+        (run1 / "summary.json").write_text('{"ok": true}\n')
+
+        out = tmp_path / "package"
+        build_repro_package(name="verify-ok", run_dir=run_dir, out_dir=out)
+
+        ok, issues = verify_repro_package(out)
+        assert ok
+        assert issues == []
+
+    def test_verify_missing_manifest(self, tmp_path: Path):
+        ok, issues = verify_repro_package(tmp_path)
+        assert not ok
+        assert "MANIFEST.json not found" in issues[0]
+
+    def test_verify_detects_missing_artifact(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run1 = run_dir / "run_001"
+        run1.mkdir(parents=True)
+        (run1 / "scenario.yaml").write_text("data\n")
+        (run1 / "summary.json").write_text("{}\n")
+
+        out = tmp_path / "package"
+        build_repro_package(name="missing-art", run_dir=run_dir, out_dir=out)
+
+        # Delete an artifact
+        scenarios = list((out / "scenarios").glob("*.yaml"))
+        assert len(scenarios) > 0
+        scenarios[0].unlink()
+
+        ok, issues = verify_repro_package(out)
+        assert not ok
+        assert any("Missing artifact" in i for i in issues)
+
+    def test_verify_detects_checksum_mismatch(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run1 = run_dir / "run_001"
+        run1.mkdir(parents=True)
+        (run1 / "scenario.yaml").write_text("original\n")
+        (run1 / "summary.json").write_text("{}\n")
+
+        out = tmp_path / "package"
+        build_repro_package(name="tampered", run_dir=run_dir, out_dir=out)
+
+        # Tamper with a file
+        scenarios = list((out / "scenarios").glob("*.yaml"))
+        assert len(scenarios) > 0
+        scenarios[0].write_text("tampered content\n")
+
+        ok, issues = verify_repro_package(out)
+        assert not ok
+        assert any("Checksum mismatch" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# CheckResult / ChecklistReport
+# ---------------------------------------------------------------------------
+
+
+class TestCheckResult:
+    def test_basic_fields(self):
+        r = CheckResult("test_check", True, "looks good")
+        assert r.name == "test_check"
+        assert r.passed
+        assert r.message == "looks good"
+
+
+class TestChecklistReport:
+    def test_all_passed(self):
+        report = ChecklistReport(
+            package_name="test",
+            results=[
+                CheckResult("a", True, "ok"),
+                CheckResult("b", True, "ok"),
+            ],
+        )
+        assert report.passed
+        assert report.total == 2
+        assert report.passed_count == 2
+
+    def test_some_failed(self):
+        report = ChecklistReport(
+            package_name="test",
+            results=[
+                CheckResult("a", True, "ok"),
+                CheckResult("b", False, "missing"),
+            ],
+        )
+        assert not report.passed
+        assert report.passed_count == 1
+
+    def test_to_dict(self):
+        report = ChecklistReport(
+            package_name="pkg",
+            results=[CheckResult("x", True, "fine")],
+        )
+        d = report.to_dict()
+        assert d["package_name"] == "pkg"
+        assert d["passed"] is True
+        assert d["total_checks"] == 1
+
+    def test_to_markdown(self):
+        report = ChecklistReport(
+            package_name="study",
+            results=[
+                CheckResult("check_a", True, "passed"),
+                CheckResult("check_b", False, "failed"),
+            ],
+        )
+        md = report.to_markdown()
+        assert "study" in md
+        assert "PASS" in md
+        assert "FAIL" in md
+        assert "check_a" in md
+
+    def test_empty_report(self):
+        report = ChecklistReport(package_name="empty")
+        assert report.passed  # vacuously true
+        assert report.total == 0
+
+
+# ---------------------------------------------------------------------------
+# run_checklist
+# ---------------------------------------------------------------------------
+
+
+class TestRunChecklist:
+    def test_full_checklist_on_complete_package(self, tmp_path: Path):
+        """Build a complete package and verify checklist passes."""
+        run_dir = tmp_path / "runs"
+        run1 = run_dir / "run_001"
+        run1.mkdir(parents=True)
+        (run1 / "scenario.yaml").write_text("grid: {rows: 10}\n")
+        (run1 / "summary.json").write_text('{"success_rate": 0.95}\n')
+
+        # Create pack results for expected metrics
+        pack_results = tmp_path / "pack_results.json"
+        pack_data = {
+            "manifest_name": "test",
+            "manifest_version": "1.0",
+            "manifest_checksum": "abc",
+            "timestamp": "2024-01-01",
+            "runs": [
+                {
+                    "entry_id": "s1",
+                    "seed": 42,
+                    "metrics": {"success_rate": 0.95},
+                    "status": "completed",
+                    "error": None,
+                },
+            ],
+        }
+        pack_results.write_text(json.dumps(pack_data))
+
+        out = tmp_path / "package"
+        build_repro_package(
+            name="complete-pkg",
+            run_dir=run_dir,
+            pack_result_path=pack_results,
+            out_dir=out,
+            description="A complete study",
+        )
+
+        report = run_checklist(out)
+        assert report.passed
+        assert report.passed_count == report.total
+
+    def test_checklist_on_missing_dir(self, tmp_path: Path):
+        pkg_dir = tmp_path / "missing"
+        pkg_dir.mkdir()
+        report = run_checklist(pkg_dir)
+        assert not report.passed
+
+    def test_checklist_on_minimal_package(self, tmp_path: Path):
+        """A package with no scenarios/results should fail some checks."""
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+        out = tmp_path / "package"
+        build_repro_package(name="minimal", run_dir=run_dir, out_dir=out)
+
+        report = run_checklist(out)
+        # Should fail on scenarios, results, expected_metrics
+        failed = [r for r in report.results if not r.passed]
+        assert len(failed) >= 2
+
+    def test_checklist_json_format(self, tmp_path: Path):
+        """Verify checklist report serializes correctly."""
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+        out = tmp_path / "package"
+        build_repro_package(name="json-test", run_dir=run_dir, out_dir=out)
+
+        report = run_checklist(out)
+        d = report.to_dict()
+        assert isinstance(d["results"], list)
+        assert all("name" in r and "passed" in r for r in d["results"])
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLIIntegration:
+    def test_repro_parser_exists(self):
+        from navirl.cli import build_parser
+
+        parser = build_parser()
+        # Should not raise
+        args = parser.parse_args(["repro", "check", "/some/path"])
+        assert args.repro_command == "check"
+
+    def test_repro_build_parser(self):
+        from navirl.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            ["repro", "build", "my-study", "/runs", "--version", "2.0", "--author", "Alice"]
+        )
+        assert args.name == "my-study"
+        assert args.run_dir == "/runs"
+        assert args.version == "2.0"
+        assert args.author == "Alice"
+
+    def test_repro_verify_parser(self):
+        from navirl.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["repro", "verify", "/some/package"])
+        assert args.repro_command == "verify"


### PR DESCRIPTION
## Summary
- Adds `navirl/repro` module implementing the reproducibility package system from ROADMAP #11
- `build_repro_package()` bundles experiment configs, environment pins (Python version, platform, all installed packages), expected metrics from pack results, and SHA-256 artifact checksums into a self-contained publishable directory with a `MANIFEST.json`
- `run_checklist()` performs 10 automated publication readiness checks (manifest validity, environment pins, scenarios included, results present, artifact checksums, expected metrics, description, package pins, checksum)
- `verify_repro_package()` validates artifact integrity by re-checking all file checksums and sizes
- CLI integration: `navirl repro build`, `navirl repro check`, `navirl repro verify`
- 34 tests covering all components

## Test plan
- [x] All 34 new tests pass
- [x] Full suite: 5116 passed, 98 skipped, 3 xfailed
- [x] `ruff check` clean
- [x] `python -c "from navirl.repro import ReproPackage; print('OK')"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)