### PR TITLE
test: add 87 tests for communication channels, ORCA+ controller, and render helpers

### DIFF
--- a/tests/test_coordination_communication.py
+++ b/tests/test_coordination_communication.py
@@ -1,0 +1,267 @@
+"""Tests for navirl.coordination.communication classical channels.
+
+Covers BroadcastChannel, DirectChannel, SharedMemory, and MessageProtocol.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from navirl.coordination.communication import (
+    BroadcastChannel,
+    DirectChannel,
+    MessageProtocol,
+    SharedMemory,
+)
+
+# ---------------------------------------------------------------------------
+# MessageProtocol
+# ---------------------------------------------------------------------------
+
+
+class TestMessageProtocol:
+    def test_basic_construction(self):
+        msg = MessageProtocol(sender="a1", receiver="a2", content="hello")
+        assert msg.sender == "a1"
+        assert msg.receiver == "a2"
+        assert msg.content == "hello"
+        assert isinstance(msg.timestamp, float)
+        assert msg.metadata == {}
+
+    def test_broadcast_message_receiver_none(self):
+        msg = MessageProtocol(sender="a1", receiver=None, content=[1, 2, 3])
+        assert msg.receiver is None
+        assert msg.content == [1, 2, 3]
+
+    def test_metadata_dict(self):
+        msg = MessageProtocol(
+            sender="a1", receiver="a2", content="x", metadata={"priority": 5}
+        )
+        assert msg.metadata["priority"] == 5
+
+    def test_custom_timestamp(self):
+        ts = 1000.0
+        msg = MessageProtocol(sender="a1", receiver=None, content="x", timestamp=ts)
+        assert msg.timestamp == ts
+
+    def test_default_metadata_independent(self):
+        """Each instance should get its own metadata dict."""
+        m1 = MessageProtocol(sender="a", receiver=None, content="x")
+        m2 = MessageProtocol(sender="b", receiver=None, content="y")
+        m1.metadata["key"] = "val"
+        assert "key" not in m2.metadata
+
+
+# ---------------------------------------------------------------------------
+# BroadcastChannel
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastChannel:
+    def test_send_and_receive(self):
+        ch = BroadcastChannel()
+        msg = MessageProtocol(sender="a1", receiver=None, content="hello")
+        ch.send(msg)
+        received = ch.receive()
+        assert len(received) == 1
+        assert received[0].content == "hello"
+
+    def test_receive_returns_copy(self):
+        ch = BroadcastChannel()
+        ch.send(MessageProtocol(sender="a1", receiver=None, content="x"))
+        r1 = ch.receive()
+        r2 = ch.receive()
+        assert r1 is not r2
+        assert len(r1) == len(r2) == 1
+
+    def test_receive_agent_id_ignored(self):
+        ch = BroadcastChannel()
+        ch.send(MessageProtocol(sender="a1", receiver=None, content="x"))
+        assert len(ch.receive(agent_id="a1")) == 1
+        assert len(ch.receive(agent_id="a2")) == 1
+
+    def test_size_property(self):
+        ch = BroadcastChannel()
+        assert ch.size == 0
+        ch.send(MessageProtocol(sender="a1", receiver=None, content="x"))
+        assert ch.size == 1
+        ch.send(MessageProtocol(sender="a2", receiver=None, content="y"))
+        assert ch.size == 2
+
+    def test_clear(self):
+        ch = BroadcastChannel()
+        ch.send(MessageProtocol(sender="a1", receiver=None, content="x"))
+        ch.clear()
+        assert ch.size == 0
+        assert ch.receive() == []
+
+    def test_buffer_overflow_trims_oldest(self):
+        ch = BroadcastChannel(max_buffer_size=3)
+        for i in range(5):
+            ch.send(MessageProtocol(sender="a1", receiver=None, content=i))
+        assert ch.size == 3
+        msgs = ch.receive()
+        assert [m.content for m in msgs] == [2, 3, 4]
+
+    def test_concurrent_sends(self):
+        ch = BroadcastChannel(max_buffer_size=10000)
+        num_threads = 4
+        msgs_per_thread = 50
+        barrier = threading.Barrier(num_threads)
+
+        def sender(tid):
+            barrier.wait()
+            for i in range(msgs_per_thread):
+                ch.send(
+                    MessageProtocol(sender=f"t{tid}", receiver=None, content=(tid, i))
+                )
+
+        threads = [threading.Thread(target=sender, args=(t,)) for t in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert ch.size == num_threads * msgs_per_thread
+
+
+# ---------------------------------------------------------------------------
+# DirectChannel
+# ---------------------------------------------------------------------------
+
+
+class TestDirectChannel:
+    def test_send_and_receive(self):
+        ch = DirectChannel()
+        msg = MessageProtocol(sender="a1", receiver="a2", content="hello")
+        ch.send(msg)
+        received = ch.receive("a2")
+        assert len(received) == 1
+        assert received[0].content == "hello"
+
+    def test_receive_clears_mailbox(self):
+        ch = DirectChannel()
+        ch.send(MessageProtocol(sender="a1", receiver="a2", content="x"))
+        assert len(ch.receive("a2")) == 1
+        assert len(ch.receive("a2")) == 0
+
+    def test_receive_empty_mailbox(self):
+        ch = DirectChannel()
+        assert ch.receive("nonexistent") == []
+
+    def test_peek_does_not_remove(self):
+        ch = DirectChannel()
+        ch.send(MessageProtocol(sender="a1", receiver="a2", content="x"))
+        peeked = ch.peek("a2")
+        assert len(peeked) == 1
+        # Still there after peek
+        assert len(ch.peek("a2")) == 1
+        # receive should still get it
+        assert len(ch.receive("a2")) == 1
+
+    def test_peek_empty(self):
+        ch = DirectChannel()
+        assert ch.peek("a1") == []
+
+    def test_messages_routed_correctly(self):
+        ch = DirectChannel()
+        ch.send(MessageProtocol(sender="a1", receiver="a2", content="for_a2"))
+        ch.send(MessageProtocol(sender="a1", receiver="a3", content="for_a3"))
+        ch.send(MessageProtocol(sender="a2", receiver="a3", content="also_for_a3"))
+
+        a2_msgs = ch.receive("a2")
+        a3_msgs = ch.receive("a3")
+        assert len(a2_msgs) == 1
+        assert a2_msgs[0].content == "for_a2"
+        assert len(a3_msgs) == 2
+
+    def test_send_requires_receiver(self):
+        ch = DirectChannel()
+        msg = MessageProtocol(sender="a1", receiver=None, content="x")
+        with pytest.raises(ValueError, match="specific receiver"):
+            ch.send(msg)
+
+    def test_peek_returns_copy(self):
+        ch = DirectChannel()
+        ch.send(MessageProtocol(sender="a1", receiver="a2", content="x"))
+        p1 = ch.peek("a2")
+        p2 = ch.peek("a2")
+        assert p1 is not p2
+
+
+# ---------------------------------------------------------------------------
+# SharedMemory
+# ---------------------------------------------------------------------------
+
+
+class TestSharedMemory:
+    def test_write_and_read(self):
+        mem = SharedMemory()
+        mem.write("key1", 42)
+        assert mem.read("key1") == 42
+
+    def test_read_default(self):
+        mem = SharedMemory()
+        assert mem.read("missing") is None
+        assert mem.read("missing", "default") == "default"
+
+    def test_overwrite(self):
+        mem = SharedMemory()
+        mem.write("k", 1)
+        mem.write("k", 2)
+        assert mem.read("k") == 2
+
+    def test_read_all(self):
+        mem = SharedMemory()
+        mem.write("a", 1)
+        mem.write("b", 2)
+        snapshot = mem.read_all()
+        assert snapshot == {"a": 1, "b": 2}
+
+    def test_read_all_returns_copy(self):
+        mem = SharedMemory()
+        mem.write("a", 1)
+        snapshot = mem.read_all()
+        snapshot["a"] = 999
+        assert mem.read("a") == 1
+
+    def test_clear(self):
+        mem = SharedMemory()
+        mem.write("a", 1)
+        mem.clear()
+        assert mem.read("a") is None
+        assert mem.keys == []
+
+    def test_keys_property(self):
+        mem = SharedMemory()
+        assert mem.keys == []
+        mem.write("x", 1)
+        mem.write("y", 2)
+        assert sorted(mem.keys) == ["x", "y"]
+
+    def test_complex_values(self):
+        mem = SharedMemory()
+        mem.write("nested", {"a": [1, 2], "b": {"c": 3}})
+        val = mem.read("nested")
+        assert val["a"] == [1, 2]
+        assert val["b"]["c"] == 3
+
+    def test_concurrent_writes(self):
+        mem = SharedMemory()
+        barrier = threading.Barrier(4)
+
+        def writer(tid):
+            barrier.wait()
+            for i in range(50):
+                mem.write(f"t{tid}_{i}", i)
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(mem.keys) == 200

--- a/tests/test_orca_plus_controller.py
+++ b/tests/test_orca_plus_controller.py
@@ -1,0 +1,419 @@
+"""Tests for navirl.humans.orca_plus.controller.ORCAPlusHumanController.
+
+Covers doorway token protocol, anisotropic personal space, group cohesion,
+speed profiling with acceleration limits, and hesitation injection.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from navirl.core.types import Action, AgentState
+from navirl.humans.orca_plus.controller import ORCAPlusHumanController
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(
+    agent_id: int,
+    x: float,
+    y: float,
+    *,
+    kind: str = "human",
+    vx: float = 0.0,
+    vy: float = 0.0,
+    goal_x: float = 5.0,
+    goal_y: float = 0.0,
+    radius: float = 0.18,
+    max_speed: float = 1.2,
+) -> AgentState:
+    return AgentState(
+        agent_id=agent_id,
+        kind=kind,
+        x=x,
+        y=y,
+        vx=vx,
+        vy=vy,
+        goal_x=goal_x,
+        goal_y=goal_y,
+        radius=radius,
+        max_speed=max_speed,
+    )
+
+
+def _noop_emit(event_type, agent_id, payload):
+    """No-op event sink."""
+
+
+class _CollectingEmit:
+    """Event sink that records all emitted events."""
+
+    def __init__(self):
+        self.events: list[tuple[str, int | None, dict]] = []
+
+    def __call__(self, event_type, agent_id, payload):
+        self.events.append((event_type, agent_id, payload))
+
+
+def _make_controller(cfg=None, seed=0):
+    """Construct controller, bypassing backend path planning."""
+    ctrl = ORCAPlusHumanController(cfg=cfg, seed=seed)
+    return ctrl
+
+
+def _reset_simple(ctrl, human_ids, starts, goals):
+    """Reset with no backend (direct-to-goal paths)."""
+    ctrl.reset(human_ids, starts, goals, backend=None)
+
+
+# ---------------------------------------------------------------------------
+# Construction and configuration
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_default_config(self):
+        ctrl = _make_controller()
+        assert ctrl.enable_doorway_token is True
+        assert ctrl.enable_anisotropic_space is True
+        assert ctrl.enable_speed_profile is True
+        assert ctrl.enable_group_cohesion is False
+
+    def test_custom_config(self):
+        cfg = {
+            "doorway_token": False,
+            "anisotropic_space": False,
+            "speed_profile": False,
+            "group_cohesion": True,
+            "personal_space": 1.2,
+            "accel_limit": 2.0,
+            "hesitation_prob": 0.0,
+            "groups": [[1, 2]],
+        }
+        ctrl = _make_controller(cfg=cfg)
+        assert ctrl.enable_doorway_token is False
+        assert ctrl.enable_group_cohesion is True
+        assert ctrl.personal_space == 1.2
+        assert ctrl.accel_limit == 2.0
+
+    def test_doorway_config(self):
+        cfg = {
+            "doorway": {
+                "center": [1.0, 2.0],
+                "half_extents": [0.5, 0.3],
+                "approach_margin": 0.8,
+            }
+        }
+        ctrl = _make_controller(cfg=cfg)
+        assert ctrl.door_center == (1.0, 2.0)
+        assert ctrl.door_half_extents == (0.5, 0.3)
+        assert ctrl.door_approach_margin == 0.8
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_initializes_state(self):
+        ctrl = _make_controller()
+        _reset_simple(ctrl, [1, 2], {1: (0.0, 0.0), 2: (1.0, 0.0)}, {1: (5.0, 0.0), 2: (5.0, 1.0)})
+        assert ctrl.current_speed == {1: 0.0, 2: 0.0}
+        assert ctrl.token_holder is None
+
+    def test_reset_builds_group_index(self):
+        cfg = {"groups": [[1, 2], [3]]}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(
+            ctrl,
+            [1, 2, 3],
+            {1: (0, 0), 2: (1, 0), 3: (2, 0)},
+            {1: (5, 0), 2: (5, 1), 3: (5, 2)},
+        )
+        assert ctrl.group_by_agent[1] == [1, 2]
+        assert ctrl.group_by_agent[2] == [1, 2]
+        assert ctrl.group_by_agent[3] == [3]
+
+
+# ---------------------------------------------------------------------------
+# Doorway helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDoorwayHelpers:
+    def test_in_doorway_center(self):
+        ctrl = _make_controller()
+        assert ctrl._in_doorway(0.0, 0.0) is True
+
+    def test_in_doorway_margin(self):
+        ctrl = _make_controller()
+        # Default half_extents=(0.25, 0.2), approach_margin=0.6
+        # With margin=0.6: threshold_x=0.25+0.6=0.85
+        assert ctrl._in_doorway(0.8, 0.0, margin=0.6) is True
+        assert ctrl._in_doorway(1.0, 0.0, margin=0.6) is False
+
+    def test_in_doorway_outside(self):
+        ctrl = _make_controller()
+        assert ctrl._in_doorway(10.0, 10.0) is False
+
+    def test_doorway_candidates(self):
+        ctrl = _make_controller()
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (10, 10)}, {1: (5, 0), 2: (5, 5)})
+        states = {
+            1: _make_state(1, 0.0, 0.0),  # near door
+            2: _make_state(2, 10.0, 10.0),  # far from door
+        }
+        cands = ctrl._doorway_candidates(states)
+        assert cands == [1]
+
+
+# ---------------------------------------------------------------------------
+# Doorway token protocol
+# ---------------------------------------------------------------------------
+
+
+class TestDoorwayToken:
+    def test_token_acquired_on_approach(self):
+        ctrl = _make_controller(cfg={"hesitation_prob": 0.0})
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (0.1, 0)}, {1: (5, 0), 2: (5, 0)})
+        states = {
+            1: _make_state(1, 0.0, 0.0),
+            2: _make_state(2, 0.1, 0.0),
+        }
+        emit = _CollectingEmit()
+        ctrl._update_token(states, emit)
+        assert ctrl.token_holder == 1
+        assert any(e[0] == "door_token_acquire" for e in emit.events)
+
+    def test_token_released_when_leaving(self):
+        ctrl = _make_controller(cfg={"hesitation_prob": 0.0})
+        _reset_simple(ctrl, [1], {1: (0, 0)}, {1: (5, 0)})
+        states_near = {1: _make_state(1, 0.0, 0.0)}
+        emit = _CollectingEmit()
+        ctrl._update_token(states_near, emit)
+        assert ctrl.token_holder == 1
+
+        # Agent moves far away
+        states_far = {1: _make_state(1, 10.0, 10.0)}
+        ctrl._update_token(states_far, emit)
+        assert ctrl.token_holder is None
+        assert any(e[0] == "door_token_release" for e in emit.events)
+
+    def test_yielding_non_holder_near_door(self):
+        cfg = {"hesitation_prob": 0.0, "speed_profile": False}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (0.1, 0)}, {1: (5, 0), 2: (5, 0)})
+        states = {
+            1: _make_state(1, 0.0, 0.0),
+            2: _make_state(2, 0.1, 0.0),
+            99: _make_state(99, -5.0, -5.0, kind="robot"),
+        }
+        emit = _CollectingEmit()
+        actions = ctrl.step(0, 0.0, 0.1, states, 99, emit)
+        # Agent 1 gets token (lowest id), agent 2 should yield
+        assert actions[2].behavior == "YIELDING"
+        assert actions[2].pref_vx == 0.0
+        assert actions[2].pref_vy == 0.0
+
+    def test_doorway_disabled(self):
+        cfg = {"doorway_token": False, "hesitation_prob": 0.0, "speed_profile": False}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (0.1, 0)}, {1: (5, 0), 2: (5, 0)})
+        states = {
+            1: _make_state(1, 0.0, 0.0),
+            2: _make_state(2, 0.1, 0.0),
+            99: _make_state(99, -5.0, -5.0, kind="robot"),
+        }
+        emit = _CollectingEmit()
+        actions = ctrl.step(0, 0.0, 0.1, states, 99, emit)
+        # Neither should yield since doorway token is disabled
+        assert actions[2].behavior != "YIELDING"
+
+
+# ---------------------------------------------------------------------------
+# Anisotropic personal space
+# ---------------------------------------------------------------------------
+
+
+class TestAnisotropicSpace:
+    def test_scale_reduces_when_agent_ahead(self):
+        ctrl = _make_controller(cfg={"hesitation_prob": 0.0})
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (0.5, 0)}, {1: (5, 0), 2: (5, 0)})
+        state1 = _make_state(1, 0.0, 0.0)
+        states = {
+            1: state1,
+            2: _make_state(2, 0.5, 0.0),  # directly ahead if moving +x
+        }
+        scale = ctrl._apply_anisotropic_scale(1, state1, (1.0, 0.0), states)
+        # Agent 2 is 0.5m ahead, personal_space=0.9 → scale = 0.5/0.9 ≈ 0.556
+        assert 0.25 <= scale < 1.0
+
+    def test_scale_one_when_no_agent_ahead(self):
+        ctrl = _make_controller(cfg={"hesitation_prob": 0.0})
+        _reset_simple(ctrl, [1], {1: (0, 0)}, {1: (5, 0)})
+        state1 = _make_state(1, 0.0, 0.0)
+        states = {1: state1}
+        scale = ctrl._apply_anisotropic_scale(1, state1, (1.0, 0.0), states)
+        assert scale == 1.0
+
+    def test_scale_one_when_zero_velocity(self):
+        ctrl = _make_controller()
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (0.5, 0)}, {1: (5, 0), 2: (5, 0)})
+        state1 = _make_state(1, 0.0, 0.0)
+        states = {1: state1, 2: _make_state(2, 0.5, 0.0)}
+        scale = ctrl._apply_anisotropic_scale(1, state1, (0.0, 0.0), states)
+        assert scale == 1.0
+
+    def test_disabled_anisotropic(self):
+        ctrl = _make_controller(cfg={"anisotropic_space": False})
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (0.5, 0)}, {1: (5, 0), 2: (5, 0)})
+        state1 = _make_state(1, 0.0, 0.0)
+        states = {1: state1, 2: _make_state(2, 0.5, 0.0)}
+        scale = ctrl._apply_anisotropic_scale(1, state1, (1.0, 0.0), states)
+        assert scale == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Group cohesion
+# ---------------------------------------------------------------------------
+
+
+class TestGroupCohesion:
+    def test_no_bias_when_disabled(self):
+        ctrl = _make_controller(cfg={"group_cohesion": False, "groups": [[1, 2]]})
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (2, 0)}, {1: (5, 0), 2: (5, 0)})
+        states = {1: _make_state(1, 0.0, 0.0), 2: _make_state(2, 2.0, 0.0)}
+        bx, by = ctrl._group_velocity_bias(1, states)
+        assert bx == 0.0 and by == 0.0
+
+    def test_bias_toward_group_center(self):
+        cfg = {"group_cohesion": True, "groups": [[1, 2]], "group_weight": 0.5}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (2, 0)}, {1: (5, 0), 2: (5, 0)})
+        states = {1: _make_state(1, 0.0, 0.0), 2: _make_state(2, 2.0, 0.0)}
+        bx, by = ctrl._group_velocity_bias(1, states)
+        # Group center for agent 1 is at (2.0, 0.0), so bias should be +x
+        assert bx > 0.0
+        assert abs(by) < 1e-6
+
+    def test_no_bias_solo_agent(self):
+        cfg = {"group_cohesion": True, "groups": [[1]]}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1], {1: (0, 0)}, {1: (5, 0)})
+        states = {1: _make_state(1, 0.0, 0.0)}
+        bx, by = ctrl._group_velocity_bias(1, states)
+        assert bx == 0.0 and by == 0.0
+
+    def test_no_bias_ungrouped_agent(self):
+        cfg = {"group_cohesion": True, "groups": [[2, 3]]}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1, 2, 3], {1: (0, 0), 2: (1, 0), 3: (2, 0)}, {1: (5, 0), 2: (5, 0), 3: (5, 0)})
+        states = {
+            1: _make_state(1, 0.0, 0.0),
+            2: _make_state(2, 1.0, 0.0),
+            3: _make_state(3, 2.0, 0.0),
+        }
+        bx, by = ctrl._group_velocity_bias(1, states)
+        assert bx == 0.0 and by == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Speed profiling and hesitation
+# ---------------------------------------------------------------------------
+
+
+class TestSpeedProfile:
+    def test_acceleration_limited(self):
+        cfg = {"hesitation_prob": 0.0, "accel_limit": 1.0, "doorway_token": False}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1], {1: (0, 0)}, {1: (10, 0)})
+        states = {
+            1: _make_state(1, 0.0, 0.0, max_speed=2.0),
+            99: _make_state(99, -5, -5, kind="robot"),
+        }
+
+        # First step: from speed 0, limited by accel_limit * dt
+        dt = 0.1
+        actions = ctrl.step(0, 0.0, dt, states, 99, _noop_emit)
+        speed = math.hypot(actions[1].pref_vx, actions[1].pref_vy)
+        # Max acceleration = 1.0 * 0.1 = 0.1 m/s from standstill
+        assert speed <= 1.0 * dt + 0.01  # small tolerance
+
+    def test_hesitation_reduces_speed(self):
+        # Use seed that triggers hesitation (prob=1.0 guarantees it)
+        cfg = {"hesitation_prob": 1.0, "hesitation_scale": 0.1, "doorway_token": False, "accel_limit": 100.0}
+        ctrl = _make_controller(cfg=cfg, seed=42)
+        _reset_simple(ctrl, [1], {1: (0, 0)}, {1: (10, 0)})
+
+        # Give the agent some current speed
+        ctrl.current_speed[1] = 1.0
+        states = {
+            1: _make_state(1, 0.0, 0.0, max_speed=2.0),
+            99: _make_state(99, -5, -5, kind="robot"),
+        }
+        emit = _CollectingEmit()
+        actions = ctrl.step(0, 0.0, 0.1, states, 99, emit)
+        # With hesitation_prob=1.0, speed should be significantly reduced
+        speed = math.hypot(actions[1].pref_vx, actions[1].pref_vy)
+        assert speed < 0.5  # Should be much less than max_speed
+        assert any(e[0] == "hesitation" for e in emit.events)
+
+    def test_speed_profile_disabled(self):
+        cfg = {"speed_profile": False, "doorway_token": False, "hesitation_prob": 0.0}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1], {1: (0, 0)}, {1: (10, 0)})
+        states = {
+            1: _make_state(1, 0.0, 0.0, max_speed=2.0),
+            99: _make_state(99, -5, -5, kind="robot"),
+        }
+        actions = ctrl.step(0, 0.0, 0.1, states, 99, _noop_emit)
+        # Without speed profile, no acceleration limiting — velocity from ORCA base
+        speed = math.hypot(actions[1].pref_vx, actions[1].pref_vy)
+        assert speed > 0.0  # Should have some velocity toward goal
+
+
+# ---------------------------------------------------------------------------
+# Full step integration
+# ---------------------------------------------------------------------------
+
+
+class TestStepIntegration:
+    def test_step_returns_actions_for_all_humans(self):
+        cfg = {"hesitation_prob": 0.0, "doorway_token": False}
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (1, 0)}, {1: (5, 0), 2: (5, 1)})
+        states = {
+            1: _make_state(1, 0.0, 0.0),
+            2: _make_state(2, 1.0, 0.0),
+            99: _make_state(99, -5, -5, kind="robot"),
+        }
+        actions = ctrl.step(0, 0.0, 0.1, states, 99, _noop_emit)
+        assert 1 in actions
+        assert 2 in actions
+        assert isinstance(actions[1], Action)
+        assert isinstance(actions[2], Action)
+
+    def test_step_with_all_features_enabled(self):
+        cfg = {
+            "doorway_token": True,
+            "anisotropic_space": True,
+            "speed_profile": True,
+            "group_cohesion": True,
+            "groups": [[1, 2]],
+            "hesitation_prob": 0.0,
+        }
+        ctrl = _make_controller(cfg=cfg)
+        _reset_simple(ctrl, [1, 2], {1: (0, 0), 2: (0.1, 0)}, {1: (5, 0), 2: (5, 0)})
+        states = {
+            1: _make_state(1, 0.0, 0.0),
+            2: _make_state(2, 0.1, 0.0),
+            99: _make_state(99, -5, -5, kind="robot"),
+        }
+        # Should not raise
+        actions = ctrl.step(0, 0.0, 0.1, states, 99, _noop_emit)
+        assert len(actions) == 2

--- a/tests/test_viz_render_helpers.py
+++ b/tests/test_viz_render_helpers.py
@@ -1,0 +1,336 @@
+"""Tests for pure helper functions in navirl.viz.render.
+
+Covers _world_to_px, _load_rows, _door_token_by_step, _arrow_endpoint,
+_agent_palette, and EnvironmentRenderer (without requiring a real backend).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from navirl.viz.render import (
+    EnvironmentRenderer,
+    _agent_palette,
+    _arrow_endpoint,
+    _door_token_by_step,
+    _load_rows,
+    _world_to_px,
+)
+
+# ---------------------------------------------------------------------------
+# _world_to_px
+# ---------------------------------------------------------------------------
+
+
+class TestWorldToPx:
+    def test_origin_maps_to_center(self):
+        shape = (100, 200)  # h=100, w=200
+        px, py = _world_to_px(0.0, 0.0, shape, scale=1.0, pixels_per_meter=10.0)
+        assert px == 100  # w/2
+        assert py == 50   # h/2
+
+    def test_scale_factor(self):
+        shape = (100, 100)
+        px1, py1 = _world_to_px(1.0, 0.0, shape, scale=1.0, pixels_per_meter=10.0)
+        px2, py2 = _world_to_px(1.0, 0.0, shape, scale=2.0, pixels_per_meter=10.0)
+        assert px2 == pytest.approx(px1 * 2, abs=1)
+
+    def test_offset_applied(self):
+        shape = (100, 100)
+        px1, py1 = _world_to_px(0.0, 0.0, shape, scale=1.0, pixels_per_meter=10.0)
+        px2, py2 = _world_to_px(
+            0.0, 0.0, shape, scale=1.0, pixels_per_meter=10.0,
+            row_offset=10, col_offset=20,
+        )
+        assert px2 == px1 - 20
+        assert py2 == py1 - 10
+
+    def test_positive_world_x_increases_col(self):
+        shape = (100, 100)
+        px_zero, _ = _world_to_px(0.0, 0.0, shape, scale=1.0, pixels_per_meter=10.0)
+        px_pos, _ = _world_to_px(1.0, 0.0, shape, scale=1.0, pixels_per_meter=10.0)
+        assert px_pos > px_zero
+
+    def test_positive_world_y_increases_row(self):
+        shape = (100, 100)
+        _, py_zero = _world_to_px(0.0, 0.0, shape, scale=1.0, pixels_per_meter=10.0)
+        _, py_pos = _world_to_px(0.0, 1.0, shape, scale=1.0, pixels_per_meter=10.0)
+        assert py_pos > py_zero
+
+
+# ---------------------------------------------------------------------------
+# _load_rows
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRows:
+    def test_loads_jsonl(self, tmp_path):
+        p = tmp_path / "state.jsonl"
+        rows = [{"step": 0, "x": 1.0}, {"step": 1, "x": 2.0}]
+        p.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+        loaded = _load_rows(p)
+        assert len(loaded) == 2
+        assert loaded[0]["step"] == 0
+        assert loaded[1]["x"] == 2.0
+
+    def test_skips_blank_lines(self, tmp_path):
+        p = tmp_path / "state.jsonl"
+        p.write_text('{"step": 0}\n\n\n{"step": 1}\n')
+        loaded = _load_rows(p)
+        assert len(loaded) == 2
+
+    def test_empty_file(self, tmp_path):
+        p = tmp_path / "state.jsonl"
+        p.write_text("")
+        assert _load_rows(p) == []
+
+
+# ---------------------------------------------------------------------------
+# _door_token_by_step
+# ---------------------------------------------------------------------------
+
+
+class TestDoorTokenByStep:
+    def test_nonexistent_file(self, tmp_path):
+        result = _door_token_by_step(tmp_path / "no_such_file.jsonl")
+        assert result == {}
+
+    def test_acquire_and_release(self, tmp_path):
+        p = tmp_path / "events.jsonl"
+        events = [
+            {"step": 0, "event_type": "door_token_acquire", "agent_id": 1},
+            {"step": 5, "event_type": "door_token_release", "agent_id": 1},
+        ]
+        p.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+        result = _door_token_by_step(p)
+        assert result[0] == 1
+        assert result[5] is None
+
+    def test_multiple_agents(self, tmp_path):
+        p = tmp_path / "events.jsonl"
+        events = [
+            {"step": 0, "event_type": "door_token_acquire", "agent_id": 1},
+            {"step": 3, "event_type": "door_token_release", "agent_id": 1},
+            {"step": 4, "event_type": "door_token_acquire", "agent_id": 2},
+        ]
+        p.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+        result = _door_token_by_step(p)
+        assert result[0] == 1
+        assert result[3] is None
+        assert result[4] == 2
+
+    def test_skips_blank_lines(self, tmp_path):
+        p = tmp_path / "events.jsonl"
+        p.write_text('{"step": 0, "event_type": "door_token_acquire", "agent_id": 1}\n\n')
+        result = _door_token_by_step(p)
+        assert result[0] == 1
+
+    def test_non_token_events_dont_change_holder(self, tmp_path):
+        """Non-token events still record the current token_holder at that step."""
+        p = tmp_path / "events.jsonl"
+        events = [
+            {"step": 0, "event_type": "door_token_acquire", "agent_id": 1},
+            {"step": 1, "event_type": "collision", "agent_id": 99},
+            {"step": 2, "event_type": "door_token_release", "agent_id": 1},
+        ]
+        p.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+        result = _door_token_by_step(p)
+        assert result[0] == 1
+        # collision event at step 1 records current holder (still 1)
+        assert result[1] == 1
+        assert result[2] is None
+
+
+# ---------------------------------------------------------------------------
+# _arrow_endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestArrowEndpoint:
+    def test_moving_agent_arrow(self):
+        x, y = 0.0, 0.0
+        vx, vy = 1.0, 0.0
+        ex, ey, heading = _arrow_endpoint(x, y, vx, vy, None)
+        assert ex > x  # Arrow points in +x direction
+        assert abs(ey - y) < 1e-6
+        assert heading is not None
+        assert abs(heading[0] - 1.0) < 1e-6
+
+    def test_stationary_agent_with_last_heading(self):
+        x, y = 0.0, 0.0
+        vx, vy = 0.0, 0.0
+        last_heading = (0.0, 1.0)
+        ex, ey, heading = _arrow_endpoint(x, y, vx, vy, last_heading)
+        assert ey > y  # Arrow points in +y using last heading
+        assert heading == last_heading
+
+    def test_stationary_agent_no_heading(self):
+        x, y = 1.0, 2.0
+        ex, ey, heading = _arrow_endpoint(x, y, 0.0, 0.0, None)
+        assert ex == x
+        assert ey == y
+        assert heading is None
+
+    def test_min_arrow_length(self):
+        x, y = 0.0, 0.0
+        # Very slow speed
+        vx, vy = 0.001, 0.0
+        ex, ey, heading = _arrow_endpoint(x, y, vx, vy, None)
+        length = math.hypot(ex - x, ey - y)
+        assert length >= 0.2  # min_len_m default
+
+    def test_max_arrow_length_capped(self):
+        x, y = 0.0, 0.0
+        vx, vy = 100.0, 0.0
+        ex, ey, heading = _arrow_endpoint(x, y, vx, vy, None)
+        length = math.hypot(ex - x, ey - y)
+        assert length <= 0.52 + 0.01  # capped at 0.52
+
+    def test_diagonal_direction(self):
+        x, y = 0.0, 0.0
+        vx, vy = 1.0, 1.0
+        ex, ey, heading = _arrow_endpoint(x, y, vx, vy, None)
+        assert ex > 0 and ey > 0
+        # Should be roughly equal displacement
+        assert abs(ex - ey) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# _agent_palette
+# ---------------------------------------------------------------------------
+
+
+class TestAgentPalette:
+    def test_robot_palette(self):
+        edge, fill, highlight = _agent_palette("robot", "GO_TO")
+        assert len(edge) == 3
+        assert len(fill) == 3
+        assert len(highlight) == 3
+
+    def test_yielding_human(self):
+        edge, fill, highlight = _agent_palette("human", "YIELDING")
+        # Should differ from regular human
+        edge2, fill2, highlight2 = _agent_palette("human", "GO_TO")
+        assert fill != fill2
+
+    def test_regular_human(self):
+        edge, fill, highlight = _agent_palette("human", "GO_TO")
+        assert all(isinstance(c, int) for c in fill)
+
+    def test_robot_palette_ignores_behavior(self):
+        p1 = _agent_palette("robot", "GO_TO")
+        p2 = _agent_palette("robot", "YIELDING")
+        p3 = _agent_palette("robot", "STOP")
+        assert p1 == p2 == p3
+
+
+# ---------------------------------------------------------------------------
+# EnvironmentRenderer
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentRenderer:
+    def test_construction(self):
+        renderer = EnvironmentRenderer()
+        # cv2 should be available in test env
+        assert isinstance(renderer._cv2_available, bool)
+
+    def test_prepare_map_image_none_backend(self):
+        renderer = EnvironmentRenderer()
+        result = renderer.prepare_map_image(None)
+        assert result is None
+
+    def test_prepare_map_image_grayscale_to_rgb(self):
+        renderer = EnvironmentRenderer()
+
+        class FakeBackend:
+            def map_image(self):
+                return np.ones((10, 10), dtype=np.uint8) * 128
+
+        img = renderer.prepare_map_image(FakeBackend())
+        assert img is not None
+        assert img.ndim == 3
+        assert img.shape == (10, 10, 3)
+        assert img.dtype == np.uint8
+
+    def test_prepare_map_image_already_rgb(self):
+        renderer = EnvironmentRenderer()
+
+        class FakeBackend:
+            def map_image(self):
+                return np.ones((10, 10, 3), dtype=np.uint8) * 128
+
+        img = renderer.prepare_map_image(FakeBackend(), grayscale_to_rgb=True)
+        assert img.shape == (10, 10, 3)
+
+    def test_prepare_map_image_no_grayscale_conversion(self):
+        renderer = EnvironmentRenderer()
+
+        class FakeBackend:
+            def map_image(self):
+                return np.ones((10, 10), dtype=np.uint8) * 128
+
+        img = renderer.prepare_map_image(FakeBackend(), grayscale_to_rgb=False)
+        assert img.ndim == 2
+
+    def test_prepare_map_image_returns_none_for_none_image(self):
+        renderer = EnvironmentRenderer()
+
+        class FakeBackend:
+            def map_image(self):
+                return None
+
+        result = renderer.prepare_map_image(FakeBackend())
+        assert result is None
+
+    def test_draw_agent_circle_with_backend(self):
+        renderer = EnvironmentRenderer()
+        if not renderer._cv2_available:
+            pytest.skip("cv2 not available")
+
+        img = np.zeros((50, 50, 3), dtype=np.uint8)
+
+        class FakeBackend:
+            def world_to_map(self, pos):
+                return (25, 25)
+
+        renderer.draw_agent_circle(img, (0.0, 0.0), FakeBackend())
+        # Some pixels should be non-zero after drawing
+        assert img.sum() > 0
+
+    def test_draw_goal_circle(self):
+        renderer = EnvironmentRenderer()
+        if not renderer._cv2_available:
+            pytest.skip("cv2 not available")
+
+        img = np.zeros((50, 50, 3), dtype=np.uint8)
+
+        class FakeBackend:
+            def world_to_map(self, pos):
+                return (25, 25)
+
+        renderer.draw_goal_circle(img, (1.0, 1.0), FakeBackend())
+        assert img.sum() > 0
+
+    def test_draw_humans(self):
+        renderer = EnvironmentRenderer()
+        if not renderer._cv2_available:
+            pytest.skip("cv2 not available")
+
+        img = np.zeros((50, 50, 3), dtype=np.uint8)
+
+        class FakeBackend:
+            def get_position(self, hid):
+                return (0.0, 0.0)
+
+            def world_to_map(self, pos):
+                return (25, 25)
+
+        renderer.draw_humans(img, [1, 2], FakeBackend())
+        assert img.sum() > 0


### PR DESCRIPTION
## Summary
- **coordination/communication.py** (56% → higher): 30 tests covering BroadcastChannel (send/receive/overflow/concurrent), DirectChannel (routing/peek/error handling), SharedMemory (read/write/concurrent), and MessageProtocol
- **humans/orca_plus/controller.py** (13% → higher): 25 tests covering doorway token protocol (acquire/release/yielding), anisotropic personal space scaling, group cohesion bias, speed profiling with acceleration limits, hesitation injection, and full step integration
- **viz/render.py** (9% → higher): 32 tests covering pure helper functions (_world_to_px, _load_rows, _door_token_by_step, _arrow_endpoint, _agent_palette) and EnvironmentRenderer with fake backends

All 5495 tests pass (87 new), 173 skipped (PyTorch/gymnasium optional deps). Ruff clean.

## Test plan
- [x] All new tests pass individually
- [x] Full test suite passes (5495 passed, 173 skipped)
- [x] Ruff linting clean
- [x] No changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)