### PR TITLE
fix: make mock gymnasium Env.reset() a no-op to match real gymnasium

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -80,7 +80,7 @@ def _build_mock_gym() -> types.ModuleType:
             raise NotImplementedError
 
         def reset(self, **kwargs):
-            raise NotImplementedError
+            pass  # Base class no-op, matching real gymnasium.Env behaviour
 
         def close(self):
             pass


### PR DESCRIPTION
## Summary
- The mock gymnasium module in `test_wrappers.py` (injected into `sys.modules`) had `Env.reset()` raising `NotImplementedError`
- When `test_envs.py` ran after `test_wrappers.py` in the same process, it picked up the mock gymnasium (thinking it was the real package), causing `MockNavEnv.reset()` → `super().reset()` to hit the `NotImplementedError` — **27 test failures**
- Fix: change the mock `Env.reset()` to a no-op (`pass`), matching real `gymnasium.Env.reset()` behavior that subclasses call via `super()`

## Test plan
- [x] All 27 previously failing tests in `test_envs.py` now pass
- [x] All `test_wrappers.py` tests still pass (58 tests)
- [x] Full non-e2e test suite verified across all test files (~5500 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)