### PR TITLE
test: promote kitchen_congestion to reliable e2e scenario

### DIFF
--- a/tests/test_e2e_regression.py
+++ b/tests/test_e2e_regression.py
@@ -38,6 +38,7 @@ RELIABLE_SCENARIOS = [
     "doorway_token_yield.yaml",
     "routine_cook_dinner_micro.yaml",
     "elevator_lobby_waiting.yaml",
+    "kitchen_congestion.yaml",
 ]
 
 # Complex multi-agent scenarios that may deadlock stochastically under
@@ -46,7 +47,6 @@ RELIABLE_SCENARIOS = [
 # rather than hard failures so they don't block the pipeline while still
 # being visible.
 COMPLEX_SCENARIOS = [
-    "kitchen_congestion.yaml",
     "group_cohesion.yaml",
     "robot_comfort_avoidance.yaml",
     "grocery_aisle_navigation.yaml",


### PR DESCRIPTION
## Summary
- Promote `kitchen_congestion.yaml` from `COMPLEX_SCENARIOS` (xfail) to `RELIABLE_SCENARIOS` (hard-fail) in e2e regression tests
- This scenario now consistently passes all invariant checks without deadlocking, giving stronger regression coverage

## Test plan
- [x] Full non-e2e test suite passes (5413 passed, 149 skipped)
- [x] kitchen_congestion passes as a reliable scenario (hard-fail assertion)
- [x] C++ build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)