### PR TITLE
test: add 55 tests for repro checklist and config domain validators

### DIFF
--- a/tests/test_config_domain_validators.py
+++ b/tests/test_config_domain_validators.py
@@ -1,0 +1,209 @@
+"""Tests for domain-specific validators and strict mode in navirl.config.validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from navirl.config.validation import (
+    ConfigValidator,
+    validate_agent_config,
+    validate_env_config,
+    validate_training_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# ConfigValidator strict mode
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidatorStrictMode:
+    def test_strict_rejects_unknown_keys(self):
+        schema = {"lr": {"type": float, "required": False}}
+        config = {"lr": 0.01, "unknown_param": 42}
+        is_valid, errors = ConfigValidator.validate(config, schema, strict=True)
+        assert is_valid is False
+        assert any("Unknown key" in e for e in errors)
+        assert any("strict" in e.lower() for e in errors)
+
+    def test_strict_allows_known_keys(self):
+        schema = {"lr": {"type": float, "required": False}}
+        config = {"lr": 0.01}
+        is_valid, errors = ConfigValidator.validate(config, schema, strict=True)
+        assert is_valid is True
+
+    def test_strict_empty_config(self):
+        schema = {"lr": {"type": float, "required": False}}
+        is_valid, errors = ConfigValidator.validate({}, schema, strict=True)
+        assert is_valid is True
+
+    def test_strict_multiple_unknown_keys(self):
+        schema = {"lr": {"type": float, "required": False}}
+        config = {"lr": 0.01, "extra1": 1, "extra2": 2}
+        is_valid, errors = ConfigValidator.validate(config, schema, strict=True)
+        assert is_valid is False
+        assert len(errors) == 2
+
+    def test_non_strict_allows_unknown_keys(self):
+        schema = {"lr": {"type": float, "required": False}}
+        config = {"lr": 0.01, "unknown_param": 42}
+        is_valid, errors = ConfigValidator.validate(config, schema, strict=False)
+        assert is_valid is True
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# validate_agent_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAgentConfig:
+    def test_valid_agent_config(self):
+        config = {
+            "hidden_sizes": [128, 64],
+            "learning_rate": 1e-4,
+            "batch_size": 32,
+            "gamma": 0.99,
+            "tau": 0.005,
+        }
+        errors = validate_agent_config(config)
+        assert errors == []
+
+    def test_missing_required_hidden_sizes(self):
+        config = {"learning_rate": 1e-4}
+        errors = validate_agent_config(config)
+        assert any("hidden_sizes" in e for e in errors)
+
+    def test_missing_required_learning_rate(self):
+        config = {"hidden_sizes": [64]}
+        errors = validate_agent_config(config)
+        assert any("learning_rate" in e for e in errors)
+
+    def test_negative_learning_rate(self):
+        config = {"hidden_sizes": [64], "learning_rate": -0.01}
+        errors = validate_agent_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_gamma_out_of_range(self):
+        config = {"hidden_sizes": [64], "learning_rate": 1e-4, "gamma": 1.5}
+        errors = validate_agent_config(config)
+        assert any("maximum" in e for e in errors)
+
+    def test_gamma_below_zero(self):
+        config = {"hidden_sizes": [64], "learning_rate": 1e-4, "gamma": -0.1}
+        errors = validate_agent_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_tau_out_of_range(self):
+        config = {"hidden_sizes": [64], "learning_rate": 1e-4, "tau": 2.0}
+        errors = validate_agent_config(config)
+        assert any("maximum" in e for e in errors)
+
+    def test_batch_size_zero(self):
+        config = {"hidden_sizes": [64], "learning_rate": 1e-4, "batch_size": 0}
+        errors = validate_agent_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_wrong_type_learning_rate(self):
+        config = {"hidden_sizes": [64], "learning_rate": "fast"}
+        errors = validate_agent_config(config)
+        assert any("expected type" in e for e in errors)
+
+    def test_minimal_valid_config(self):
+        config = {"hidden_sizes": [32], "learning_rate": 0.001}
+        errors = validate_agent_config(config)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# validate_env_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateEnvConfig:
+    def test_valid_env_config(self):
+        config = {"num_humans": 5, "env_size": 10.0, "time_limit": 100}
+        errors = validate_env_config(config)
+        assert errors == []
+
+    def test_empty_config_ok(self):
+        # All env keys are optional
+        errors = validate_env_config({})
+        assert errors == []
+
+    def test_negative_num_humans(self):
+        config = {"num_humans": -1}
+        errors = validate_env_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_negative_env_size(self):
+        config = {"env_size": -5.0}
+        errors = validate_env_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_negative_time_limit(self):
+        config = {"time_limit": -10}
+        errors = validate_env_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_zero_values_ok(self):
+        config = {"num_humans": 0, "env_size": 0, "time_limit": 0}
+        errors = validate_env_config(config)
+        assert errors == []
+
+    def test_wrong_type_num_humans(self):
+        config = {"num_humans": "five"}
+        errors = validate_env_config(config)
+        assert any("expected type" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# validate_training_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTrainingConfig:
+    def test_valid_training_config(self):
+        config = {
+            "total_steps": 100000,
+            "eval_interval": 5000,
+            "log_interval": 1000,
+            "seed": 42,
+        }
+        errors = validate_training_config(config)
+        assert errors == []
+
+    def test_missing_required_total_steps(self):
+        config = {"eval_interval": 5000}
+        errors = validate_training_config(config)
+        assert any("total_steps" in e for e in errors)
+
+    def test_total_steps_zero(self):
+        config = {"total_steps": 0}
+        errors = validate_training_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_eval_interval_zero(self):
+        config = {"total_steps": 1000, "eval_interval": 0}
+        errors = validate_training_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_log_interval_zero(self):
+        config = {"total_steps": 1000, "log_interval": 0}
+        errors = validate_training_config(config)
+        assert any("minimum" in e for e in errors)
+
+    def test_seed_is_optional(self):
+        config = {"total_steps": 1000}
+        errors = validate_training_config(config)
+        assert errors == []
+
+    def test_wrong_type_total_steps(self):
+        config = {"total_steps": "a lot"}
+        errors = validate_training_config(config)
+        assert any("expected type" in e for e in errors)
+
+    def test_minimal_valid_config(self):
+        config = {"total_steps": 1}
+        errors = validate_training_config(config)
+        assert errors == []

--- a/tests/test_repro_checklist.py
+++ b/tests/test_repro_checklist.py
@@ -1,0 +1,279 @@
+"""Tests for navirl.repro.checklist — publication readiness verification."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from navirl.repro.checklist import ChecklistReport, CheckResult, run_checklist
+
+
+# ---------------------------------------------------------------------------
+# CheckResult
+# ---------------------------------------------------------------------------
+
+
+class TestCheckResult:
+    def test_passed_result(self):
+        r = CheckResult(name="foo", passed=True, message="ok")
+        assert r.name == "foo"
+        assert r.passed is True
+        assert r.message == "ok"
+
+    def test_failed_result(self):
+        r = CheckResult(name="bar", passed=False, message="missing")
+        assert r.passed is False
+
+
+# ---------------------------------------------------------------------------
+# ChecklistReport
+# ---------------------------------------------------------------------------
+
+
+class TestChecklistReport:
+    def test_empty_report_passes(self):
+        report = ChecklistReport(package_name="pkg")
+        assert report.passed is True
+        assert report.total == 0
+        assert report.passed_count == 0
+
+    def test_all_pass(self):
+        report = ChecklistReport(
+            package_name="pkg",
+            results=[
+                CheckResult("a", True, "ok"),
+                CheckResult("b", True, "ok"),
+            ],
+        )
+        assert report.passed is True
+        assert report.total == 2
+        assert report.passed_count == 2
+
+    def test_one_failure_means_not_passed(self):
+        report = ChecklistReport(
+            package_name="pkg",
+            results=[
+                CheckResult("a", True, "ok"),
+                CheckResult("b", False, "missing"),
+            ],
+        )
+        assert report.passed is False
+        assert report.total == 2
+        assert report.passed_count == 1
+
+    def test_to_dict(self):
+        report = ChecklistReport(
+            package_name="test_pkg",
+            results=[CheckResult("a", True, "fine")],
+        )
+        d = report.to_dict()
+        assert d["package_name"] == "test_pkg"
+        assert d["passed"] is True
+        assert d["total_checks"] == 1
+        assert d["passed_checks"] == 1
+        assert len(d["results"]) == 1
+        assert d["results"][0]["name"] == "a"
+
+    def test_to_markdown_pass(self):
+        report = ChecklistReport(
+            package_name="test_pkg",
+            results=[CheckResult("check_one", True, "all good")],
+        )
+        md = report.to_markdown()
+        assert "test_pkg" in md
+        assert "PASS" in md
+        assert "1/1" in md
+        assert "check_one" in md
+
+    def test_to_markdown_fail(self):
+        report = ChecklistReport(
+            package_name="pkg",
+            results=[CheckResult("x", False, "bad")],
+        )
+        md = report.to_markdown()
+        assert "FAIL" in md
+        assert "0/1" in md
+
+
+# ---------------------------------------------------------------------------
+# run_checklist — no MANIFEST.json
+# ---------------------------------------------------------------------------
+
+
+class TestRunChecklistNoManifest:
+    def test_missing_manifest(self, tmp_path):
+        report = run_checklist(tmp_path)
+        assert report.passed is False
+        assert any("MANIFEST.json" in r.message for r in report.results)
+
+
+# ---------------------------------------------------------------------------
+# run_checklist — minimal manifest
+# ---------------------------------------------------------------------------
+
+
+class TestRunChecklistMinimal:
+    def _write_manifest(self, tmp_path, data):
+        (tmp_path / "MANIFEST.json").write_text(json.dumps(data), encoding="utf-8")
+
+    def test_empty_manifest_fails_most_checks(self, tmp_path):
+        self._write_manifest(tmp_path, {})
+        report = run_checklist(tmp_path)
+        assert report.passed is False
+        # Should have multiple failing checks
+        failed = [r for r in report.results if not r.passed]
+        assert len(failed) >= 5
+
+    def test_manifest_exists_check_passes(self, tmp_path):
+        self._write_manifest(tmp_path, {})
+        report = run_checklist(tmp_path)
+        manifest_check = next(r for r in report.results if r.name == "manifest_exists")
+        assert manifest_check.passed is True
+
+    def test_identity_requires_name_and_version(self, tmp_path):
+        self._write_manifest(tmp_path, {"name": "pkg", "version": "1.0"})
+        report = run_checklist(tmp_path)
+        identity = next(r for r in report.results if r.name == "identity")
+        assert identity.passed is True
+
+    def test_identity_fails_without_version(self, tmp_path):
+        self._write_manifest(tmp_path, {"name": "pkg"})
+        report = run_checklist(tmp_path)
+        identity = next(r for r in report.results if r.name == "identity")
+        assert identity.passed is False
+
+    def test_environment_pins(self, tmp_path):
+        self._write_manifest(
+            tmp_path,
+            {
+                "environment": {
+                    "python_version": "3.12.0",
+                    "platform_system": "Linux",
+                    "packages": {"numpy": "1.26"},
+                }
+            },
+        )
+        report = run_checklist(tmp_path)
+        env_check = next(r for r in report.results if r.name == "environment_pins")
+        assert env_check.passed is True
+
+    def test_environment_pins_fail_without_python(self, tmp_path):
+        self._write_manifest(
+            tmp_path,
+            {"environment": {"platform_system": "Linux"}},
+        )
+        report = run_checklist(tmp_path)
+        env_check = next(r for r in report.results if r.name == "environment_pins")
+        assert env_check.passed is False
+
+    def test_scenarios_included(self, tmp_path):
+        self._write_manifest(tmp_path, {})
+        (tmp_path / "scenarios").mkdir()
+        (tmp_path / "scenarios" / "test.yaml").write_text("scenario: true")
+        report = run_checklist(tmp_path)
+        sc = next(r for r in report.results if r.name == "scenarios_included")
+        assert sc.passed is True
+
+    def test_scenarios_missing(self, tmp_path):
+        self._write_manifest(tmp_path, {})
+        report = run_checklist(tmp_path)
+        sc = next(r for r in report.results if r.name == "scenarios_included")
+        assert sc.passed is False
+
+    def test_results_present(self, tmp_path):
+        self._write_manifest(tmp_path, {})
+        (tmp_path / "results").mkdir()
+        (tmp_path / "results" / "run1.json").write_text("{}")
+        report = run_checklist(tmp_path)
+        res = next(r for r in report.results if r.name == "results_present")
+        assert res.passed is True
+
+    def test_artifact_checksums(self, tmp_path):
+        self._write_manifest(
+            tmp_path,
+            {"artifacts": [{"name": "model.pt", "sha256": "abc123"}]},
+        )
+        report = run_checklist(tmp_path)
+        art = next(r for r in report.results if r.name == "artifact_checksums")
+        assert art.passed is True
+
+    def test_artifact_checksums_fail_missing_hash(self, tmp_path):
+        self._write_manifest(
+            tmp_path,
+            {"artifacts": [{"name": "model.pt"}]},
+        )
+        report = run_checklist(tmp_path)
+        art = next(r for r in report.results if r.name == "artifact_checksums")
+        assert art.passed is False
+
+    def test_expected_metrics(self, tmp_path):
+        self._write_manifest(
+            tmp_path,
+            {"expected_metrics": {"success_rate": 0.95}},
+        )
+        report = run_checklist(tmp_path)
+        met = next(r for r in report.results if r.name == "expected_metrics")
+        assert met.passed is True
+
+    def test_description_check(self, tmp_path):
+        self._write_manifest(tmp_path, {"description": "A test package"})
+        report = run_checklist(tmp_path)
+        desc = next(r for r in report.results if r.name == "description")
+        assert desc.passed is True
+
+    def test_package_pins(self, tmp_path):
+        self._write_manifest(
+            tmp_path,
+            {"environment": {"packages": {"numpy": "1.26"}}},
+        )
+        report = run_checklist(tmp_path)
+        pins = next(r for r in report.results if r.name == "package_pins")
+        assert pins.passed is True
+
+    def test_package_checksum(self, tmp_path):
+        self._write_manifest(
+            tmp_path,
+            {"checksum": "sha256:abcdef1234567890"},
+        )
+        report = run_checklist(tmp_path)
+        cs = next(r for r in report.results if r.name == "package_checksum")
+        assert cs.passed is True
+
+
+# ---------------------------------------------------------------------------
+# run_checklist — fully passing package
+# ---------------------------------------------------------------------------
+
+
+class TestRunChecklistFullPass:
+    def test_complete_package_passes_all_checks(self, tmp_path):
+        manifest = {
+            "name": "my_study",
+            "version": "1.0.0",
+            "description": "Reproducibility package for hallway navigation study",
+            "environment": {
+                "python_version": "3.12.0",
+                "platform_system": "Linux",
+                "packages": {"numpy": "1.26.4", "navirl": "0.1.0"},
+            },
+            "artifacts": [
+                {"name": "model.pt", "sha256": "abc123def456"},
+                {"name": "data.h5", "sha256": "789xyz"},
+            ],
+            "expected_metrics": {
+                "success_rate": 0.95,
+                "avg_time_to_goal": 12.5,
+            },
+            "checksum": "sha256:packagelevelchecksum",
+        }
+        (tmp_path / "MANIFEST.json").write_text(json.dumps(manifest), encoding="utf-8")
+        (tmp_path / "scenarios").mkdir()
+        (tmp_path / "scenarios" / "hallway.yaml").write_text("scenario: hallway")
+        (tmp_path / "results").mkdir()
+        (tmp_path / "results" / "run_001.json").write_text("{}")
+
+        report = run_checklist(tmp_path)
+        assert report.passed is True
+        assert report.passed_count == report.total
+        assert report.total == 10  # all 10 checks


### PR DESCRIPTION
## Summary
- **28 tests** for `navirl.repro.checklist` — previously completely untested module relevant to ROADMAP item #11 (reproducibility package). Covers `CheckResult`, `ChecklistReport` (serialization, markdown output), and `run_checklist` (all 10 publication-readiness checks including manifest parsing, identity, environment pins, scenarios, results, artifact checksums, expected metrics, description, package pins, and package checksum).
- **27 tests** for `navirl.config.validation` — covers previously untested strict mode (`ConfigValidator.validate(..., strict=True)`) and all three domain validators (`validate_agent_config`, `validate_env_config`, `validate_training_config`) with valid configs, missing required keys, out-of-range values, and wrong types.

Full suite: **5565 passed**, 149 skipped, 11 xfailed, 0 failures.

## Test plan
- [x] All 55 new tests pass
- [x] Full test suite passes with no regressions (5565 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)