### PR TITLE
feat: add repro package generator and publication templates (ROADMAP #11)

### DIFF
--- a/navirl/cli.py
+++ b/navirl/cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -20,7 +21,14 @@ from navirl.orchestration import Orchestrator, OrchestratorConfig
 from navirl.overseer import apply_layout_to_scenario, suggest_layout
 from navirl.packs import load_pack, run_pack, write_pack_json, write_pack_markdown
 from navirl.pipeline import expand_state_paths, run_batch, run_scenario_file
-from navirl.repro import build_repro_package, run_checklist, verify_repro_package
+from navirl.repro import (
+    GeneratorConfig,
+    build_repro_package,
+    generate_canonical_package,
+    generate_repro_package,
+    run_checklist,
+    verify_repro_package,
+)
 from navirl.scenarios import load_scenario
 from navirl.scenarios.validate import validate_scenario_dict
 from navirl.tune import run_tuning
@@ -501,6 +509,30 @@ def _cmd_repro_build(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_repro_generate(args: argparse.Namespace) -> int:
+    scenario_path = Path(args.scenario)
+    if not scenario_path.is_file():
+        raise FileNotFoundError(f"Scenario not found: {scenario_path}")
+
+    metadata: dict[str, Any] = {}
+    if args.author:
+        metadata["author"] = args.author
+
+    package = generate_canonical_package(
+        scenario_path=scenario_path,
+        out_dir=Path(args.out),
+        name=args.name,
+        version=args.version,
+        description=args.description or "",
+        metadata=metadata or None,
+    )
+    print(f"Generated reproducibility package '{package.name}' v{package.version}")
+    print(f"  Artifacts: {len(package.artifacts)}")
+    print(f"  Checksum: {package.checksum()[:16]}...")
+    print(f"  Output: {args.out}")
+    return 0
+
+
 def _cmd_repro_check(args: argparse.Namespace) -> int:
     package_dir = Path(args.package_dir)
     if not package_dir.is_dir():
@@ -555,6 +587,18 @@ def _create_repro_parser(subparsers) -> None:
     p_build.add_argument("--author", type=str, default=None)
     p_build.add_argument("--study", type=str, default=None)
     p_build.set_defaults(func=_cmd_repro_build)
+
+    # repro generate
+    p_gen = repro_sub.add_parser(
+        "generate", help="Generate a repro package from a single scenario file"
+    )
+    p_gen.add_argument("scenario", type=str, help="Path to scenario YAML file")
+    p_gen.add_argument("--out", type=str, default="out/repro", help="Output directory")
+    p_gen.add_argument("--name", type=str, default=None, help="Package name (defaults to scenario stem)")
+    p_gen.add_argument("--version", type=str, default="1.0")
+    p_gen.add_argument("--description", type=str, default=None)
+    p_gen.add_argument("--author", type=str, default=None)
+    p_gen.set_defaults(func=_cmd_repro_generate)
 
     # repro check
     p_check = repro_sub.add_parser("check", help="Run publication readiness checklist")

--- a/navirl/repro/__init__.py
+++ b/navirl/repro/__init__.py
@@ -8,6 +8,13 @@ publication readiness checklists.
 from __future__ import annotations
 
 from navirl.repro.checklist import ChecklistReport, CheckResult, run_checklist
+from navirl.repro.generator import (
+    GeneratorConfig,
+    discover_run_dirs,
+    discover_scenarios,
+    generate_canonical_package,
+    generate_repro_package,
+)
 from navirl.repro.package import (
     ArtifactEntry,
     EnvironmentPin,
@@ -21,8 +28,13 @@ __all__ = [
     "ChecklistReport",
     "CheckResult",
     "EnvironmentPin",
+    "GeneratorConfig",
     "ReproPackage",
     "build_repro_package",
+    "discover_run_dirs",
+    "discover_scenarios",
+    "generate_canonical_package",
+    "generate_repro_package",
     "run_checklist",
     "verify_repro_package",
 ]

--- a/navirl/repro/generator.py
+++ b/navirl/repro/generator.py
@@ -1,0 +1,240 @@
+"""Auto-generate reproducibility packages from experiment runs.
+
+Provides a higher-level interface than :func:`build_repro_package` that
+can discover scenario files and run outputs automatically, generate
+documentation from templates, and produce publication-ready packages
+in a single call.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from navirl.repro.package import ReproPackage, build_repro_package
+from navirl.repro.templates import get_checklist_template, get_package_readme_template
+
+
+@dataclass
+class GeneratorConfig:
+    """Configuration for reproducibility package generation.
+
+    Parameters
+    ----------
+    name:
+        Package name (e.g. ``"hallway-study-2024"``).
+    version:
+        Semantic version string.
+    description:
+        Human-readable description for the package.
+    run_dir:
+        Directory containing experiment run outputs.
+    out_dir:
+        Output directory for the generated package.
+    scenario_paths:
+        Explicit scenario YAML paths. If ``None``, auto-discovered
+        from *run_dir*.
+    pack_result_path:
+        Optional path to ``pack_results.json`` for expected metrics.
+    metadata:
+        Free-form metadata dict to embed in the package.
+    include_checklist:
+        Whether to include the checklist template in the package.
+    include_readme:
+        Whether to generate a README from the template.
+    """
+
+    name: str
+    version: str = "1.0"
+    description: str = ""
+    run_dir: Path = field(default_factory=lambda: Path("."))
+    out_dir: Path = field(default_factory=lambda: Path("out/repro"))
+    scenario_paths: list[Path] | None = None
+    pack_result_path: Path | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    include_checklist: bool = True
+    include_readme: bool = True
+
+
+def discover_run_dirs(root: Path) -> list[Path]:
+    """Find experiment run directories under *root*.
+
+    A run directory is identified by containing a ``summary.json`` file.
+
+    Returns
+    -------
+    list[Path]
+        Sorted list of directories that contain run outputs.
+    """
+    if not root.is_dir():
+        return []
+    return sorted({p.parent for p in root.rglob("summary.json")})
+
+
+def discover_scenarios(root: Path) -> list[Path]:
+    """Find scenario YAML files under *root*.
+
+    Looks for files named ``scenario.yaml`` or ``*.yaml`` directly
+    inside run directories.
+
+    Returns
+    -------
+    list[Path]
+        Sorted list of discovered scenario files.
+    """
+    if not root.is_dir():
+        return []
+    # Prefer scenario.yaml inside run bundles
+    scenarios = sorted(root.rglob("scenario.yaml"))
+    if scenarios:
+        return scenarios
+    # Fall back to any yaml files
+    return sorted(root.rglob("*.yaml"))
+
+
+def _format_metrics_table(expected_metrics: dict[str, dict[str, float]]) -> str:
+    """Format expected metrics as a Markdown table."""
+    if not expected_metrics:
+        return "No expected metrics recorded."
+    lines = ["| Metric | Mean | Std |", "|--------|------|-----|"]
+    for metric, values in sorted(expected_metrics.items()):
+        mean = values.get("mean", 0.0)
+        std = values.get("std", 0.0)
+        lines.append(f"| {metric} | {mean:.4f} | {std:.4f} |")
+    return "\n".join(lines)
+
+
+def generate_repro_package(config: GeneratorConfig) -> ReproPackage:
+    """Generate a complete reproducibility package from experiment outputs.
+
+    This is the main entry point for package generation. It:
+
+    1. Builds the core package via :func:`build_repro_package`
+    2. Optionally writes a README from the package template
+    3. Optionally includes the publication readiness checklist
+
+    Parameters
+    ----------
+    config:
+        Generation configuration.
+
+    Returns
+    -------
+    ReproPackage
+        The assembled package.
+    """
+    package = build_repro_package(
+        name=config.name,
+        version=config.version,
+        description=config.description,
+        run_dir=config.run_dir,
+        scenario_paths=config.scenario_paths,
+        pack_result_path=config.pack_result_path,
+        out_dir=config.out_dir,
+        metadata=config.metadata,
+    )
+
+    if config.include_checklist:
+        _write_checklist(config.out_dir)
+
+    if config.include_readme:
+        _write_readme(package, config.out_dir)
+
+    return package
+
+
+def _write_checklist(out_dir: Path) -> Path:
+    """Write the checklist template into the package directory."""
+    checklist_path = out_dir / "CHECKLIST.md"
+    checklist_path.write_text(get_checklist_template(), encoding="utf-8")
+    return checklist_path
+
+
+def _write_readme(package: ReproPackage, out_dir: Path) -> Path:
+    """Generate a README from the package template and write it."""
+    template = get_package_readme_template()
+    metrics_table = _format_metrics_table(package.expected_metrics)
+
+    readme = template.format(
+        name=package.name,
+        version=package.version,
+        created_at=package.created_at or "N/A",
+        description=package.description or "N/A",
+        python_version=package.environment.python_version or "3.x",
+        platform_system=package.environment.platform_system or "N/A",
+        platform_machine=package.environment.platform_machine or "N/A",
+        package_dir=out_dir.name,
+        metrics_table=metrics_table,
+    )
+
+    readme_path = out_dir / "README.md"
+    readme_path.write_text(readme, encoding="utf-8")
+    return readme_path
+
+
+def generate_canonical_package(
+    scenario_path: Path,
+    out_dir: Path,
+    *,
+    name: str | None = None,
+    version: str = "1.0",
+    description: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> ReproPackage:
+    """Generate a repro package from a single canonical scenario file.
+
+    This is a convenience wrapper for the common case of producing a
+    reproducibility package from one scenario YAML without first running
+    the full pipeline. It bundles the scenario config and creates
+    the package structure ready for results to be added after replay.
+
+    Parameters
+    ----------
+    scenario_path:
+        Path to a scenario YAML file.
+    out_dir:
+        Output directory.
+    name:
+        Package name. Defaults to the scenario file stem.
+    version:
+        Semantic version.
+    description:
+        Human-readable description.
+    metadata:
+        Optional metadata dict.
+
+    Returns
+    -------
+    ReproPackage
+        The assembled package.
+    """
+    if not scenario_path.is_file():
+        raise FileNotFoundError(f"Scenario not found: {scenario_path}")
+
+    pkg_name = name or scenario_path.stem
+
+    # Create a minimal run directory with the scenario
+    run_dir = out_dir / "_staging"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    bundle = run_dir / pkg_name
+    bundle.mkdir(exist_ok=True)
+    shutil.copy2(scenario_path, bundle / "scenario.yaml")
+
+    config = GeneratorConfig(
+        name=pkg_name,
+        version=version,
+        description=description or f"Reproducibility package for {scenario_path.name}",
+        run_dir=run_dir,
+        out_dir=out_dir,
+        metadata=metadata or {"source_scenario": str(scenario_path)},
+    )
+
+    package = generate_repro_package(config)
+
+    # Clean up staging directory
+    shutil.rmtree(run_dir, ignore_errors=True)
+
+    return package

--- a/navirl/repro/templates/CHECKLIST.md
+++ b/navirl/repro/templates/CHECKLIST.md
@@ -1,0 +1,47 @@
+# Reproducibility Checklist
+
+Use this checklist to verify that a reproducibility package meets the minimum
+requirements for publication alongside a study.
+
+## Package Identity
+
+- [ ] Package has a unique name
+- [ ] Package has a semantic version
+- [ ] Package includes a human-readable description
+
+## Environment Pins
+
+- [ ] Python version recorded
+- [ ] Platform (OS, architecture) recorded
+- [ ] All pip-installed packages pinned with exact versions
+
+## Scenario Configs
+
+- [ ] At least one scenario YAML included
+- [ ] Scenario files are self-contained (no external references to private data)
+- [ ] Scenario seeds are fixed for deterministic replay
+
+## Results and Metrics
+
+- [ ] Result summary JSON files included for each run
+- [ ] Expected metrics documented with mean and standard deviation
+- [ ] Metrics are reproducible within documented tolerance
+
+## Artifact Integrity
+
+- [ ] All artifacts have SHA-256 checksums in MANIFEST.json
+- [ ] Package-level checksum is present
+- [ ] `navirl repro verify <package_dir>` passes without errors
+
+## Legal and Data Compliance
+
+- [ ] No private credentials, API keys, or tokens included
+- [ ] No personally identifiable information (PII) in any artifact
+- [ ] No hardcoded absolute paths referencing private filesystems
+- [ ] License file or notice included if distributing third-party data
+
+## Replay Validation
+
+- [ ] Package can be replayed on a clean environment with documented instructions
+- [ ] Replayed results match expected metrics within tolerance
+- [ ] README includes step-by-step replay instructions

--- a/navirl/repro/templates/PACKAGE_README.md
+++ b/navirl/repro/templates/PACKAGE_README.md
@@ -1,0 +1,61 @@
+# Reproducibility Package: {name}
+
+**Version**: {version}
+**Created**: {created_at}
+**Description**: {description}
+
+## Contents
+
+```
+{name}/
+  MANIFEST.json          # Package manifest with checksums and environment pins
+  README.md              # This file
+  scenarios/             # Scenario YAML configurations
+  results/               # Run summaries and aggregated metrics
+```
+
+## Prerequisites
+
+- Python {python_version}
+- NavIRL (install from repository root: `pip install -e .`)
+
+## Replay Instructions
+
+1. Install NavIRL and its dependencies in a clean virtual environment:
+
+   ```bash
+   python -m venv .venv && source .venv/bin/activate
+   pip install -e /path/to/NavIRL
+   ```
+
+2. Verify package integrity:
+
+   ```bash
+   navirl repro verify {package_dir}
+   ```
+
+3. Run the publication readiness checklist:
+
+   ```bash
+   navirl repro check {package_dir}
+   ```
+
+4. Replay each scenario and compare results:
+
+   ```bash
+   for scenario in {package_dir}/scenarios/*.yaml; do
+     navirl run "$scenario" --out replay_output/
+   done
+   ```
+
+5. Compare replayed metrics against expected values in `MANIFEST.json`.
+
+## Expected Metrics
+
+{metrics_table}
+
+## Environment
+
+- **Python**: {python_version}
+- **Platform**: {platform_system} {platform_machine}
+- **Packages**: See `MANIFEST.json` → `environment.packages` for full pin list

--- a/navirl/repro/templates/__init__.py
+++ b/navirl/repro/templates/__init__.py
@@ -1,0 +1,21 @@
+"""Reproducibility package templates.
+
+Provides standard templates for checklist reports and package
+documentation that accompany published reproducibility packages.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).parent
+
+
+def get_checklist_template() -> str:
+    """Return the contents of the standard checklist template."""
+    return (TEMPLATES_DIR / "CHECKLIST.md").read_text(encoding="utf-8")
+
+
+def get_package_readme_template() -> str:
+    """Return the contents of the package README template."""
+    return (TEMPLATES_DIR / "PACKAGE_README.md").read_text(encoding="utf-8")

--- a/tests/test_repro_generator.py
+++ b/tests/test_repro_generator.py
@@ -1,0 +1,381 @@
+"""Tests for the reproducibility package generator and templates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from navirl.repro.generator import (
+    GeneratorConfig,
+    discover_run_dirs,
+    discover_scenarios,
+    generate_canonical_package,
+    generate_repro_package,
+)
+from navirl.repro.templates import get_checklist_template, get_package_readme_template
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+
+class TestTemplates:
+    def test_checklist_template_loads(self):
+        content = get_checklist_template()
+        assert "Reproducibility Checklist" in content
+        assert "Environment Pins" in content
+        assert "Legal and Data Compliance" in content
+
+    def test_package_readme_template_loads(self):
+        content = get_package_readme_template()
+        assert "{name}" in content
+        assert "{version}" in content
+        assert "Replay Instructions" in content
+
+    def test_checklist_template_has_all_sections(self):
+        content = get_checklist_template()
+        required_sections = [
+            "Package Identity",
+            "Environment Pins",
+            "Scenario Configs",
+            "Results and Metrics",
+            "Artifact Integrity",
+            "Legal and Data Compliance",
+            "Replay Validation",
+        ]
+        for section in required_sections:
+            assert section in content, f"Missing section: {section}"
+
+    def test_readme_template_has_placeholders(self):
+        content = get_package_readme_template()
+        required_placeholders = [
+            "{name}",
+            "{version}",
+            "{created_at}",
+            "{description}",
+            "{python_version}",
+            "{metrics_table}",
+        ]
+        for placeholder in required_placeholders:
+            assert placeholder in content, f"Missing placeholder: {placeholder}"
+
+
+# ---------------------------------------------------------------------------
+# discover_run_dirs
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverRunDirs:
+    def test_finds_run_dirs(self, tmp_path: Path):
+        run1 = tmp_path / "runs" / "run_001" / "bundle"
+        run1.mkdir(parents=True)
+        (run1 / "summary.json").write_text("{}")
+
+        run2 = tmp_path / "runs" / "run_002" / "bundle"
+        run2.mkdir(parents=True)
+        (run2 / "summary.json").write_text("{}")
+
+        dirs = discover_run_dirs(tmp_path / "runs")
+        assert len(dirs) == 2
+
+    def test_returns_empty_for_nonexistent(self, tmp_path: Path):
+        dirs = discover_run_dirs(tmp_path / "nonexistent")
+        assert dirs == []
+
+    def test_returns_empty_for_no_summaries(self, tmp_path: Path):
+        d = tmp_path / "runs"
+        d.mkdir()
+        dirs = discover_run_dirs(d)
+        assert dirs == []
+
+
+# ---------------------------------------------------------------------------
+# discover_scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverScenarios:
+    def test_finds_scenario_yaml(self, tmp_path: Path):
+        run_dir = tmp_path / "runs" / "run_001"
+        run_dir.mkdir(parents=True)
+        (run_dir / "scenario.yaml").write_text("id: test\n")
+
+        scenarios = discover_scenarios(tmp_path / "runs")
+        assert len(scenarios) == 1
+        assert scenarios[0].name == "scenario.yaml"
+
+    def test_returns_empty_for_nonexistent(self, tmp_path: Path):
+        scenarios = discover_scenarios(tmp_path / "nonexistent")
+        assert scenarios == []
+
+    def test_falls_back_to_any_yaml(self, tmp_path: Path):
+        run_dir = tmp_path / "runs"
+        run_dir.mkdir()
+        (run_dir / "custom.yaml").write_text("id: custom\n")
+
+        scenarios = discover_scenarios(run_dir)
+        assert len(scenarios) == 1
+        assert scenarios[0].name == "custom.yaml"
+
+
+# ---------------------------------------------------------------------------
+# GeneratorConfig
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratorConfig:
+    def test_defaults(self):
+        config = GeneratorConfig(name="test")
+        assert config.version == "1.0"
+        assert config.include_checklist is True
+        assert config.include_readme is True
+        assert config.metadata == {}
+
+    def test_custom_values(self):
+        config = GeneratorConfig(
+            name="study",
+            version="2.0",
+            description="A study",
+            include_checklist=False,
+            metadata={"author": "Alice"},
+        )
+        assert config.name == "study"
+        assert config.version == "2.0"
+        assert config.include_checklist is False
+        assert config.metadata["author"] == "Alice"
+
+
+# ---------------------------------------------------------------------------
+# generate_repro_package
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReproPackage:
+    def _make_run_dir(self, tmp_path: Path) -> Path:
+        run_dir = tmp_path / "runs"
+        run1 = run_dir / "run_001"
+        run1.mkdir(parents=True)
+        (run1 / "scenario.yaml").write_text("id: hallway_pass\n")
+        (run1 / "summary.json").write_text('{"success_rate": 1.0}\n')
+        return run_dir
+
+    def test_generates_complete_package(self, tmp_path: Path):
+        run_dir = self._make_run_dir(tmp_path)
+        out = tmp_path / "package"
+
+        config = GeneratorConfig(
+            name="test-gen",
+            run_dir=run_dir,
+            out_dir=out,
+            description="Test generation",
+        )
+        package = generate_repro_package(config)
+
+        assert package.name == "test-gen"
+        assert (out / "MANIFEST.json").is_file()
+        assert (out / "CHECKLIST.md").is_file()
+        assert (out / "README.md").is_file()
+
+    def test_generates_without_checklist(self, tmp_path: Path):
+        run_dir = self._make_run_dir(tmp_path)
+        out = tmp_path / "package"
+
+        config = GeneratorConfig(
+            name="no-checklist",
+            run_dir=run_dir,
+            out_dir=out,
+            include_checklist=False,
+        )
+        generate_repro_package(config)
+
+        assert (out / "MANIFEST.json").is_file()
+        assert not (out / "CHECKLIST.md").exists()
+
+    def test_generates_without_readme(self, tmp_path: Path):
+        run_dir = self._make_run_dir(tmp_path)
+        out = tmp_path / "package"
+
+        config = GeneratorConfig(
+            name="no-readme",
+            run_dir=run_dir,
+            out_dir=out,
+            include_readme=False,
+        )
+        generate_repro_package(config)
+
+        assert (out / "MANIFEST.json").is_file()
+        assert not (out / "README.md").exists()
+
+    def test_readme_contains_package_info(self, tmp_path: Path):
+        run_dir = self._make_run_dir(tmp_path)
+        out = tmp_path / "package"
+
+        config = GeneratorConfig(
+            name="readme-test",
+            version="3.0",
+            description="A readable study",
+            run_dir=run_dir,
+            out_dir=out,
+        )
+        generate_repro_package(config)
+
+        readme = (out / "README.md").read_text()
+        assert "readme-test" in readme
+        assert "3.0" in readme
+        assert "A readable study" in readme
+
+    def test_checklist_file_matches_template(self, tmp_path: Path):
+        run_dir = self._make_run_dir(tmp_path)
+        out = tmp_path / "package"
+
+        config = GeneratorConfig(name="checklist-test", run_dir=run_dir, out_dir=out)
+        generate_repro_package(config)
+
+        checklist = (out / "CHECKLIST.md").read_text()
+        template = get_checklist_template()
+        assert checklist == template
+
+    def test_generates_with_metadata(self, tmp_path: Path):
+        run_dir = self._make_run_dir(tmp_path)
+        out = tmp_path / "package"
+
+        config = GeneratorConfig(
+            name="meta-gen",
+            run_dir=run_dir,
+            out_dir=out,
+            metadata={"author": "Bob", "lab": "NavLab"},
+        )
+        package = generate_repro_package(config)
+
+        assert package.metadata["author"] == "Bob"
+        assert package.metadata["lab"] == "NavLab"
+
+    def test_generates_from_empty_run_dir(self, tmp_path: Path):
+        run_dir = tmp_path / "empty_runs"
+        run_dir.mkdir()
+        out = tmp_path / "package"
+
+        config = GeneratorConfig(name="empty-gen", run_dir=run_dir, out_dir=out)
+        package = generate_repro_package(config)
+
+        assert package.name == "empty-gen"
+        assert (out / "MANIFEST.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# generate_canonical_package
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateCanonicalPackage:
+    def test_from_scenario_file(self, tmp_path: Path):
+        scenario = tmp_path / "hallway_pass.yaml"
+        scenario.write_text("id: hallway_pass\nseed: 7\n")
+
+        out = tmp_path / "package"
+        package = generate_canonical_package(scenario, out)
+
+        assert package.name == "hallway_pass"
+        assert (out / "MANIFEST.json").is_file()
+        assert (out / "README.md").is_file()
+        assert (out / "CHECKLIST.md").is_file()
+        # Staging dir should be cleaned up
+        assert not (out / "_staging").exists()
+
+    def test_custom_name(self, tmp_path: Path):
+        scenario = tmp_path / "test.yaml"
+        scenario.write_text("id: test\n")
+
+        out = tmp_path / "package"
+        package = generate_canonical_package(scenario, out, name="custom-name")
+
+        assert package.name == "custom-name"
+
+    def test_raises_on_missing_scenario(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="Scenario not found"):
+            generate_canonical_package(tmp_path / "nonexistent.yaml", tmp_path / "out")
+
+    def test_includes_scenario_in_package(self, tmp_path: Path):
+        scenario = tmp_path / "my_scenario.yaml"
+        scenario.write_text("id: my_scenario\ngrid: {rows: 5}\n")
+
+        out = tmp_path / "package"
+        package = generate_canonical_package(scenario, out)
+
+        # The scenario should be in the scenarios subdirectory
+        scenario_files = list((out / "scenarios").glob("*.yaml"))
+        assert len(scenario_files) > 0
+
+    def test_metadata_includes_source(self, tmp_path: Path):
+        scenario = tmp_path / "src.yaml"
+        scenario.write_text("id: src\n")
+
+        out = tmp_path / "package"
+        package = generate_canonical_package(scenario, out)
+
+        assert "source_scenario" in package.metadata
+
+    def test_with_description_and_version(self, tmp_path: Path):
+        scenario = tmp_path / "study.yaml"
+        scenario.write_text("id: study\n")
+
+        out = tmp_path / "package"
+        package = generate_canonical_package(
+            scenario, out, version="2.0", description="Hallway study"
+        )
+
+        assert package.version == "2.0"
+        assert package.description == "Hallway study"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration for repro generate
+# ---------------------------------------------------------------------------
+
+
+class TestCLIGenerateParser:
+    def test_repro_generate_parser(self):
+        from navirl.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            ["repro", "generate", "/path/to/scenario.yaml", "--name", "my-pkg", "--version", "2.0"]
+        )
+        assert args.scenario == "/path/to/scenario.yaml"
+        assert args.name == "my-pkg"
+        assert args.version == "2.0"
+
+    def test_repro_generate_defaults(self):
+        from navirl.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["repro", "generate", "/path/scenario.yaml"])
+        assert args.scenario == "/path/scenario.yaml"
+        assert args.name is None
+        assert args.version == "1.0"
+        assert args.out == "out/repro"
+
+
+# ---------------------------------------------------------------------------
+# Imports from navirl.repro
+# ---------------------------------------------------------------------------
+
+
+class TestReproExports:
+    def test_generator_exports_available(self):
+        from navirl.repro import (
+            GeneratorConfig,
+            discover_run_dirs,
+            discover_scenarios,
+            generate_canonical_package,
+            generate_repro_package,
+        )
+
+        assert GeneratorConfig is not None
+        assert callable(discover_run_dirs)
+        assert callable(discover_scenarios)
+        assert callable(generate_canonical_package)
+        assert callable(generate_repro_package)


### PR DESCRIPTION
## Summary
- Adds `navirl/repro/generator.py` with `GeneratorConfig`, `generate_repro_package()`, `generate_canonical_package()`, and discovery helpers (`discover_run_dirs`, `discover_scenarios`)
- Adds `navirl/repro/templates/` with publication readiness checklist template (`CHECKLIST.md`) and package README template (`PACKAGE_README.md`)
- Adds `repro generate` CLI subcommand for creating packages from individual scenario files
- Adds 28 tests covering generator, templates, CLI parsing, and module exports

## Context
Part of ROADMAP #11 (formal reproducibility package). Complements PR #141 which adds replay validation and compliance scanning. This PR focuses on the generation pipeline and documentation templates.

## Test plan
- [x] All 28 new tests pass (`pytest tests/test_repro_generator.py`)
- [x] All 34 existing repro tests still pass (`pytest tests/test_repro_package.py`)
- [x] Full suite passes: 5523 passed, 173 skipped
- [x] Import verification: `from navirl.repro.package import ReproPackage` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)