### PR TITLE
fix: remove phantom imports from navirl.rewards and navirl.maps

### DIFF
--- a/navirl/maps/__init__.py
+++ b/navirl/maps/__init__.py
@@ -1,40 +1,12 @@
 """NavIRL maps sub-package.
 
-Provides grid-based occupancy maps, semantic maps, topological
-(graph-based) maps, procedural map generation, and utility functions
-for map I/O, coordinate transforms, and path operations.
+Provides grid-based occupancy maps for indoor navigation.
 """
 
 from __future__ import annotations
 
 from navirl.maps.grid_map import GridMap
-from navirl.maps.map_utils import (
-    line_of_sight,
-    load_map_pgm,
-    load_map_png,
-    load_map_yaml,
-    map_statistics,
-    path_smooth,
-    save_map_pgm,
-    save_map_png,
-    save_map_yaml,
-)
-from navirl.maps.procedural import ProceduralGenerator
-from navirl.maps.semantic_map import SemanticMap
-from navirl.maps.topological_map import TopologicalMap
 
 __all__ = [
     "GridMap",
-    "ProceduralGenerator",
-    "SemanticMap",
-    "TopologicalMap",
-    "line_of_sight",
-    "load_map_pgm",
-    "load_map_png",
-    "load_map_yaml",
-    "map_statistics",
-    "path_smooth",
-    "save_map_pgm",
-    "save_map_png",
-    "save_map_yaml",
 ]

--- a/navirl/rewards/__init__.py
+++ b/navirl/rewards/__init__.py
@@ -8,9 +8,6 @@ Submodules
 ----------
 - **base** -- Abstract base classes, composition utilities, normalisation and shaping.
 - **navigation** -- Goal-seeking, path-following, collision and motion-quality rewards.
-- **social** -- Social-awareness rewards (proxemics, yielding, group coherence, ...).
-- **learned** -- Neural / IRL / GAIL / curiosity-driven learned reward functions.
-- **multi_objective** -- Multi-objective reward handling with Pareto front support.
 """
 
 from __future__ import annotations
@@ -23,18 +20,6 @@ from navirl.rewards.base import (
     RewardNormalizer,
     RewardShaper,
 )
-from navirl.rewards.learned import (
-    CuriosityReward,
-    EnsembleReward,
-    GAILReward,
-    IRLReward,
-    NeuralRewardFunction,
-    RNDReward,
-)
-from navirl.rewards.multi_objective import (
-    MultiObjectiveReward,
-    ParetoFront,
-)
 from navirl.rewards.navigation import (
     BoundaryPenalty,
     CollisionPenalty,
@@ -44,17 +29,6 @@ from navirl.rewards.navigation import (
     SmoothnessReward,
     TimePenaltyReward,
     VelocityReward,
-)
-from navirl.rewards.social import (
-    ComfortReward,
-    GazeAwarenessReward,
-    GroupCoherenceReward,
-    OvertakingReward,
-    PersonalSpaceReward,
-    ProxemicsReward,
-    RightOfWayReward,
-    SocialForceReward,
-    YieldingReward,
 )
 
 __all__ = [
@@ -74,24 +48,4 @@ __all__ = [
     "VelocityReward",
     "SmoothnessReward",
     "BoundaryPenalty",
-    # social
-    "PersonalSpaceReward",
-    "SocialForceReward",
-    "ProxemicsReward",
-    "GazeAwarenessReward",
-    "GroupCoherenceReward",
-    "OvertakingReward",
-    "YieldingReward",
-    "RightOfWayReward",
-    "ComfortReward",
-    # learned
-    "NeuralRewardFunction",
-    "IRLReward",
-    "GAILReward",
-    "EnsembleReward",
-    "CuriosityReward",
-    "RNDReward",
-    # multi-objective
-    "MultiObjectiveReward",
-    "ParetoFront",
 ]

--- a/tests/test_maps_rewards.py
+++ b/tests/test_maps_rewards.py
@@ -2,70 +2,30 @@
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
 import math
-import pathlib as _pathlib
-import sys
-import types
 
 import numpy as np
 import pytest
 
-# ---------------------------------------------------------------------------
-# Bootstrap: navirl.maps and navirl.rewards __init__.py files import
-# submodules that may not exist in this checkout. We register stub packages
-# and load the specific modules we need directly from their file paths.
-# ---------------------------------------------------------------------------
-
-_root = _pathlib.Path(__file__).resolve().parent.parent / "navirl"
-
-
-def _load_module(fqn: str, filepath: _pathlib.Path) -> types.ModuleType:
-    """Load a single Python file as *fqn* into sys.modules."""
-    spec = importlib.util.spec_from_file_location(fqn, filepath)
-    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
-    sys.modules[fqn] = mod
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    return mod
-
-
-def _ensure_stub_package(fqn: str, path: _pathlib.Path) -> None:
-    """Register a lightweight stub package so child modules can be imported."""
-    if fqn not in sys.modules:
-        stub = types.ModuleType(fqn)
-        stub.__path__ = [str(path)]  # type: ignore[attr-defined]
-        stub.__package__ = fqn
-        sys.modules[fqn] = stub
-
-
-_ensure_stub_package("navirl.maps", _root / "maps")
-_ensure_stub_package("navirl.rewards", _root / "rewards")
-
-_grid_map = _load_module("navirl.maps.grid_map", _root / "maps" / "grid_map.py")
-_rewards_base = _load_module("navirl.rewards.base", _root / "rewards" / "base.py")
-_rewards_nav = _load_module("navirl.rewards.navigation", _root / "rewards" / "navigation.py")
-
-GridMap = _grid_map.GridMap
-FREE = _grid_map.FREE
-OCCUPIED = _grid_map.OCCUPIED
-UNKNOWN = _grid_map.UNKNOWN
-
-CompositeReward = _rewards_base.CompositeReward
-RewardClipper = _rewards_base.RewardClipper
-RewardComponent = _rewards_base.RewardComponent
-RewardFunction = _rewards_base.RewardFunction
-RewardNormalizer = _rewards_base.RewardNormalizer
-RewardShaper = _rewards_base.RewardShaper
-
-BoundaryPenalty = _rewards_nav.BoundaryPenalty
-CollisionPenalty = _rewards_nav.CollisionPenalty
-GoalReward = _rewards_nav.GoalReward
-PathFollowingReward = _rewards_nav.PathFollowingReward
-ProgressReward = _rewards_nav.ProgressReward
-SmoothnessReward = _rewards_nav.SmoothnessReward
-TimePenaltyReward = _rewards_nav.TimePenaltyReward
-VelocityReward = _rewards_nav.VelocityReward
+from navirl.maps.grid_map import FREE, OCCUPIED, UNKNOWN, GridMap
+from navirl.rewards.base import (
+    CompositeReward,
+    RewardClipper,
+    RewardComponent,
+    RewardFunction,
+    RewardNormalizer,
+    RewardShaper,
+)
+from navirl.rewards.navigation import (
+    BoundaryPenalty,
+    CollisionPenalty,
+    GoalReward,
+    PathFollowingReward,
+    ProgressReward,
+    SmoothnessReward,
+    TimePenaltyReward,
+    VelocityReward,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_navigation_rewards.py
+++ b/tests/test_navigation_rewards.py
@@ -2,37 +2,34 @@
 
 from __future__ import annotations
 
-import importlib.util
 import math
-import sys
-from pathlib import Path
 
 import numpy as np
 import pytest
 
-# Import the submodule directly from file to avoid the package __init__
-# which tries to import navirl.rewards.learned (may not exist).
-# First ensure the base module is loadable.
-_base_path = Path(__file__).resolve().parent.parent / "navirl" / "rewards" / "base.py"
-_base_spec = importlib.util.spec_from_file_location("navirl.rewards.base", _base_path)
-if "navirl.rewards.base" not in sys.modules:
-    _base_mod = importlib.util.module_from_spec(_base_spec)
-    sys.modules[_base_spec.name] = _base_mod
-    _base_spec.loader.exec_module(_base_mod)
+from navirl.rewards.navigation import (
+    BoundaryPenalty,
+    CollisionPenalty,
+    GoalReward,
+    PathFollowingReward,
+    ProgressReward,
+    SmoothnessReward,
+    TimePenaltyReward,
+    VelocityReward,
+)
 
-_nav_path = Path(__file__).resolve().parent.parent / "navirl" / "rewards" / "navigation.py"
-_nav_spec = importlib.util.spec_from_file_location("navirl.rewards.navigation", _nav_path)
-_nav = importlib.util.module_from_spec(_nav_spec)
-sys.modules[_nav_spec.name] = _nav
-_nav_spec.loader.exec_module(_nav)
-BoundaryPenalty = _nav.BoundaryPenalty
-CollisionPenalty = _nav.CollisionPenalty
-GoalReward = _nav.GoalReward
-PathFollowingReward = _nav.PathFollowingReward
-ProgressReward = _nav.ProgressReward
-SmoothnessReward = _nav.SmoothnessReward
-TimePenaltyReward = _nav.TimePenaltyReward
-VelocityReward = _nav.VelocityReward
+
+def test_rewards_package_imports_cleanly():
+    """Guard against phantom imports in navirl.rewards.__init__.
+
+    Past regression: __init__.py referenced modules (learned, social,
+    multi_objective) that were never created, making `import navirl.rewards`
+    fail with ModuleNotFoundError.
+    """
+    import navirl.rewards as r
+
+    for name in r.__all__:
+        assert hasattr(r, name), f"navirl.rewards.__all__ lists {name!r} but it is not importable"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Both `navirl.rewards` and `navirl.maps` package `__init__.py` files imported from submodules that were never created (`learned`, `social`, `multi_objective`, `map_utils`, `procedural`, `semantic_map`, `topological_map`), so `import navirl.rewards` and `import navirl.maps` failed with `ModuleNotFoundError`.
- Two tests (`test_navigation_rewards.py`, `test_maps_rewards.py`) worked around the breakage by registering stub packages in `sys.modules` and loading submodules by file path. Under pytest-xdist those stubs leaked across workers and masked the real bug.
- Trimmed `__init__.py` in both packages to export only the symbols that actually exist (`base`, `navigation` for rewards; `grid_map` for maps).
- Replaced bootstrap stubs in the two tests with plain imports.
- Added a regression test that walks `navirl.rewards.__all__` to catch future phantom imports.

## Test plan

- [x] `import navirl.rewards` and `import navirl.maps` both succeed on a clean checkout.
- [x] `pytest --tb=short -q` → 5493 passed, 176 skipped (was 5492 / 176; +1 from the new regression test).
- [x] `cmake .. && make` still produces `libRVO.a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)