### PR TITLE
fix: resolve phantom imports and torch-less failure in navirl.imitation

### DIFF
--- a/navirl/imitation/__init__.py
+++ b/navirl/imitation/__init__.py
@@ -3,24 +3,49 @@
 This package contains implementations of various imitation learning algorithms
 including behavioral cloning, inverse reinforcement learning, and adversarial
 imitation learning methods.
+
+Classes that wrap torch networks (``RewardNetwork``, ``Discriminator``) import
+without torch installed, but instantiating them — or any of the agent classes
+(``AIRLAgent``, ``BCAgent``, ``DAggerAgent``, ``GAILAgent``) — requires the
+``[agents]`` extra.
 """
 
 from __future__ import annotations
 
-from .airl import AIRL
-from .bc import BehavioralCloning
-from .dagger import DAgger
-from .dataset import ImitationDataset
-from .gail import GAIL
-from .irl import InverseReinforcementLearning
-from .reward_learning import RewardLearning
+from .airl import AIRLAgent, AIRLConfig, RewardNetwork
+from .bc import BCAgent, BCConfig
+from .dagger import DAggerAgent, DAggerConfig
+from .dataset import DemonstrationDataset, FeatureStatistics
+from .gail import Discriminator, GAILAgent, GAILConfig
+from .irl import MaxEntIRL, MaxEntIRLConfig
+from .reward_learning import (
+    DemonstrationRewardConfig,
+    DemonstrationRewardModel,
+    EnsembleRewardConfig,
+    EnsembleRewardModel,
+    PreferenceRewardConfig,
+    PreferenceRewardModel,
+)
 
 __all__ = [
-    "AIRL",
-    "GAIL",
-    "BehavioralCloning",
-    "DAgger",
-    "ImitationDataset",
-    "InverseReinforcementLearning",
-    "RewardLearning",
+    "AIRLAgent",
+    "AIRLConfig",
+    "BCAgent",
+    "BCConfig",
+    "DAggerAgent",
+    "DAggerConfig",
+    "DemonstrationDataset",
+    "DemonstrationRewardConfig",
+    "DemonstrationRewardModel",
+    "Discriminator",
+    "EnsembleRewardConfig",
+    "EnsembleRewardModel",
+    "FeatureStatistics",
+    "GAILAgent",
+    "GAILConfig",
+    "MaxEntIRL",
+    "MaxEntIRLConfig",
+    "PreferenceRewardConfig",
+    "PreferenceRewardModel",
+    "RewardNetwork",
 ]

--- a/navirl/imitation/airl.py
+++ b/navirl/imitation/airl.py
@@ -35,6 +35,12 @@ try:
     _TORCH_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _TORCH_AVAILABLE = False
+    # Minimal shim so module-level class definitions (RewardNetwork(nn.Module)
+    # etc.) succeed. Actual torch-using code paths are guarded by
+    # _TORCH_AVAILABLE checks and raise from AIRLAgent.__init__ instead.
+    import types as _types
+
+    nn = _types.SimpleNamespace(Module=object)
 
 __all__ = ["AIRLAgent", "AIRLConfig", "RewardNetwork"]
 

--- a/navirl/imitation/gail.py
+++ b/navirl/imitation/gail.py
@@ -30,6 +30,12 @@ try:
     _TORCH_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _TORCH_AVAILABLE = False
+    # Minimal shim so module-level class definitions (Discriminator(nn.Module)
+    # etc.) succeed. Actual torch-using code paths are guarded by
+    # _TORCH_AVAILABLE checks and raise from GAILAgent.__init__ instead.
+    import types as _types
+
+    nn = _types.SimpleNamespace(Module=object)
 
 __all__ = ["Discriminator", "GAILAgent", "GAILConfig"]
 

--- a/tests/test_imitation_package_imports.py
+++ b/tests/test_imitation_package_imports.py
@@ -1,0 +1,61 @@
+"""Regression tests for navirl.imitation package-level imports.
+
+These tests guard against two classes of bug that have bitten this package
+before:
+
+1. ``__init__.py`` references names that do not exist in the submodules
+   (phantom imports — masked by test bootstrap stubs that leak across
+   pytest-xdist workers).
+2. Submodules define ``nn.Module`` subclasses at module top level but guard
+   ``import torch`` with a ``try/except ImportError`` that leaves ``nn``
+   undefined, so ``import navirl.imitation`` blows up on torch-less envs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import textwrap
+
+
+def test_navirl_imitation_imports_cleanly() -> None:
+    """``import navirl.imitation`` must succeed in-process."""
+    mod = importlib.import_module("navirl.imitation")
+    assert mod.__all__, "navirl.imitation should expose a non-empty __all__"
+
+
+def test_navirl_imitation_all_names_resolve() -> None:
+    """Every name listed in ``__all__`` must be attached to the module."""
+    mod = importlib.import_module("navirl.imitation")
+    missing = [name for name in mod.__all__ if not hasattr(mod, name)]
+    assert not missing, f"navirl.imitation.__all__ references missing names: {missing}"
+
+
+def test_navirl_imitation_imports_in_fresh_interpreter() -> None:
+    """Spawn a fresh interpreter to avoid sys.modules workarounds masking breakage.
+
+    Test files in this suite register stubs in ``sys.modules`` before loading
+    submodules directly from disk to work around historical ``__init__.py``
+    phantom imports. Those stubs leak between tests via pytest-xdist workers,
+    so a regression in ``__init__.py`` can be invisible to the main suite.
+    A subprocess guarantees a clean import.
+    """
+    script = textwrap.dedent(
+        """
+        import navirl.imitation
+        missing = [n for n in navirl.imitation.__all__
+                   if not hasattr(navirl.imitation, n)]
+        assert not missing, f"missing: {missing}"
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"navirl.imitation failed to import in a fresh interpreter.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

- `import navirl.imitation` has been failing on any interpreter without torch with `NameError: name 'nn' is not defined`, because `airl.py` and `gail.py` define `nn.Module` subclasses at module top level but the `try: import torch` fallback leaves `nn` unbound.
- Separately, `__init__.py` imports seven names (`AIRL`, `BehavioralCloning`, `DAgger`, `GAIL`, `InverseReinforcementLearning`, `ImitationDataset`, `RewardLearning`) that have never existed in any of the submodules. The real classes are `AIRLAgent`, `BCAgent`, `DAggerAgent`, `GAILAgent`, `MaxEntIRL`, `DemonstrationDataset`, and the three `*RewardModel` classes.
- Both bugs were masked because every `tests/test_imitation*.py` file imports from submodules directly (`from navirl.imitation.airl import AIRLAgent`) or registers `sys.modules` stubs that leak across pytest-xdist workers. CI stayed green; `import navirl.imitation` in a fresh interpreter did not.

## Changes

- `navirl/imitation/airl.py`, `navirl/imitation/gail.py`: when `import torch` fails, bind `types.SimpleNamespace(Module=object)` as `nn` so module-level class definitions still succeed. Every actual torch code path is already guarded by `_TORCH_AVAILABLE` inside the agent `__init__` methods, which raise with a clear `"requires PyTorch"` message.
- `navirl/imitation/__init__.py`: replace the phantom import list with the real symbols each submodule exports, and update `__all__` to match.
- `tests/test_imitation_package_imports.py`: new regression suite. Asserts `import navirl.imitation` works in-process *and* in a subprocess (to defeat sys.modules stub leakage), and walks `__all__` to confirm every name resolves.

## Test plan

- [x] `pytest tests/test_imitation_package_imports.py -v` — 3 new tests pass
- [x] `pytest --tb=no -q` — full suite: 5495 passed, 176 skipped (was 5492 + 176 on main, +3 new tests, no regressions)
- [x] `python -c "import navirl.imitation"` in a venv without torch — succeeds (previously raised `NameError`)
- [x] `python -c "from navirl.imitation import AIRLAgent, BCAgent, DAggerAgent, GAILAgent, MaxEntIRL, DemonstrationDataset"` — succeeds (previously raised `ImportError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)