### PR TITLE
test: add 44 tests for datasets parser, astar recovery, orca human controller

### DIFF
--- a/tests/test_baseline_astar_controller.py
+++ b/tests/test_baseline_astar_controller.py
@@ -1,0 +1,261 @@
+"""Coverage tests for navirl.robots.baselines.astar.BaselineAStarRobotController.
+
+The existing test_robot_baseline_planners.py only exercises the happy path via
+a smoke test. This file targets the stuck-recovery state machine, replanning,
+grace period, waypoint advance, goal-tolerance paths, and DONE behavior.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import Mock
+
+import pytest
+
+from navirl.core.types import Action, AgentState
+from navirl.robots.baselines import BaselineAStarRobotController
+
+
+class _StraightLineBackend:
+    """Minimal backend that returns the direct start->goal path."""
+
+    def __init__(self, return_empty: bool = False):
+        self.return_empty = return_empty
+        self.calls: list[tuple[tuple[float, float], tuple[float, float]]] = []
+
+    def shortest_path(self, start, goal):
+        self.calls.append((tuple(start), tuple(goal)))
+        if self.return_empty:
+            return []
+        # Create a short multi-waypoint path so lookahead and advance logic run.
+        sx, sy = start
+        gx, gy = goal
+        return [
+            (sx, sy),
+            ((sx + gx) / 3, (sy + gy) / 3),
+            (2 * (sx + gx) / 3, 2 * (sy + gy) / 3),
+            (gx, gy),
+        ]
+
+
+def _robot_state(x: float, y: float, goal=(3.0, 3.0), max_speed: float = 1.0) -> AgentState:
+    return AgentState(
+        agent_id=0,
+        kind="robot",
+        x=x,
+        y=y,
+        vx=0.0,
+        vy=0.0,
+        goal_x=goal[0],
+        goal_y=goal[1],
+        max_speed=max_speed,
+        radius=0.2,
+    )
+
+
+@pytest.fixture
+def emit():
+    return Mock()
+
+
+class TestPlanFallback:
+    def test_empty_path_falls_back_to_goal(self):
+        """If backend returns [], the planner stores [goal] as the path."""
+        ctrl = BaselineAStarRobotController()
+        backend = _StraightLineBackend(return_empty=True)
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+        assert ctrl.path == [(3.0, 3.0)]
+
+
+class TestDoneBehavior:
+    def test_step_returns_done_at_goal(self, emit):
+        ctrl = BaselineAStarRobotController({"goal_tolerance": 0.25})
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), _StraightLineBackend())
+        state = _robot_state(3.0, 3.0)
+        action = ctrl.step(0, 0.0, 0.1, {0: state}, emit)
+        assert action.behavior == "DONE"
+        assert action.pref_vx == 0.0 and action.pref_vy == 0.0
+
+
+class TestWaypointAdvance:
+    def test_close_to_waypoint_advances_path_index(self, emit):
+        """Standing on a waypoint makes the controller advance past it."""
+        ctrl = BaselineAStarRobotController(
+            {"goal_tolerance": 0.1, "target_lookahead": 1, "velocity_smoothing": 1.0}
+        )
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), _StraightLineBackend())
+        # Place robot at the first intermediate waypoint so the close-to-target
+        # branch triggers and the index advances.
+        wp0 = ctrl.path[0]
+        state = _robot_state(wp0[0], wp0[1])
+        action = ctrl.step(1, 0.1, 0.1, {0: state}, emit)
+        assert ctrl.path_idx >= 1
+        assert action.behavior == "GO_TO"
+
+
+class TestStuckRecovery:
+    def _make_controller(self, **kwargs) -> BaselineAStarRobotController:
+        cfg = {
+            "stuck_window": 3,  # very small so tests stay fast
+            "stuck_dist_threshold": 0.05,
+            "wait_duration": 50,  # keep the controller in wait long enough to assert
+            "max_wait_cycles": 4,
+            "replan_interval": 1000,  # don't let periodic replans confound assertions
+            "goal_tolerance": 0.1,
+            "target_lookahead": 1,
+        }
+        cfg.update(kwargs)
+        return BaselineAStarRobotController(cfg)
+
+    def test_detect_stuck_false_until_window_full(self):
+        ctrl = self._make_controller()
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+        # After reset _pos_window has 1 entry; window size 3, so detection stays
+        # False until the window fills (lines 91-92).
+        assert ctrl._detect_stuck(_robot_state(0.0, 0.0)) is False
+
+    def test_detect_stuck_true_on_full_window_no_progress(self):
+        ctrl = self._make_controller()
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+        # Fill window with near-identical positions → stuck=True once full.
+        ctrl._detect_stuck(_robot_state(0.0, 0.0))
+        assert ctrl._detect_stuck(_robot_state(0.005, 0.0)) is True
+
+    def test_detect_stuck_progress_resets_wait_cycles(self):
+        ctrl = self._make_controller()
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+        ctrl._wait_cycles = 2
+        # Fill window then supply a position far from the start.
+        ctrl._detect_stuck(_robot_state(0.0, 0.0))
+        ctrl._detect_stuck(_robot_state(0.0, 0.0))
+        # Large displacement — dist >= threshold → progress branch resets cycles.
+        assert ctrl._detect_stuck(_robot_state(1.0, 1.0)) is False
+        assert ctrl._wait_cycles == 0
+
+    def test_stuck_triggers_yield_and_wait(self, emit):
+        ctrl = self._make_controller(wait_duration=50)
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+
+        # Three step() calls with near-stationary position trip the stuck check.
+        stuck_pos = _robot_state(0.005, 0.0)
+        action = None
+        for i in range(3):
+            action = ctrl.step(i, 0.1 * i, 0.1, {0: stuck_pos}, emit)
+
+        assert ctrl._is_waiting is True
+        assert ctrl._wait_cycles == 1
+        assert action is not None and action.behavior == "YIELD"
+        yield_events = [c for c in emit.call_args_list if c.args[0] == "robot_yield"]
+        assert yield_events, "expected a robot_yield event to be emitted"
+
+    def test_wait_emits_crawl_velocity_toward_goal(self, emit):
+        """While waiting, the controller emits a tiny velocity in goal direction."""
+        ctrl = self._make_controller(wait_duration=50)
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+
+        # Trigger stuck.
+        stuck_pos = _robot_state(0.0, 0.0)
+        for i in range(3):
+            ctrl.step(i, 0.1 * i, 0.1, {0: stuck_pos}, emit)
+        assert ctrl._is_waiting is True
+
+        # Next step: still waiting, should emit a small crawl velocity.
+        action = ctrl.step(10, 1.0, 0.1, {0: stuck_pos}, emit)
+        assert action.behavior == "YIELD"
+        speed = math.hypot(action.pref_vx, action.pref_vy)
+        assert speed == pytest.approx(0.05, rel=0.1)
+
+    def test_wait_countdown_exits_and_replans(self, emit):
+        """After wait_duration ticks, controller exits wait and replans."""
+        ctrl = self._make_controller(wait_duration=3)
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+
+        stuck_pos = _robot_state(0.0, 0.0)
+        for i in range(3):
+            ctrl.step(i, 0.1 * i, 0.1, {0: stuck_pos}, emit)
+        assert ctrl._is_waiting is True
+        backend.calls.clear()
+
+        # wait_duration=3: three more step() calls decrement the counter and exit.
+        for i in range(3):
+            ctrl.step(100 + i, 10.0 + i * 0.1, 0.1, {0: stuck_pos}, emit)
+        assert ctrl._is_waiting is False
+        post_wait = [
+            c
+            for c in emit.call_args_list
+            if c.args[0] == "robot_replan" and c.args[2].get("reason") == "post_wait"
+        ]
+        assert post_wait, "expected a post_wait replan event"
+        # Grace period active so stuck detection is skipped temporarily.
+        assert ctrl._grace_steps > 0
+
+    def test_grace_period_suppresses_stuck_check(self, emit):
+        """Immediately after yielding, _grace_steps prevents immediate re-yield."""
+        ctrl = self._make_controller(wait_duration=1, stuck_window=3)
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+        # Force waiting state directly, then take a step that exits wait mode.
+        ctrl._is_waiting = True
+        ctrl._wait_counter = 1
+        stuck_pos = _robot_state(0.0, 0.0)
+        ctrl.step(100, 10.0, 0.1, {0: stuck_pos}, emit)  # exits wait
+        assert ctrl._grace_steps > 0
+        before = ctrl._grace_steps
+        ctrl.step(101, 10.1, 0.1, {0: stuck_pos}, emit)
+        assert ctrl._grace_steps == before - 1
+
+
+class TestPeriodicReplan:
+    def test_replan_interval_triggers_event(self, emit):
+        ctrl = BaselineAStarRobotController(
+            {"replan_interval": 2, "goal_tolerance": 0.05, "stuck_window": 999}
+        )
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+        state = _robot_state(0.5, 0.5)
+        # step=0: replan (0 % 2 == 0), step=2: replan
+        backend.calls.clear()
+        ctrl.step(0, 0.0, 0.1, {0: state}, emit)
+        ctrl.step(1, 0.1, 0.1, {0: state}, emit)
+        ctrl.step(2, 0.2, 0.1, {0: state}, emit)
+        replan_events = [c for c in emit.call_args_list if c.args[0] == "robot_replan"]
+        assert len(replan_events) == 2
+        # Corresponding backend shortest_path calls (plus the one from reset).
+        assert len(backend.calls) >= 2
+
+
+class TestSpeedScaling:
+    def test_slowdown_near_target(self, emit):
+        """Speed must scale down as dist_target approaches slowdown_dist."""
+        ctrl = BaselineAStarRobotController(
+            {
+                "slowdown_dist": 1.0,
+                "max_speed": 1.0,
+                "velocity_smoothing": 1.0,
+                "stuck_window": 999,
+                "goal_tolerance": 0.05,
+            }
+        )
+        backend = _StraightLineBackend()
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), backend)
+        # Very close to target (0.1m) -> speed should be ~0.1 * max_speed
+        state = _robot_state(ctrl.path[-1][0] - 0.1, ctrl.path[-1][1])
+        action = ctrl.step(0, 0.0, 0.1, {0: state}, emit)
+        speed = math.hypot(action.pref_vx, action.pref_vy)
+        assert speed < 0.2  # scaled well below max
+
+
+class TestCurrentTargetOverrun:
+    def test_current_target_past_path_end_returns_goal(self):
+        """_current_target with path_idx beyond path length returns goal."""
+        ctrl = BaselineAStarRobotController()
+        ctrl.goal = (9.0, 9.0)
+        ctrl.path = [(0.0, 0.0), (1.0, 1.0)]
+        ctrl.path_idx = 99
+        assert ctrl._current_target() == (9.0, 9.0)

--- a/tests/test_datasets_parsing.py
+++ b/tests/test_datasets_parsing.py
@@ -1,0 +1,222 @@
+"""Coverage tests for navirl.data.datasets — parsers and fallback paths.
+
+Existing ``tests/test_data.py`` covers the happy-path SocialDataset loader and
+the obvious error cases, but leaves the actual ETHUCY parser, recursive scene
+discovery, txt fallbacks, and ``to_numpy`` / ``get_scene`` uncovered. These
+tests exercise those paths with synthesised on-disk data.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from navirl.data.datasets import ETHUCYDataset, SocialDataset
+
+# ---------------------------------------------------------------------------
+# ETHUCY text parser — full loader path
+# ---------------------------------------------------------------------------
+
+
+def _write_ethucy(path: Path, rows: list[tuple[float, int, float, float]], *, sep: str) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for frame, ped, x, y in rows:
+            f.write(f"{frame}{sep}{ped}{sep}{x}{sep}{y}\n")
+
+
+class TestETHUCYParser:
+    def test_parse_tab_delimited(self, tmp_path):
+        rows = [
+            (10.0, 1, 0.0, 0.0),
+            (20.0, 1, 1.0, 0.0),
+            (30.0, 1, 2.0, 0.0),
+            (10.0, 2, 5.0, 5.0),
+            (20.0, 2, 5.5, 5.0),
+        ]
+        _write_ethucy(tmp_path / "eth.txt", rows, sep="\t")
+        ds = ETHUCYDataset(scenes=["eth"], delim="auto")
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+        tc = ds.get_scene(0)
+        assert len(tc) == 2  # two pedestrians
+        ped1 = next(t for t in tc.trajectories if t.agent_id == 1)
+        assert len(ped1) == 3
+        np.testing.assert_allclose(ped1.positions[0], [0.0, 0.0])
+        np.testing.assert_allclose(ped1.timestamps, [10.0, 20.0, 30.0])
+
+    def test_parse_space_delimited_auto(self, tmp_path):
+        """``delim='auto'`` must fall back to whitespace split when tab split fails."""
+        rows = [
+            (1.0, 7, 0.0, 0.0),
+            (2.0, 7, 0.1, 0.2),
+            (3.0, 7, 0.2, 0.4),
+        ]
+        _write_ethucy(tmp_path / "hotel.txt", rows, sep=" ")
+        ds = ETHUCYDataset(scenes=["hotel"])
+        ds.load(tmp_path)
+        tc = ds.get_scene(0)
+        assert len(tc) == 1
+        assert tc.trajectories[0].agent_id == 7
+        assert len(tc.trajectories[0]) == 3
+
+    def test_parse_explicit_delim(self, tmp_path):
+        _write_ethucy(tmp_path / "zara1.txt", [(1.0, 3, 0.0, 0.0), (2.0, 3, 1.0, 0.0)], sep=",")
+        ds = ETHUCYDataset(scenes=["zara1"], delim=",")
+        ds.load(tmp_path)
+        tc = ds.get_scene(0)
+        assert len(tc) == 1
+
+    def test_skips_blank_and_malformed_lines(self, tmp_path):
+        """Blank lines and rows with too few / non-numeric fields are dropped."""
+        path = tmp_path / "univ.txt"
+        path.write_text(
+            "\n"  # blank
+            "1.0\t1\t0.0\t0.0\n"  # valid
+            "bad\tnot\ta\trow\n"  # non-numeric -> ValueError branch
+            "2.0\t1\t1.0\n"  # too few fields
+            "3.0\t1\t2.0\t0.0\n"  # valid
+            "   \n"  # whitespace-only
+        )
+        ds = ETHUCYDataset(scenes=["univ"])
+        ds.load(tmp_path)
+        tc = ds.get_scene(0)
+        assert len(tc) == 1
+        assert len(tc.trajectories[0]) == 2  # only two valid rows survived
+
+    def test_sorts_rows_by_frame_per_pedestrian(self, tmp_path):
+        """Out-of-order input must emerge sorted by timestamp."""
+        rows = [
+            (30.0, 1, 3.0, 0.0),
+            (10.0, 1, 1.0, 0.0),
+            (20.0, 1, 2.0, 0.0),
+        ]
+        _write_ethucy(tmp_path / "eth.txt", rows, sep="\t")
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        traj = ds.get_scene(0).trajectories[0]
+        np.testing.assert_allclose(traj.timestamps, [10.0, 20.0, 30.0])
+        np.testing.assert_allclose(traj.positions[:, 0], [1.0, 2.0, 3.0])
+
+
+# ---------------------------------------------------------------------------
+# _find_scene_file — discovery fallbacks
+# ---------------------------------------------------------------------------
+
+
+class TestSceneFileDiscovery:
+    def test_nested_scene_directory(self, tmp_path):
+        """``root/eth/eth.txt`` layout (one of the tried candidates)."""
+        (tmp_path / "eth").mkdir()
+        _write_ethucy(tmp_path / "eth" / "eth.txt", [(1.0, 1, 0.0, 0.0)], sep="\t")
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+
+    def test_recursive_fallback_picks_txt(self, tmp_path):
+        """File outside the standard candidate paths is found by rglob fallback."""
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        _write_ethucy(deep / "zara2_session.txt", [(1.0, 1, 0.0, 0.0)], sep="\t")
+        ds = ETHUCYDataset(scenes=["zara2"])
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+
+    def test_missing_scene_raises(self, tmp_path):
+        # Create an unrelated file so the directory is not empty.
+        (tmp_path / "something_else.txt").write_text("x\n")
+        ds = ETHUCYDataset(scenes=["eth"])
+        with pytest.raises(FileNotFoundError, match="scene 'eth'"):
+            ds.load(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Base class helpers — load path validation, to_numpy, get_scene
+# ---------------------------------------------------------------------------
+
+
+class TestBaseDatasetBehavior:
+    def test_load_nonexistent_path_raises(self, tmp_path):
+        ds = SocialDataset()
+        missing = tmp_path / "does_not_exist"
+        with pytest.raises(FileNotFoundError, match="Dataset path does not exist"):
+            ds.load(missing)
+
+    def test_get_scene_before_load_raises(self):
+        ds = SocialDataset()
+        with pytest.raises(RuntimeError, match="not loaded"):
+            ds.get_scene(0)
+
+    def test_to_numpy_before_load_raises(self):
+        ds = SocialDataset()
+        with pytest.raises(RuntimeError, match="not loaded"):
+            ds.to_numpy()
+
+    def test_to_numpy_stacks_all_scenes(self, tmp_path):
+        # Two scenes with 3 rows each => 6 x 2 positions
+        for i in range(2):
+            p = tmp_path / f"scene_{i}.csv"
+            with p.open("w", newline="") as fh:
+                w = csv.writer(fh)
+                w.writerow(["t", "id", "x", "y"])
+                for k in range(3):
+                    w.writerow([k * 0.1, f"a{i}", float(k), float(i)])
+        ds = SocialDataset(has_header=True)
+        ds.load(tmp_path)
+        arr = ds.to_numpy()
+        assert arr.shape == (6, 2)
+
+
+# ---------------------------------------------------------------------------
+# SocialDataset parsing — txt fallback and malformed-row tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestSocialDatasetEdges:
+    def test_falls_back_to_txt_when_no_csv(self, tmp_path):
+        path = tmp_path / "data.txt"
+        path.write_text("0.0,a,1.0,1.0\n0.1,a,1.1,1.2\n0.2,a,1.2,1.4\n")
+        ds = SocialDataset(has_header=False)
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+        tc = ds.get_scene(0)
+        assert len(tc) == 1
+        assert len(tc.trajectories[0]) == 3
+
+    def test_no_files_raises(self, tmp_path):
+        # Directory with only an unsupported extension.
+        (tmp_path / "README.md").write_text("no data here\n")
+        ds = SocialDataset()
+        with pytest.raises(FileNotFoundError, match="No CSV/TXT"):
+            ds.load(tmp_path)
+
+    def test_skips_short_and_bad_rows(self, tmp_path):
+        csv_file = tmp_path / "scene.csv"
+        with csv_file.open("w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["t", "id", "x", "y"])
+            w.writerow(["0.0", "a", "1.0", "1.0"])
+            w.writerow(["short", "row"])  # len < 4 -> skipped
+            w.writerow(["notnum", "a", "bad", "bad"])  # ValueError -> skipped
+            w.writerow(["0.1", "a", "1.1", "1.2"])
+        ds = SocialDataset(has_header=True)
+        ds.load(csv_file)
+        tc = ds.get_scene(0)
+        assert len(tc) == 1
+        assert len(tc.trajectories[0]) == 2
+
+    def test_mixed_velocity_column_not_applied(self, tmp_path):
+        """If only some rows carry velocities, the parser drops velocity arrays
+        rather than failing mid-parse."""
+        csv_file = tmp_path / "mixed.csv"
+        with csv_file.open("w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["t", "id", "x", "y", "vx", "vy"])
+            w.writerow(["0.0", "a", "0.0", "0.0", "1.0", "0.0"])
+            w.writerow(["0.1", "a", "0.1", "0.0", "", ""])  # missing vel -> None
+        ds = SocialDataset(has_header=True)
+        ds.load(csv_file)
+        traj = ds.get_scene(0).trajectories[0]
+        assert traj.velocities is None

--- a/tests/test_orca_human_controller.py
+++ b/tests/test_orca_human_controller.py
@@ -1,0 +1,299 @@
+"""Coverage tests for navirl.humans.orca.controller.ORCAHumanController.
+
+Existing tests exercise the subclass ORCAPlusHumanController. This file
+targets the base-class-only paths: plan failure fallbacks, goal swapping,
+waypoint advancement, replanning after waypoint exhaustion, and the
+defensive error branches in :meth:`step`.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import Mock
+
+import pytest
+
+from navirl.core.types import AgentState
+from navirl.humans.orca.controller import ORCAHumanController
+
+
+class _PathBackend:
+    def __init__(self, path=None, raise_on_plan: bool = False):
+        self.path = path
+        self.raise_on_plan = raise_on_plan
+        self.plans: list[tuple[tuple[float, float], tuple[float, float]]] = []
+
+    def shortest_path(self, start, goal):
+        self.plans.append((tuple(start), tuple(goal)))
+        if self.raise_on_plan:
+            raise RuntimeError("planner blew up")
+        if self.path is None:
+            return [(goal[0], goal[1])]
+        return list(self.path)
+
+
+def _human(hid: int, x: float, y: float, max_speed: float = 1.0) -> AgentState:
+    return AgentState(
+        agent_id=hid,
+        kind="human",
+        x=x,
+        y=y,
+        vx=0.0,
+        vy=0.0,
+        goal_x=0.0,
+        goal_y=0.0,
+        max_speed=max_speed,
+        radius=0.2,
+    )
+
+
+@pytest.fixture
+def emit():
+    return Mock()
+
+
+# ---------------------------------------------------------------------------
+# reset() — backend path failure
+# ---------------------------------------------------------------------------
+
+
+class TestResetPlanFailure:
+    def test_reset_falls_back_to_direct_path_on_exception(self):
+        ctrl = ORCAHumanController()
+        backend = _PathBackend(raise_on_plan=True)
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=backend,
+        )
+        # Despite the exception, controller records direct-to-goal fallback.
+        assert ctrl.paths[1] == [(5.0, 5.0)]
+        assert ctrl.path_idx[1] == 0
+        assert ctrl.last_pref[1] == (0.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _plan_path — direct branches
+# ---------------------------------------------------------------------------
+
+
+class TestPlanPath:
+    def test_plan_path_no_backend_returns_goal_only(self):
+        ctrl = ORCAHumanController()
+        assert ctrl._plan_path((0.0, 0.0), (2.0, 3.0)) == [(2.0, 3.0)]
+
+    def test_plan_path_empty_result_returns_goal_only(self):
+        ctrl = ORCAHumanController()
+        ctrl.backend = _PathBackend(path=[])
+        assert ctrl._plan_path((0.0, 0.0), (1.0, 1.0)) == [(1.0, 1.0)]
+
+
+# ---------------------------------------------------------------------------
+# _maybe_swap_goal — ping-pong behavior
+# ---------------------------------------------------------------------------
+
+
+class TestGoalSwap:
+    def test_goal_swap_when_close(self, emit):
+        ctrl = ORCAHumanController({"goal_tolerance": 0.25})
+        backend = _PathBackend(path=[(0.0, 0.0), (5.0, 5.0)])
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=backend,
+        )
+        # Human at (5.0, 5.0) — inside tolerance of the goal → swap start/goal.
+        state = _human(1, 5.0, 5.0)
+        swapped = ctrl._maybe_swap_goal(1, state, emit)
+        assert swapped is True
+        assert ctrl.goals[1] == (0.0, 0.0)
+        assert ctrl.starts[1] == (5.0, 5.0)
+        emit.assert_called_once()
+        event_name, agent_id, payload = emit.call_args.args
+        assert event_name == "goal_swap"
+        assert agent_id == 1
+        assert payload["new_goal"] == [0.0, 0.0]
+
+    def test_goal_swap_no_op_when_far(self, emit):
+        ctrl = ORCAHumanController({"goal_tolerance": 0.25})
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=_PathBackend(path=[(0.0, 0.0), (5.0, 5.0)]),
+        )
+        state = _human(1, 0.0, 0.0)
+        assert ctrl._maybe_swap_goal(1, state, emit) is False
+        emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _current_waypoint — empty path replan + waypoint advance + exhaustion replan
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentWaypoint:
+    def test_empty_path_triggers_replan(self):
+        ctrl = ORCAHumanController()
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=_PathBackend(path=[(5.0, 5.0)]),
+        )
+        ctrl.paths[1] = []  # force the empty-path branch
+        # Supply a backend whose shortest_path returns a real path next time.
+        ctrl.backend = _PathBackend(path=[(1.0, 1.0), (5.0, 5.0)])
+        wp = ctrl._current_waypoint(1, _human(1, 0.0, 0.0))
+        assert ctrl.paths[1] == [(1.0, 1.0), (5.0, 5.0)]
+        assert wp in ctrl.paths[1]
+
+    def test_waypoint_advances_past_reached_points(self):
+        ctrl = ORCAHumanController({"waypoint_tolerance": 0.5, "lookahead": 1})
+        backend = _PathBackend(path=[(0.0, 0.0), (1.0, 0.0), (5.0, 0.0)])
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 0.0)},
+            backend=backend,
+        )
+        # Human at (0.0, 0.0) is within tolerance of wp index 0 only.
+        # The advance loop should consume wp 0 and stop at wp 1.
+        wp = ctrl._current_waypoint(1, _human(1, 0.0, 0.0))
+        assert ctrl.path_idx[1] == 1
+        assert wp == (1.0, 0.0)
+
+    def test_exhausted_path_replans_from_current_position(self):
+        """When idx advances past the end, _current_waypoint must replan."""
+        ctrl = ORCAHumanController({"waypoint_tolerance": 100.0, "lookahead": 1})
+        # First planning returns short path; waypoint_tolerance is so large that
+        # the advance loop consumes every waypoint, forcing the exhaustion branch.
+        backend = _PathBackend(path=[(0.0, 0.0)])
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=backend,
+        )
+        # Swap to a backend that returns a richer path on replan.
+        backend.path = [(2.0, 2.0), (5.0, 5.0)]
+        wp = ctrl._current_waypoint(1, _human(1, 1.0, 1.0))
+        assert ctrl.path_idx[1] == 0
+        assert wp in backend.path
+
+
+# ---------------------------------------------------------------------------
+# _goal_velocity — inside tolerance and clamping
+# ---------------------------------------------------------------------------
+
+
+class TestGoalVelocity:
+    def test_zero_velocity_inside_goal_tolerance(self):
+        ctrl = ORCAHumanController({"goal_tolerance": 0.5})
+        state = _human(1, 0.0, 0.0)
+        assert ctrl._goal_velocity(state, (0.1, 0.1)) == (0.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _smooth_preferred_velocity — max speed clamp and stop threshold
+# ---------------------------------------------------------------------------
+
+
+class TestSmoothing:
+    def test_clamps_to_max_speed(self):
+        ctrl = ORCAHumanController({"velocity_smoothing": 1.0})
+        state = _human(1, 0.0, 0.0, max_speed=1.0)
+        ctrl.last_pref[1] = (0.0, 0.0)
+        svx, svy = ctrl._smooth_preferred_velocity(1, state, 5.0, 0.0)
+        assert math.hypot(svx, svy) == pytest.approx(1.0)
+
+    def test_snaps_to_zero_below_stop_speed(self):
+        ctrl = ORCAHumanController({"velocity_smoothing": 1.0, "stop_speed": 0.1})
+        state = _human(1, 0.0, 0.0, max_speed=1.0)
+        ctrl.last_pref[1] = (0.0, 0.0)
+        svx, svy = ctrl._smooth_preferred_velocity(1, state, 0.01, 0.01)
+        assert svx == 0.0 and svy == 0.0
+
+
+# ---------------------------------------------------------------------------
+# step() — defensive branches
+# ---------------------------------------------------------------------------
+
+
+class TestStepErrorBranches:
+    def _ctrl(self, **cfg) -> ORCAHumanController:
+        ctrl = ORCAHumanController(cfg or None)
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=_PathBackend(path=[(0.0, 0.0), (5.0, 5.0)]),
+        )
+        return ctrl
+
+    def test_missing_state_produces_stop(self, emit):
+        ctrl = self._ctrl()
+        actions = ctrl.step(0, 0.0, 0.1, states={}, robot_id=0, emit_event=emit)
+        assert actions[1].behavior == "STOP"
+        assert actions[1].pref_vx == 0.0 and actions[1].pref_vy == 0.0
+
+    def test_non_finite_position_produces_stop(self, emit):
+        ctrl = self._ctrl()
+        states = {1: _human(1, float("nan"), 0.0)}
+        actions = ctrl.step(0, 0.0, 0.1, states=states, robot_id=0, emit_event=emit)
+        assert actions[1].behavior == "STOP"
+
+    def test_replan_failure_after_goal_swap_does_not_crash(self, emit):
+        """If the post-swap replan raises, step() logs and continues."""
+
+        class _OneShotBackend:
+            """Planner that succeeds once (reset) then raises on any subsequent call."""
+
+            def __init__(self):
+                self.calls = 0
+
+            def shortest_path(self, start, goal):
+                self.calls += 1
+                if self.calls == 1:
+                    return [(0.0, 0.0), (5.0, 5.0)]
+                raise RuntimeError("replan failed")
+
+        ctrl = ORCAHumanController({"goal_tolerance": 0.25})
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=_OneShotBackend(),
+        )
+        # Place human at goal so swap triggers then replan fails.
+        state = _human(1, 5.0, 5.0)
+        actions = ctrl.step(0, 0.0, 0.1, states={1: state}, robot_id=0, emit_event=emit)
+        # step() must still produce an action for the human.
+        assert 1 in actions
+
+    def test_outer_exception_handler_returns_stop(self, emit):
+        """An exception in the inner pipeline is caught and mapped to STOP."""
+
+        class _ExplodingBackend:
+            def shortest_path(self, start, goal):
+                return [(0.0, 0.0), (5.0, 5.0)]
+
+        ctrl = ORCAHumanController()
+        ctrl.reset(
+            human_ids=[1],
+            starts={1: (0.0, 0.0)},
+            goals={1: (5.0, 5.0)},
+            backend=_ExplodingBackend(),
+        )
+
+        def _raise(self, *args, **kwargs):  # type: ignore[no-redef]
+            raise RuntimeError("boom")
+
+        # Monkey-patch an internal helper so the try/except at step() level fires.
+        ctrl._current_waypoint = _raise.__get__(ctrl, ORCAHumanController)
+        actions = ctrl.step(
+            0, 0.0, 0.1, states={1: _human(1, 0.0, 0.0)}, robot_id=0, emit_event=emit
+        )
+        assert actions[1].behavior == "STOP"


### PR DESCRIPTION
## Summary
Fills coverage gaps in three under-tested modules by exercising paths that currently have no direct test.

| Module | Before | After | New tests |
| --- | --- | --- | --- |
| `navirl/data/datasets.py` | 70% | **100%** | 16 |
| `navirl/robots/baselines/astar.py` | 76% | **97%** | 13 |
| `navirl/humans/orca/controller.py` | 70% | **99%** | 15 |

### What's covered

- **`ETHUCYDataset`**: `_parse_scene_file` (tab / space / explicit delimiters), malformed-row tolerance, timestamp sorting, nested and recursive scene-file discovery, and the missing-scene error path. Plus base-class guards: `load()` on nonexistent paths, `get_scene()` / `to_numpy()` before load.
- **`SocialDataset`**: `.txt` fallback when no CSV exists, the no-files-found error, short / non-numeric row skipping, and the mixed-velocity-column branch that drops velocity arrays.
- **`BaselineAStarRobotController`**: empty-path fallback, `DONE` at goal, the stuck-recovery state machine (window detection, yield/wait, crawl velocity, post-wait replan, grace period), periodic replan event, speed slowdown, and `_current_target` past end-of-path.
- **`ORCAHumanController`**: `reset()` plan-failure fallback, `_plan_path` no-backend / empty-result branches, goal swap ping-pong, waypoint advance + exhaustion replan, velocity clamping & stop threshold, and the defensive STOP branches in `step()` for missing state, non-finite positions, post-swap replan failure, and unexpected inner exceptions.

Full test suite: **5534 passed, 178 skipped** (up from 5490 passed baseline). Ruff clean.

## Test plan
- [x] `pytest tests/test_datasets_parsing.py tests/test_baseline_astar_controller.py tests/test_orca_human_controller.py` passes (44/44)
- [x] Full `pytest` run: 5534 passed, 178 skipped, 0 failures, 0 errors
- [x] `ruff check navirl tests` clean
- [x] Coverage verified with `pytest --cov=navirl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)