### PR TITLE
test: 43 tests bring behavior_model and camera/depth sensors to 100% coverage

### DIFF
--- a/tests/test_behavior_model_decisions.py
+++ b/tests/test_behavior_model_decisions.py
@@ -1,0 +1,404 @@
+"""Tests for under-covered decision methods of navirl.humans.behavior_model.
+
+Complements the broad smoke tests in test_humans.py by targeting branches that
+were previously uncovered:
+
+- AttentionModel.step: enters distraction, returns to focus when the timer expires.
+- AttentionModel.can_perceive: co-located observer/target short-circuit.
+- BehaviorModel.should_yield: assertiveness vs. compliance vs. speed-ratio paths.
+- BehaviorModel.adapt_speed: blending toward slower neighbours and the
+  assertiveness-weighted preferred-speed mix.
+- BehaviorModel.choose_side: non-compliant random branch.
+- BehaviorModel.compute_comfort: personal-space intrusion and distraction penalty.
+- BehaviorModel.compute_stress: very-close neighbour stress term.
+- BehaviorModel.reset: propagates to the attention model.
+- Personality-specific attention defaults and factory classmethods.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from navirl.humans.behavior_model import (
+    AttentionModel,
+    BehaviorModel,
+    PersonalityParams,
+)
+from navirl.humans.pedestrian_state import PedestrianState, PersonalityTag
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _ped(
+    pid: int = 0,
+    x: float = 0.0,
+    y: float = 0.0,
+    vx: float = 0.0,
+    vy: float = 0.0,
+    goal_x: float = 10.0,
+    goal_y: float = 0.0,
+    heading: float = 0.0,
+    radius: float = 0.3,
+) -> PedestrianState:
+    return PedestrianState(
+        pid=pid,
+        position=np.array([x, y], dtype=np.float64),
+        velocity=np.array([vx, vy], dtype=np.float64),
+        heading=heading,
+        goal=np.array([goal_x, goal_y], dtype=np.float64),
+        radius=radius,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AttentionModel.step -- distraction lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysEnterRng:
+    """rng.random() returns 0.0 (always < any positive probability)."""
+
+    def random(self) -> float:
+        return 0.0
+
+    def exponential(self, mean: float) -> float:
+        return float(mean)
+
+
+class _NeverEnterRng:
+    """rng.random() returns 1.0 (never < a probability in [0, 1])."""
+
+    def random(self) -> float:
+        return 1.0
+
+
+class TestAttentionModelStep:
+    def test_enters_distracted_when_probability_triggers(self):
+        attn = AttentionModel(
+            distraction_probability=1.0,
+            distraction_duration_mean=2.0,
+        )
+        assert not attn.is_distracted
+        attn.step(dt=0.5, rng=_AlwaysEnterRng())
+        # random()=0 < 1.0*0.5=0.5, so we entered distraction.
+        assert attn.is_distracted
+        # Remaining time comes from exponential(mean) stub.
+        assert attn._distraction_remaining == pytest.approx(2.0)
+
+    def test_skips_entering_when_rng_rejects(self):
+        attn = AttentionModel(distraction_probability=0.01)
+        attn.step(dt=0.05, rng=_NeverEnterRng())
+        assert not attn.is_distracted
+
+    def test_distraction_timer_counts_down(self):
+        attn = AttentionModel(distraction_probability=0.0)
+        attn._distracted = True
+        attn._distraction_remaining = 1.0
+        attn.step(dt=0.3, rng=_NeverEnterRng())
+        assert attn.is_distracted
+        assert attn._distraction_remaining == pytest.approx(0.7)
+
+    def test_distraction_clears_when_timer_expires(self):
+        attn = AttentionModel(distraction_probability=0.0)
+        attn._distracted = True
+        attn._distraction_remaining = 0.1
+        attn.step(dt=0.5, rng=_NeverEnterRng())
+        assert not attn.is_distracted
+        assert attn._distraction_remaining == 0.0
+
+    def test_distraction_clamps_remaining_to_zero(self):
+        attn = AttentionModel(distraction_probability=0.0)
+        attn._distracted = True
+        attn._distraction_remaining = 0.2
+        attn.step(dt=5.0, rng=_NeverEnterRng())  # Overshoot.
+        # Remaining is reset to 0 rather than being negative.
+        assert attn._distraction_remaining == 0.0
+
+
+class TestAttentionCanPerceiveCollocated:
+    def test_colocated_returns_true(self):
+        """When observer and target coincide, perception is always granted."""
+        attn = AttentionModel(awareness_radius=10.0, field_of_view=math.pi / 4.0)
+        observer = _ped(x=0.0, y=0.0, heading=0.0)
+        # Target within < 1e-9 of observer -> short-circuit.
+        assert attn.can_perceive(observer, np.array([0.0, 0.0]))
+
+
+# ---------------------------------------------------------------------------
+# _default_attention -- personality-specific paths
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultAttentionPerPersonality:
+    def test_distracted_attention_defaults(self):
+        bm = BehaviorModel(personality=PersonalityTag.DISTRACTED, rng_seed=0)
+        # DISTRACTED branch of _default_attention.
+        assert bm.attention.awareness_radius == pytest.approx(5.0)
+        assert bm.attention.field_of_view == pytest.approx(math.pi / 3.0)
+        assert bm.attention.distraction_probability > 0.0
+
+    def test_child_attention_defaults(self):
+        bm = BehaviorModel(personality=PersonalityTag.CHILD, rng_seed=0)
+        # CHILD branch of _default_attention — 180 deg FOV and small distraction.
+        assert bm.attention.awareness_radius == pytest.approx(5.0)
+        assert bm.attention.field_of_view == pytest.approx(math.pi)
+        assert bm.attention.reaction_time == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# create_child classmethod
+# ---------------------------------------------------------------------------
+
+
+class TestCreateChild:
+    def test_create_child_sets_personality(self):
+        bm = BehaviorModel.create_child(base_preferred_speed=1.0, rng_seed=0)
+        assert bm.personality == PersonalityTag.CHILD
+        # Child personality applies 0.9 speed factor.
+        assert bm.preferred_speed == pytest.approx(0.9)
+
+
+# ---------------------------------------------------------------------------
+# BehaviorModel.should_yield
+# ---------------------------------------------------------------------------
+
+
+class _YieldingCoinRng:
+    """random() returns a configurable constant for deterministic yielding."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def random(self) -> float:
+        return self._value
+
+
+class TestShouldYield:
+    def test_passive_yields_for_equal_speed_neighbour(self):
+        """assertiveness=0 -> base p_yield=1.0; equal-speed neighbour gives 0.8."""
+        params = PersonalityParams(assertiveness=0.0, compliance=0.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _YieldingCoinRng(0.5)  # < p_yield=0.8 -> yields.
+
+        ego = _ped(x=0.0, y=0.0, vx=1.0, heading=0.0)
+        other = _ped(x=5.0, y=0.0, vx=-1.0, heading=math.pi)
+        assert bm.should_yield(ego, other) is True
+
+    def test_equal_speed_passive_declines_when_rng_above_threshold(self):
+        """With p_yield=0.8 an rng value above 0.8 still declines to yield."""
+        params = PersonalityParams(assertiveness=0.0, compliance=0.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _YieldingCoinRng(0.95)  # 0.95 >= 0.8 -> no yield.
+
+        ego = _ped(x=0.0, y=0.0, vx=1.0, heading=0.0)
+        other = _ped(x=5.0, y=0.0, vx=-1.0, heading=math.pi)
+        assert bm.should_yield(ego, other) is False
+
+    def test_fully_assertive_never_yields(self):
+        """assertiveness=1 -> base p_yield=0, compliance=0 keeps it near 0 so rng>=p_yield."""
+        params = PersonalityParams(assertiveness=1.0, compliance=0.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _YieldingCoinRng(0.001)
+
+        ego = _ped(x=0.0, y=0.0, vx=1.0, heading=0.0)
+        # Other on the left (positive y -> positive bearing) so no +0.15 bump even if
+        # compliance were nonzero.
+        other = _ped(x=0.0, y=5.0, vx=0.0, heading=0.0)
+        assert bm.should_yield(ego, other) is False
+
+    def test_faster_other_increases_yield_probability(self):
+        """speed_ratio > 1 multiplies p_yield by 1.2; slower divides by 0.8."""
+        params = PersonalityParams(assertiveness=0.5, compliance=0.0)
+
+        bm_fast = BehaviorModel(params=params, rng_seed=0)
+        bm_fast.rng = _YieldingCoinRng(0.55)  # Just above 0.5
+        ego = _ped(x=0.0, y=0.0, vx=1.0, heading=0.0)
+        fast_other = _ped(x=5.0, y=0.0, vx=-2.0, heading=math.pi)
+        # p_yield = 0.5 * 1.2 = 0.6; rng=0.55 < 0.6 -> yields
+        assert bm_fast.should_yield(ego, fast_other) is True
+
+        bm_slow = BehaviorModel(params=params, rng_seed=0)
+        bm_slow.rng = _YieldingCoinRng(0.45)  # Just below 0.5 but above 0.4
+        slow_other = _ped(x=5.0, y=0.0, vx=-0.1, heading=math.pi)
+        # p_yield = 0.5 * 0.8 = 0.4; rng=0.45 >= 0.4 -> does not yield
+        assert bm_slow.should_yield(ego, slow_other) is False
+
+    def test_compliance_bonus_for_right_hand_neighbour(self):
+        """A neighbour on the ego's right adds 0.15 * compliance to p_yield."""
+        # With assertiveness=1.0 the base is 0, and slower neighbour drops to 0.0.
+        # The compliance bump should be the only source of p_yield.
+        params = PersonalityParams(assertiveness=1.0, compliance=1.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _YieldingCoinRng(0.1)
+
+        ego = _ped(x=0.0, y=0.0, vx=1.0, heading=0.0)
+        # Other on the ego's right: heading is +x, so +y is left, -y is right.
+        right_side_other = _ped(x=1.0, y=-1.0, vx=0.1, heading=0.0)
+        # p_yield = 0.0 * 0.8 + 0.15 (compliance) = 0.15; rng=0.1 < 0.15 -> yields
+        assert bm.should_yield(ego, right_side_other) is True
+
+    def test_yield_probability_clamped_to_unit_interval(self):
+        """Aggregated p_yield beyond 1 is clamped, so rng=0.999 still triggers yield."""
+        # High compliance bump combined with faster neighbour pushes p_yield > 1.
+        params = PersonalityParams(assertiveness=0.0, compliance=1.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _YieldingCoinRng(0.999)
+
+        ego = _ped(x=0.0, y=0.0, vx=1.0, heading=0.0)
+        # Other on the right moving fast -> ratio>1, +0.15 compliance bonus.
+        right_fast = _ped(x=1.0, y=-1.0, vx=-3.0, heading=math.pi)
+        assert bm.should_yield(ego, right_fast) is True
+
+
+# ---------------------------------------------------------------------------
+# BehaviorModel.adapt_speed
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptSpeedWithNeighbours:
+    def test_all_neighbours_outside_awareness(self):
+        """Neighbours beyond awareness_radius don't affect adaptation."""
+        bm = BehaviorModel(rng_seed=42)
+        # Force awareness radius tiny so no one is "perceived" inside.
+        bm.attention = AttentionModel(awareness_radius=0.1)
+
+        ego = _ped(vx=1.0)
+        far_neighbour = _ped(x=10.0, y=0.0, vx=0.5)
+        assert bm.adapt_speed(ego, [far_neighbour]) == pytest.approx(bm.preferred_speed)
+
+    def test_slow_neighbour_drags_adapted_speed_down(self):
+        """Nearby slow neighbours blend the adapted speed toward their mean."""
+        # assertiveness=0 -> fully influenced by blended neighbour speed.
+        params = PersonalityParams(assertiveness=0.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.attention = AttentionModel(awareness_radius=5.0)
+
+        ego = _ped(vx=1.2)
+        slow_close = _ped(x=1.0, y=0.0, vx=0.2)
+        adapted = bm.adapt_speed(ego, [slow_close])
+
+        # Adapted must be strictly between neighbour speed and preferred speed.
+        assert adapted < bm.preferred_speed
+        assert adapted >= 0.0
+
+    def test_result_clamped_to_max_speed(self):
+        """Adapted speed cannot exceed max_speed regardless of blending."""
+        bm = BehaviorModel(rng_seed=0)
+        bm.attention = AttentionModel(awareness_radius=5.0)
+
+        ego = _ped(vx=0.1)
+        # Neighbour much faster than max_speed -> blending pulls up, but capped.
+        fast_close = _ped(x=0.5, y=0.0, vx=50.0)
+        adapted = bm.adapt_speed(ego, [fast_close])
+        assert adapted <= bm.max_speed + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# BehaviorModel.choose_side
+# ---------------------------------------------------------------------------
+
+
+class _SeqRng:
+    """rng.random() returns successive values from a sequence."""
+
+    def __init__(self, values):
+        self._iter = iter(values)
+
+    def random(self) -> float:
+        return float(next(self._iter))
+
+
+class TestChooseSide:
+    def test_compliant_path_passes_right(self):
+        params = PersonalityParams(compliance=1.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _SeqRng([0.0])  # < compliance -> returns -1 immediately.
+        side = bm.choose_side(_ped(), _ped(x=3.0))
+        assert side == -1
+
+    def test_non_compliant_random_left(self):
+        """compliance=0 -> skip right, then rng()<0.5 -> pass on the left (+1)."""
+        params = PersonalityParams(compliance=0.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _SeqRng([0.9, 0.1])  # First rejects right, second picks left.
+        side = bm.choose_side(_ped(), _ped(x=3.0))
+        assert side == 1
+
+    def test_non_compliant_random_right(self):
+        """compliance=0 + second rng>=0.5 -> pass on the right (-1)."""
+        params = PersonalityParams(compliance=0.0)
+        bm = BehaviorModel(params=params, rng_seed=0)
+        bm.rng = _SeqRng([0.9, 0.9])
+        side = bm.choose_side(_ped(), _ped(x=3.0))
+        assert side == -1
+
+
+# ---------------------------------------------------------------------------
+# BehaviorModel.compute_comfort
+# ---------------------------------------------------------------------------
+
+
+class TestComputeComfort:
+    def test_close_neighbour_reduces_comfort(self):
+        bm = BehaviorModel(rng_seed=0)
+        ego = _ped(vx=bm.preferred_speed)
+        intrusive = _ped(x=0.1, y=0.0)  # Well inside personal_space*1.5.
+        alone = bm.compute_comfort(ego, [])
+        crowded = bm.compute_comfort(ego, [intrusive])
+        assert crowded < alone
+        assert 0.0 <= crowded <= 1.0
+
+    def test_distraction_penalty_applied(self):
+        bm = BehaviorModel(rng_seed=0)
+        bm.attention._distracted = True
+        ego = _ped(vx=bm.preferred_speed)
+        comfort_distracted = bm.compute_comfort(ego, [])
+
+        bm.attention._distracted = False
+        comfort_focused = bm.compute_comfort(ego, [])
+        assert comfort_distracted < comfort_focused
+
+    def test_comfort_clamped_to_zero(self):
+        """Many close neighbours should not drive comfort below 0."""
+        bm = BehaviorModel(rng_seed=0)
+        bm.attention._distracted = True
+        ego = _ped(vx=0.0)  # Also triggers large speed deviation penalty.
+        neighbours = [_ped(pid=i, x=0.05 * (i + 1), y=0.0) for i in range(10)]
+        comfort = bm.compute_comfort(ego, neighbours)
+        assert comfort == 0.0
+
+
+# ---------------------------------------------------------------------------
+# BehaviorModel.compute_stress
+# ---------------------------------------------------------------------------
+
+
+class TestComputeStress:
+    def test_very_close_neighbour_increases_stress(self):
+        bm = BehaviorModel(rng_seed=0)
+        ego = _ped(vx=bm.preferred_speed, radius=0.3)
+        # Distance < radius*3 = 0.9 triggers stress term.
+        close = _ped(x=0.4, y=0.0, radius=0.3)
+        stress_alone = bm.compute_stress(ego, [])
+        stress_close = bm.compute_stress(ego, [close])
+        assert stress_close > stress_alone
+
+
+# ---------------------------------------------------------------------------
+# BehaviorModel.reset
+# ---------------------------------------------------------------------------
+
+
+class TestBehaviorModelReset:
+    def test_reset_clears_attention_distraction(self):
+        bm = BehaviorModel(rng_seed=0)
+        bm.attention._distracted = True
+        bm.attention._distraction_remaining = 3.0
+        bm.reset()
+        assert not bm.attention.is_distracted
+        assert bm.attention._distraction_remaining == 0.0

--- a/tests/test_sensors_camera_coverage.py
+++ b/tests/test_sensors_camera_coverage.py
@@ -1,0 +1,269 @@
+"""Additional coverage tests for navirl.sensors.camera.
+
+Targets branches that the top-level sensor suite leaves uncovered:
+- CameraSensor top-down wall-segment rendering via Bresenham _draw_line.
+- CameraSensor perspective mode with visible, behind, and out-of-FOV agents.
+- CameraSensor list-style agents (non-dict) and custom colour field.
+- CameraSensor._draw_line Bresenham single-pixel and off-canvas clipping.
+- DepthSensor with wall segments, circular obstacles, dict agents, and
+  array-style agents.
+- DepthSensor min_range clipping.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from navirl.sensors.camera import (
+    CameraConfig,
+    CameraSensor,
+    DepthSensor,
+    DepthSensorConfig,
+)
+
+
+def _world_state(
+    robot_pos=(0.0, 0.0),
+    robot_heading=0.0,
+    agents=None,
+    obstacles_segments=None,
+    obstacles_circles=None,
+):
+    ws = {
+        "robot_pos": np.array(robot_pos, dtype=np.float64),
+        "robot_heading": robot_heading,
+        "robot_vel": np.array([0.0, 0.0], dtype=np.float64),
+    }
+    if agents is not None:
+        ws["agents"] = agents
+    if obstacles_segments is not None:
+        ws["obstacles_segments"] = np.array(obstacles_segments, dtype=np.float64)
+    if obstacles_circles is not None:
+        ws["obstacles_circles"] = obstacles_circles
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# CameraSensor._draw_line -- Bresenham primitive
+# ---------------------------------------------------------------------------
+
+
+class TestDrawLineBresenham:
+    def test_single_pixel_line(self):
+        """x0==x1 and y0==y1 should paint exactly one pixel and terminate."""
+        img = np.zeros((5, 5, 3), dtype=np.uint8)
+        CameraSensor._draw_line(img, 2, 2, 2, 2, color=[7, 8, 9])
+        assert img[2, 2].tolist() == [7, 8, 9]
+        # No other pixel touched.
+        painted = np.sum(img.sum(axis=-1) > 0)
+        assert painted == 1
+
+    def test_diagonal_line_in_bounds(self):
+        img = np.zeros((10, 10, 3), dtype=np.uint8)
+        CameraSensor._draw_line(img, 0, 0, 9, 9, color=[10, 20, 30])
+        diag = [img[i, i].tolist() for i in range(10)]
+        assert all(px == [10, 20, 30] for px in diag)
+
+    def test_line_clipped_to_canvas(self):
+        """Pixels outside the image must be dropped silently."""
+        img = np.zeros((5, 5, 3), dtype=np.uint8)
+        # Start inside, finish well outside.
+        CameraSensor._draw_line(img, 2, 2, 20, 2, color=[255, 255, 255])
+        # The in-bounds portion (cols 2..4) should be painted.
+        assert img[2, 2].tolist() == [255, 255, 255]
+        assert img[2, 4].tolist() == [255, 255, 255]
+        # Nothing should leak beyond the canvas (it would have crashed if it did).
+
+    def test_reverse_direction_line(self):
+        """sx/sy stepping must handle x0>x1 and y0>y1."""
+        img = np.zeros((10, 10, 3), dtype=np.uint8)
+        CameraSensor._draw_line(img, 8, 8, 1, 1, color=[50, 60, 70])
+        # Endpoints are both inside and painted.
+        assert img[8, 8].tolist() == [50, 60, 70]
+        assert img[1, 1].tolist() == [50, 60, 70]
+
+
+# ---------------------------------------------------------------------------
+# CameraSensor top-down wall segments
+# ---------------------------------------------------------------------------
+
+
+class TestTopDownWithSegments:
+    def test_wall_segment_renders_line(self):
+        """obstacles_segments trigger _draw_line calls."""
+        cam = CameraSensor(
+            CameraConfig(resolution_x=64, resolution_y=64, render_mode="top_down")
+        )
+        ws_empty = _world_state(robot_pos=(0.0, 0.0))
+        segments = [[[-2.0, 2.0], [2.0, 2.0]]]  # wall in front of robot
+        ws_wall = _world_state(robot_pos=(0.0, 0.0), obstacles_segments=segments)
+
+        img_empty = cam.observe(ws_empty)
+        img_wall = cam.observe(ws_wall)
+        assert not np.array_equal(img_empty, img_wall)
+
+
+# ---------------------------------------------------------------------------
+# CameraSensor perspective mode
+# ---------------------------------------------------------------------------
+
+
+class TestPerspectiveAgents:
+    def _cam(self):
+        return CameraSensor(
+            CameraConfig(
+                resolution_x=128,
+                resolution_y=64,
+                render_mode="perspective",
+                fov_horizontal=np.pi / 2.0,  # 90 deg -> wide enough to catch center
+                max_depth=20.0,
+            )
+        )
+
+    def test_visible_agent_renders(self):
+        """Agent in front of robot within FOV should paint pixels."""
+        cam = self._cam()
+        # Agent 3m in +x direction, robot heading=0 (also +x).
+        agents = [{"pos": np.array([3.0, 0.0]), "radius": 0.4}]
+        ws = _world_state(robot_pos=(0.0, 0.0), robot_heading=0.0, agents=agents)
+
+        empty_ws = _world_state(robot_pos=(0.0, 0.0), robot_heading=0.0)
+        img_empty = cam.observe(empty_ws)
+        img_agent = cam.observe(ws)
+        assert not np.array_equal(img_empty, img_agent)
+
+    def test_agent_behind_robot_skipped(self):
+        """cam_x < EPSILON branch -- behind the robot -> no render."""
+        cam = self._cam()
+        agents = [{"pos": np.array([-3.0, 0.0]), "radius": 0.4}]
+        ws = _world_state(robot_pos=(0.0, 0.0), robot_heading=0.0, agents=agents)
+        img_agent = cam.observe(ws)
+        img_empty = cam.observe(_world_state(robot_pos=(0.0, 0.0)))
+        np.testing.assert_array_equal(img_agent, img_empty)
+
+    def test_agent_outside_fov_skipped(self):
+        """An agent beyond half-FOV angle is skipped."""
+        cam = self._cam()  # half_fov = 45 deg
+        # 1m forward, 5m to the side -> angle ~79 deg -> outside.
+        agents = [{"pos": np.array([1.0, 5.0]), "radius": 0.4}]
+        ws = _world_state(robot_pos=(0.0, 0.0), robot_heading=0.0, agents=agents)
+        img_agent = cam.observe(ws)
+        img_empty = cam.observe(_world_state(robot_pos=(0.0, 0.0)))
+        np.testing.assert_array_equal(img_agent, img_empty)
+
+    def test_perspective_list_agent_format(self):
+        """Perspective mode also accepts (x, y, radius) tuples/arrays."""
+        cam = self._cam()
+        agents = [np.array([2.0, 0.0, 0.3])]
+        ws = _world_state(robot_pos=(0.0, 0.0), robot_heading=0.0, agents=agents)
+        img = cam.observe(ws)
+        # Something rendered (non-background pixels exist).
+        assert (img != 200).any()
+
+    def test_rotated_heading_changes_projection(self):
+        """Agent position constant, heading changes -> image differs."""
+        cam = self._cam()
+        agents = [{"pos": np.array([3.0, 0.0]), "radius": 0.4}]
+        ws0 = _world_state(robot_pos=(0.0, 0.0), robot_heading=0.0, agents=agents)
+        ws_back = _world_state(robot_pos=(0.0, 0.0), robot_heading=np.pi, agents=agents)
+        img0 = cam.observe(ws0)
+        img_back = cam.observe(ws_back)
+        # With heading=pi, agent is now behind -> skipped, image stays background.
+        assert not np.array_equal(img0, img_back)
+
+
+# ---------------------------------------------------------------------------
+# CameraSensor top-down with list-style agents and custom colour
+# ---------------------------------------------------------------------------
+
+
+class TestTopDownListAgents:
+    def test_list_agent_format(self):
+        """List-style agents [x, y, radius] take the non-dict isinstance branch."""
+        cam = CameraSensor(
+            CameraConfig(resolution_x=64, resolution_y=64, render_mode="top_down")
+        )
+        # Agent offset from robot so the centre-drawn robot does not fully cover it.
+        agents = [np.array([2.0, 0.0, 0.5])]
+        ws_agent = _world_state(robot_pos=(0.0, 0.0), agents=agents)
+        ws_empty = _world_state(robot_pos=(0.0, 0.0))
+        assert not np.array_equal(cam.observe(ws_agent), cam.observe(ws_empty))
+
+    def test_dict_agent_custom_colour_renders(self):
+        """A dict agent with a colour field should produce that colour in the image."""
+        cam = CameraSensor(
+            CameraConfig(resolution_x=64, resolution_y=64, render_mode="top_down")
+        )
+        # Offset from centre so robot doesn't paint over it.
+        agents = [{"pos": np.array([2.0, 0.0]), "radius": 0.5, "color": [10, 20, 30]}]
+        ws = _world_state(robot_pos=(0.0, 0.0), agents=agents)
+        img = cam.observe(ws)
+        matches = np.all(img == [10, 20, 30], axis=-1)
+        assert matches.any()
+
+
+# ---------------------------------------------------------------------------
+# DepthSensor branches
+# ---------------------------------------------------------------------------
+
+
+class TestDepthSensorBranches:
+    def test_depth_with_wall_segments(self):
+        ds = DepthSensor(DepthSensorConfig(resolution=8, max_range=20.0, noise_std=0.0))
+        segments = [[[5.0, -10.0], [5.0, 10.0]]]  # wall at x=5
+        ws = _world_state(
+            robot_pos=(0.0, 0.0), robot_heading=0.0, obstacles_segments=segments
+        )
+        ranges = ds.observe(ws)
+        # Centre ray hits wall at distance ~5.
+        assert np.min(ranges) < 6.0
+        assert np.min(ranges) > 4.0
+
+    def test_depth_with_circle_and_segment(self):
+        ds = DepthSensor(DepthSensorConfig(resolution=16, max_range=20.0, noise_std=0.0))
+        ws = _world_state(
+            robot_pos=(0.0, 0.0),
+            obstacles_segments=[[[8.0, -5.0], [8.0, 5.0]]],
+            obstacles_circles={
+                "centres": np.array([[3.0, 0.0]]),
+                "radii": np.array([0.5]),
+            },
+        )
+        ranges = ds.observe(ws)
+        # Circle is closer than wall -> min should be near 2.5.
+        assert np.min(ranges) < 3.5
+
+    def test_depth_with_dict_agents(self):
+        ds = DepthSensor(DepthSensorConfig(resolution=16, max_range=20.0, noise_std=0.0))
+        agents = [{"pos": np.array([4.0, 0.0]), "radius": 0.3}]
+        ws = _world_state(robot_pos=(0.0, 0.0), agents=agents)
+        ranges = ds.observe(ws)
+        assert np.min(ranges) < 20.0
+
+    def test_depth_with_array_style_agents(self):
+        """agents as a (N, 3) array of [x, y, radius] triggers the non-dict branch."""
+        ds = DepthSensor(DepthSensorConfig(resolution=16, max_range=20.0, noise_std=0.0))
+        agents = np.array([[4.0, 0.0, 0.4]])  # shape (1, 3)
+        ws = _world_state(robot_pos=(0.0, 0.0), agents=list(agents))
+        # Convert to list of rows so agents[0] is an ndarray (not dict).
+        ws["agents"] = [np.asarray(row) for row in agents]
+        ranges = ds.observe(ws)
+        assert np.min(ranges) < 20.0
+
+    def test_depth_clipped_to_min_range(self):
+        """A very close obstacle still returns >= min_range after clipping."""
+        ds = DepthSensor(
+            DepthSensorConfig(
+                resolution=8, min_range=0.5, max_range=20.0, noise_std=0.0
+            )
+        )
+        # Centre the robot inside a circle so raw intersection would be negative/tiny.
+        ws = _world_state(
+            robot_pos=(0.0, 0.0),
+            obstacles_circles={
+                "centres": np.array([[0.1, 0.0]]),
+                "radii": np.array([0.05]),
+            },
+        )
+        ranges = ds.observe(ws)
+        assert np.all(ranges >= 0.5 - 1e-9)


### PR DESCRIPTION
## Summary

Target two modules with clear coverage gaps in the `pytest --cov` report:

- **`navirl/humans/behavior_model.py`** — 72.9% → **100.0%** (+46 lines covered)
- **`navirl/sensors/camera.py`** — 78.7% → **100.0%** (+36 lines covered)

Overall project coverage: 76.58% → 76.85% (+84 covered statements).

## What's covered now

### `test_behavior_model_decisions.py` — 26 tests

Previously the broad smoke suite in `tests/test_humans.py` only hit the
no-neighbour / default-personality paths of `BehaviorModel`. The missing
46 lines were the actual decision logic. This file adds targeted
branch-coverage tests for:

- `AttentionModel.step` — entering distraction on RNG trigger,
  countdown, expiry, and the clamp-to-zero after overshoot.
- `AttentionModel.can_perceive` — the co-located observer / target
  short-circuit (`dist < 1e-9`).
- `_default_attention` — `DISTRACTED` and `CHILD` personality branches.
- `BehaviorModel.create_child` — previously unused factory classmethod.
- `BehaviorModel.should_yield` — assertiveness × speed-ratio × compliance
  × bearing-from-the-right matrix, including the p_yield ≥ 1 clamp.
- `BehaviorModel.adapt_speed` — slow neighbour drags adapted speed down,
  awareness-radius gating, and max-speed clamp.
- `BehaviorModel.choose_side` — compliant-right and non-compliant
  left/right random branches.
- `BehaviorModel.compute_comfort` — personal-space intrusion penalty,
  distraction penalty, floor clamp at 0.
- `BehaviorModel.compute_stress` — very-close-neighbour stress term.
- `BehaviorModel.reset` — propagation to `AttentionModel`.

Deterministic RNG stubs (`_AlwaysEnterRng`, `_NeverEnterRng`,
`_YieldingCoinRng`, `_SeqRng`) pin random decisions so the tests exercise
specific branches without flakiness.

### `test_sensors_camera_coverage.py` — 17 tests

- `CameraSensor._draw_line` — Bresenham primitives: single-pixel
  termination, diagonal lines, off-canvas clipping, reversed direction
  (`sx`/`sy` negative stepping).
- Top-down wall-segment rendering (wires up `_draw_line`).
- Top-down list-style (non-dict) agents and dict agents with a custom
  `color` field.
- Perspective mode: visible agents, the `cam_x < EPSILON` skip branch
  for agents behind the robot, the out-of-FOV skip branch, the list-agent
  branch, and that rotating the robot changes the projection.
- `DepthSensor`: wall segments, combined segments + circles, dict vs.
  array agent formats, and the final `min_range` clip.

## Test plan

- [x] `ruff check tests/test_behavior_model_decisions.py tests/test_sensors_camera_coverage.py` — clean
- [x] `ruff check navirl tests` — clean
- [x] `pytest tests/test_behavior_model_decisions.py tests/test_sensors_camera_coverage.py` — 43 passed
- [x] Full suite: `5538 passed, 173 skipped` (baseline was 5495 + 173)
- [x] Coverage on both targeted files: 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)