### PR TITLE
test: cover crowd_generator flows, registry fail paths, ros lazy init

### DIFF
--- a/tests/test_core_registry_validation.py
+++ b/tests/test_core_registry_validation.py
@@ -442,3 +442,107 @@ class TestValidateAllPlugins:
         issues = validate_all_plugins()
         # Should detect the API version issue
         assert any("old_hc" in k for k in issues)
+
+    def test_detects_non_callable_factory(self):
+        # Insert a non-callable directly to trigger the factory-validation branch.
+        _BACKENDS["broken_be"] = "not_a_callable"
+        issues = validate_all_plugins()
+        assert "backend:broken_be" in issues
+        assert any("Factory validation" in msg for msg in issues["backend:broken_be"])
+
+    def test_detects_dangerous_class(self):
+        class DangerousPlugin(_DummyBase):
+            __navirl_api_version__ = "1.0"
+
+            def step(self):  # pragma: no cover - interface only
+                pass
+
+            def exec(self):  # triggers security validation failure
+                pass
+
+        _ROBOT_CONTROLLERS["danger_rc"] = DangerousPlugin
+        issues = validate_all_plugins()
+        assert "robot_controller:danger_rc" in issues
+        assert any("Security" in msg for msg in issues["robot_controller:danger_rc"])
+
+
+# ===================================================================
+# Failure paths in register_* helpers
+# ===================================================================
+
+
+class TestRegisterFailurePaths:
+    def test_backend_factory_validation_failure_is_propagated(self, caplog):
+        with caplog.at_level("ERROR"), pytest.raises(PluginValidationError):
+            register_backend("bad_be", "not_a_callable")
+        assert "Failed to register backend 'bad_be'" in caplog.text
+        assert "bad_be" not in _BACKENDS
+
+    def test_human_controller_factory_validation_failure_is_propagated(self, caplog):
+        with caplog.at_level("ERROR"), pytest.raises(PluginValidationError):
+            register_human_controller("bad_hc", "not_a_callable")
+        assert "Failed to register human controller 'bad_hc'" in caplog.text
+        assert "bad_hc" not in _HUMAN_CONTROLLERS
+
+    def test_human_controller_security_failure_is_propagated(self, caplog):
+        class BadPlugin(_DummyBase):
+            __navirl_api_version__ = "1.0"
+
+            def step(self):  # pragma: no cover - interface only
+                pass
+
+            def exec(self):  # triggers PluginSecurityError via validate_plugin_security
+                pass
+
+        with caplog.at_level("ERROR"), pytest.raises(PluginValidationError):
+            register_human_controller("bad_hc_sec", BadPlugin)
+        assert "Failed to register human controller 'bad_hc_sec'" in caplog.text
+
+    def test_robot_controller_factory_validation_failure_is_propagated(self, caplog):
+        with caplog.at_level("ERROR"), pytest.raises(PluginValidationError):
+            register_robot_controller("bad_rc", "not_a_callable")
+        assert "Failed to register robot controller 'bad_rc'" in caplog.text
+        assert "bad_rc" not in _ROBOT_CONTROLLERS
+
+    def test_robot_controller_override_warns(self, caplog):
+        register_robot_controller("dup_rc", _factory_fn)
+        with caplog.at_level("WARNING"):
+            register_robot_controller("dup_rc", _factory_fn)
+        assert "Overriding existing robot controller 'dup_rc'" in caplog.text
+
+    def test_human_controller_override_warns(self, caplog):
+        register_human_controller("dup_hc", _factory_fn)
+        with caplog.at_level("WARNING"):
+            register_human_controller("dup_hc", _factory_fn)
+        assert "Overriding existing human controller 'dup_hc'" in caplog.text
+
+
+# ===================================================================
+# get_plugin_info fallback when signature inspection fails
+# ===================================================================
+
+
+class TestGetPluginInfoSignatureFallback:
+    def test_signature_inspection_failure_falls_back(self, monkeypatch):
+        register_human_controller(
+            "sig_class", _GoodPlugin, enable_security_validation=False
+        )
+
+        original_signature = __import__("inspect").signature
+
+        def fake_signature(target, *args, **kwargs):
+            # Force the fallback for the registry's internal signature call
+            # on __init__, but leave all other callers untouched.
+            if getattr(target, "__qualname__", "") == "_GoodPlugin.__init__" or (
+                getattr(target, "__self__", None) is _GoodPlugin
+                and getattr(target, "__name__", "") == "__init__"
+            ):
+                raise ValueError("synthetic signature failure")
+            # The registry accesses ``factory.__init__``; match that path too.
+            if target is _GoodPlugin.__init__:
+                raise ValueError("synthetic signature failure")
+            return original_signature(target, *args, **kwargs)
+
+        monkeypatch.setattr("navirl.core.registry.inspect.signature", fake_signature)
+        info = get_plugin_info("human_controller", "sig_class")
+        assert info["init_parameters"] == "unknown"

--- a/tests/test_crowd_generator_coverage.py
+++ b/tests/test_crowd_generator_coverage.py
@@ -1,0 +1,238 @@
+"""Coverage tests for navirl/humans/crowd_generator.py.
+
+Targets the uncovered paths in GoalAssigner flow-pattern dispatch, fallback
+branches for sparsely-configured generators, and the evacuation /
+event_gathering scenario factories.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from navirl.humans.crowd_generator import (
+    CrowdGenerator,
+    FlowPattern,
+    GoalAssigner,
+    SpawnEvent,
+    SpawnRegion,
+    SpawnStrategy,
+)
+
+# ===========================================================================
+# GoalAssigner flow patterns
+# ===========================================================================
+
+
+class TestGoalAssignerFlows:
+    def _rng(self) -> np.random.Generator:
+        return np.random.default_rng(42)
+
+    def test_random_flow_prefers_goal_regions(self):
+        goal = SpawnRegion(20.0, 21.0, 20.0, 21.0)
+        ga = GoalAssigner(goal_regions=[goal], flow_pattern=FlowPattern.RANDOM)
+        g = ga.assign(np.array([0.0, 0.0]), 0, self._rng())
+        assert goal.contains(g)
+
+    def test_random_flow_uses_arena_when_no_goal_regions(self):
+        arena = SpawnRegion(-5.0, 5.0, -5.0, 5.0)
+        ga = GoalAssigner(goal_regions=None, flow_pattern=FlowPattern.RANDOM)
+        g = ga.assign(np.array([0.0, 0.0]), 0, self._rng(), arena_bounds=arena)
+        assert arena.contains(g)
+
+    def test_random_flow_fallback_when_no_regions_and_no_arena(self):
+        ga = GoalAssigner(flow_pattern=FlowPattern.RANDOM)
+        spawn = np.array([1.0, 2.0])
+        g = ga.assign(spawn, 0, self._rng())
+        # Fallback uses spawn + random offset at distance in [5, 15]
+        dist = float(np.linalg.norm(g - spawn))
+        assert 4.999 <= dist <= 15.001
+
+    def test_unidirectional_goal_left_side(self):
+        arena = SpawnRegion(-10.0, 10.0, -5.0, 5.0)
+        ga = GoalAssigner(flow_pattern=FlowPattern.UNIDIRECTIONAL)
+        g = ga.assign(np.array([-8.0, 0.0]), 0, self._rng(), arena_bounds=arena)
+        # spawn_x=-8 is below midx=0, so goal should be on right half
+        assert g[0] >= 0.0
+        assert arena.y_min <= g[1] <= arena.y_max
+
+    def test_unidirectional_goal_right_side(self):
+        arena = SpawnRegion(-10.0, 10.0, -5.0, 5.0)
+        ga = GoalAssigner(flow_pattern=FlowPattern.UNIDIRECTIONAL)
+        g = ga.assign(np.array([8.0, 0.0]), 0, self._rng(), arena_bounds=arena)
+        # spawn_x=8 is above midx=0, so goal should be on left half
+        assert g[0] <= 0.0
+
+    def test_unidirectional_goal_no_arena_fallback(self):
+        ga = GoalAssigner(flow_pattern=FlowPattern.UNIDIRECTIONAL)
+        spawn = np.array([1.0, 1.0])
+        g = ga.assign(spawn, 0, self._rng())
+        # Fallback: spawn + [20, 0]
+        np.testing.assert_allclose(g, spawn + np.array([20.0, 0.0]))
+
+    def test_bidirectional_pairs_opposite_regions(self):
+        left = SpawnRegion(-10.0, -9.0, -1.0, 1.0)
+        right = SpawnRegion(9.0, 10.0, -1.0, 1.0)
+        ga = GoalAssigner(goal_regions=[left, right], flow_pattern=FlowPattern.BIDIRECTIONAL)
+        # spawning in region 0 (left) should route goal to region 1 (right)
+        g = ga.assign(np.array([-9.5, 0.0]), 0, self._rng())
+        assert right.contains(g)
+        # spawning in region 1 (right) should route goal to region 0 (left)
+        g2 = ga.assign(np.array([9.5, 0.0]), 1, self._rng())
+        assert left.contains(g2)
+
+    def test_bidirectional_fallback_when_fewer_than_two_regions(self):
+        single = SpawnRegion(-10.0, -9.0, -1.0, 1.0)
+        ga = GoalAssigner(goal_regions=[single], flow_pattern=FlowPattern.BIDIRECTIONAL)
+        spawn = np.array([-9.5, 0.0])
+        g = ga.assign(spawn, 0, self._rng())
+        # Fallback: spawn + [15, 0]
+        np.testing.assert_allclose(g, spawn + np.array([15.0, 0.0]))
+
+    def test_crossing_routes_to_opposite_index(self):
+        # With 4 regions, crossing routes idx -> (idx + 2) % 4
+        r0 = SpawnRegion(-10.0, -9.0, -1.0, 1.0)
+        r1 = SpawnRegion(-1.0, 1.0, 9.0, 10.0)
+        r2 = SpawnRegion(9.0, 10.0, -1.0, 1.0)
+        r3 = SpawnRegion(-1.0, 1.0, -10.0, -9.0)
+        ga = GoalAssigner(goal_regions=[r0, r1, r2, r3], flow_pattern=FlowPattern.CROSSING)
+        g = ga.assign(np.array([-9.5, 0.0]), 0, self._rng())
+        assert r2.contains(g)
+
+    def test_crossing_fallback_when_fewer_than_two_regions(self):
+        single = SpawnRegion(-10.0, -9.0, -1.0, 1.0)
+        ga = GoalAssigner(goal_regions=[single], flow_pattern=FlowPattern.CROSSING)
+        spawn = np.array([0.0, 0.0])
+        g = ga.assign(spawn, 0, self._rng())
+        # Fallback: spawn + 10 * unit vector on circle
+        dist = float(np.linalg.norm(g - spawn))
+        assert dist == pytest.approx(10.0, abs=1e-6)
+
+    def test_radial_in_converges_on_centre(self):
+        arena = SpawnRegion(-10.0, 10.0, -10.0, 10.0)
+        ga = GoalAssigner(flow_pattern=FlowPattern.RADIAL_IN)
+        g = ga.assign(np.array([8.0, 8.0]), 0, self._rng(), arena_bounds=arena)
+        # Centre is origin; goal should be near it (normal noise with std 0.5)
+        assert float(np.linalg.norm(g)) < 5.0
+
+    def test_radial_in_without_arena_uses_origin(self):
+        ga = GoalAssigner(flow_pattern=FlowPattern.RADIAL_IN)
+        g = ga.assign(np.array([5.0, 5.0]), 0, self._rng())
+        # Centre defaults to [0, 0]
+        assert float(np.linalg.norm(g)) < 5.0
+
+    def test_radial_out_moves_outward(self):
+        arena = SpawnRegion(-5.0, 5.0, -5.0, 5.0)
+        ga = GoalAssigner(flow_pattern=FlowPattern.RADIAL_OUT)
+        g = ga.assign(np.array([0.0, 0.0]), 0, self._rng(), arena_bounds=arena)
+        # Distance is uniform(15, 20)
+        dist = float(np.linalg.norm(g))
+        assert 14.999 <= dist <= 20.001
+
+
+# ===========================================================================
+# CrowdGenerator branch coverage
+# ===========================================================================
+
+
+class TestCrowdGeneratorEdges:
+    def test_generate_batch_returns_empty_when_max_reached(self):
+        gen = CrowdGenerator(max_pedestrians=3, rng_seed=1)
+        first = gen.generate_batch(count=3)
+        assert len(first) == 3
+        # Second call hits the "count <= 0" early return.
+        second = gen.generate_batch(count=5)
+        assert second == []
+
+    def test_generate_poisson_returns_empty_when_max_reached(self):
+        gen = CrowdGenerator(
+            spawn_strategy=SpawnStrategy.POISSON,
+            poisson_rate=5.0,
+            max_pedestrians=2,
+            rng_seed=7,
+        )
+        gen.generate_batch(count=2)  # fill to max
+        out = gen.generate_poisson(dt=1.0)
+        assert out == []
+
+    def test_step_unknown_strategy_returns_empty(self):
+        gen = CrowdGenerator(rng_seed=2)
+        # Corrupt the strategy to force the final fallback branch.
+        gen.spawn_strategy = "not-a-real-strategy"
+        assert gen.step(0.0, 0.1) == []
+
+    def test_step_poisson_empty_before_arrivals(self):
+        # Poisson rate zero => no arrivals even at long dt.
+        gen = CrowdGenerator(
+            spawn_strategy=SpawnStrategy.POISSON,
+            poisson_rate=0.0,
+            max_pedestrians=10,
+            rng_seed=3,
+        )
+        assert gen.step(0.0, 10.0) == []
+
+    def test_step_scheduled_multiple_events_same_time(self):
+        schedule = [
+            SpawnEvent(time_s=0.0, count=2, region_idx=0),
+            SpawnEvent(time_s=0.0, count=1, region_idx=0),
+        ]
+        gen = CrowdGenerator(
+            spawn_strategy=SpawnStrategy.SCHEDULED,
+            schedule=schedule,
+            rng_seed=4,
+        )
+        out = gen.step(0.0, 0.1)
+        assert len(out) == 3
+
+
+# ===========================================================================
+# Scenario factory coverage
+# ===========================================================================
+
+
+class TestScenarioFactories:
+    def test_evacuation_scenario_respects_n_pedestrians(self):
+        gen = CrowdGenerator.evacuation_scenario(
+            room_size=10.0,
+            exit_width=1.5,
+            n_pedestrians=12,
+            rng_seed=5,
+        )
+        peds = gen.generate_batch()
+        assert len(peds) == 12
+        # Demographics default was widened for evacuation (max 2.5 m/s).
+        speeds = [p.preferred_speed for p in peds]
+        assert max(speeds) <= 2.5
+        # Assigner should use the single exit as the goal region.
+        assert gen.goal_assigner.flow_pattern == FlowPattern.UNIDIRECTIONAL
+        assert len(gen.goal_assigner.goal_regions) == 1
+
+    def test_event_gathering_scenario_uses_poisson_and_four_regions(self):
+        gen = CrowdGenerator.event_gathering_scenario(
+            arena_radius=12.0,
+            stage_pos=(0.0, 0.0),
+            poisson_rate=5.0,
+            max_pedestrians=20,
+            rng_seed=6,
+        )
+        assert gen.spawn_strategy == SpawnStrategy.POISSON
+        assert len(gen.spawn_regions) == 4
+        assert gen.goal_assigner.flow_pattern == FlowPattern.RADIAL_IN
+        # Under Poisson arrival, several peds should come in over a long dt.
+        peds = gen.step(0.0, 2.0)
+        assert all(p.pid >= 0 for p in peds)
+
+    def test_event_gathering_stage_offset_positions_goal(self):
+        gen = CrowdGenerator.event_gathering_scenario(
+            arena_radius=15.0,
+            stage_pos=(5.0, -3.0),
+            poisson_rate=1.0,
+            max_pedestrians=5,
+            rng_seed=8,
+        )
+        goal_region = gen.goal_assigner.goal_regions[0]
+        # Goal region is a 6m box centered on stage_pos.
+        assert goal_region.x_min == pytest.approx(2.0)
+        assert goal_region.x_max == pytest.approx(8.0)
+        assert goal_region.y_min == pytest.approx(-6.0)
+        assert goal_region.y_max == pytest.approx(0.0)

--- a/tests/test_ros_package_init.py
+++ b/tests/test_ros_package_init.py
@@ -1,0 +1,102 @@
+"""Coverage tests for navirl/ros/__init__.py.
+
+The package defers rclpy imports until needed. These tests exercise both the
+``ros2_available()`` availability probe and the lazy ``__getattr__`` loader
+without requiring ROS2 to be installed on the test host.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fresh_ros_pkg(monkeypatch):
+    """Reload navirl.ros in isolation so the module-level cache state is reset."""
+    for name in list(sys.modules):
+        if name == "navirl.ros" or name.startswith("navirl.ros."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    pkg = importlib.import_module("navirl.ros")
+    yield pkg
+    for name in list(sys.modules):
+        if name == "navirl.ros" or name.startswith("navirl.ros."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_ros2_available_returns_bool(fresh_ros_pkg):
+    """``ros2_available`` returns a bool regardless of environment."""
+    result = fresh_ros_pkg.ros2_available()
+    assert isinstance(result, bool)
+
+
+def test_ros2_available_caches_result(fresh_ros_pkg):
+    """A second call reuses the cached value without re-importing."""
+    first = fresh_ros_pkg.ros2_available()
+    # Prevent a second importlib.import_module("rclpy") from succeeding.
+    import navirl.ros as pkg_module
+
+    original_import = importlib.import_module
+
+    def _fail(name, *args, **kwargs):
+        if name == "rclpy":
+            raise AssertionError("rclpy should not be imported on cached call")
+        return original_import(name, *args, **kwargs)
+
+    pkg_module.importlib.import_module = _fail
+    try:
+        assert fresh_ros_pkg.ros2_available() is first
+    finally:
+        pkg_module.importlib.import_module = original_import
+
+
+def test_ros2_available_false_when_rclpy_missing(monkeypatch, fresh_ros_pkg):
+    """If rclpy import fails, the probe returns False."""
+    import navirl.ros as pkg_module
+
+    # Reset the cache to force recomputation.
+    pkg_module._ROS2_AVAILABLE = None
+
+    original_import = importlib.import_module
+
+    def _fake(name, *args, **kwargs):
+        if name == "rclpy":
+            raise ImportError("synthetic: rclpy not available")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(pkg_module.importlib, "import_module", _fake)
+    assert pkg_module.ros2_available() is False
+
+
+def test_lazy_getattr_loads_tf_utils_symbol(fresh_ros_pkg):
+    """Accessing a lazily-declared symbol imports its submodule on demand."""
+    # ``world_to_robot`` maps to the tf_utils submodule.
+    attr = fresh_ros_pkg.world_to_robot
+    assert callable(attr)
+
+    from navirl.ros.tf_utils import world_to_robot as direct
+
+    assert attr is direct
+
+
+def test_lazy_getattr_caches_on_package(fresh_ros_pkg):
+    """Once resolved, the attribute is cached on the package's globals."""
+    first = fresh_ros_pkg.world_to_robot  # first access populates the cache
+    # On a second access the import machinery is not consulted.
+    cached = fresh_ros_pkg.__dict__["world_to_robot"]
+    assert cached is first
+
+
+def test_lazy_getattr_unknown_raises_attribute_error(fresh_ros_pkg):
+    with pytest.raises(AttributeError, match="no attribute 'not_a_real_symbol'"):
+        _ = fresh_ros_pkg.not_a_real_symbol
+
+
+def test_all_exports_include_lazy_entries(fresh_ros_pkg):
+    exported = set(fresh_ros_pkg.__all__)
+    assert "ros2_available" in exported
+    # Representative entries from each submodule group.
+    for name in ("NavIRLNode", "TransformManager", "laser_scan_to_lidar_obs"):
+        assert name in exported


### PR DESCRIPTION
## Summary

Adds **37 tests** that close high-value coverage gaps in three modules none of the open test-coverage PRs are touching:

- `navirl/humans/crowd_generator.py`: **82% → 99%** — every GoalAssigner flow pattern and fallback, early-return branches in `generate_batch` / `generate_poisson` / `step`, and the previously-untested `evacuation_scenario` + `event_gathering_scenario` factories.
- `navirl/core/registry.py`: **88% → 100%** — override-warning paths for all three registries, validation-failure propagation through `register_*` helpers, `validate_all_plugins` against directly-inserted non-callable and security-unsafe factories, and the signature-inspection fallback in `get_plugin_info`.
- `navirl/ros/__init__.py`: **33% → 95%** — `ros2_available` caching and ImportError fallback, plus the lazy `__getattr__` loader for declared submodule symbols.

## Test plan

- [x] `PYTHONPATH=. pytest tests/test_crowd_generator_coverage.py tests/test_ros_package_init.py tests/test_core_registry_validation.py` — 85 pass
- [x] `PYTHONPATH=. pytest tests/` — 5529 passed, 173 skipped (was 5492 baseline). The 3 TOML library failures are pre-existing and unrelated.
- [x] `ruff check` on the new/changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)