### PR TITLE
test: add 47 tests for AsyncVecEnv, ETHUCY parsing, executor pool

### DIFF
--- a/tests/test_async_vec_env.py
+++ b/tests/test_async_vec_env.py
@@ -1,0 +1,299 @@
+"""End-to-end tests for navirl.training.parallel.AsyncVecEnv and SubprocVecEnv.
+
+Spawns real subprocesses (via the ``fork`` start method on Linux) to exercise
+the inter-process step / reset / poll paths that pure-mock tests miss.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+
+import numpy as np
+import pytest
+
+from navirl.training.parallel import AsyncVecEnv, SubprocVecEnv
+
+# ---------------------------------------------------------------------------
+# Picklable env / env_fn definitions (must be top-level for spawn semantics)
+# ---------------------------------------------------------------------------
+
+
+class _Space:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class _SimpleEnv:
+    """Minimal env where step returns deterministic values per (instance, step)."""
+
+    def __init__(self, episode_len: int = 4):
+        self.observation_space = _Space((3,))
+        self.action_space = _Space((2,))
+        self._t = 0
+        self._episode_len = episode_len
+
+    def reset(self):
+        self._t = 0
+        return np.zeros(3, dtype=np.float32)
+
+    def step(self, action):
+        self._t += 1
+        obs = np.full(3, float(self._t), dtype=np.float32)
+        reward = float(self._t)
+        done = self._t >= self._episode_len
+        info: dict = {"step": self._t}
+        return obs, reward, done, info
+
+    def close(self):
+        pass
+
+    # Used by SubprocVecEnv.env_method
+    def add(self, a, b):
+        return a + b
+
+
+class _SlowEnv(_SimpleEnv):
+    """Env that sleeps before returning the step result (used to test poll())."""
+
+    def step(self, action):
+        time.sleep(0.05)
+        return super().step(action)
+
+
+def _make_simple_env():
+    return _SimpleEnv(episode_len=4)
+
+
+def _make_slow_env():
+    return _SlowEnv(episode_len=4)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _start_method() -> str:
+    """Pick a fast start method available on this platform."""
+    available = mp.get_all_start_methods()
+    if "fork" in available:
+        return "fork"
+    return "spawn"
+
+
+# ---------------------------------------------------------------------------
+# SubprocVecEnv — real-process round trip
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocVecEnv:
+    def test_reset_returns_stacked_obs(self):
+        venv = SubprocVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            obs = venv.reset()
+            assert obs.shape == (2, 3)
+            np.testing.assert_array_equal(obs, 0.0)
+        finally:
+            venv.close()
+
+    def test_step_returns_obs_rewards_dones_infos(self):
+        venv = SubprocVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            venv.reset()
+            actions = np.zeros((2, 2), dtype=np.float32)
+            obs, rewards, dones, infos = venv.step(actions)
+            assert obs.shape == (2, 3)
+            assert rewards.shape == (2,)
+            assert dones.shape == (2,)
+            assert len(infos) == 2
+            # rewards = step count = 1 after first step
+            np.testing.assert_array_equal(rewards, [1.0, 1.0])
+            assert not dones.any()
+        finally:
+            venv.close()
+
+    def test_step_auto_resets_when_done(self):
+        venv = SubprocVecEnv([_make_simple_env], start_method=_start_method())
+        try:
+            venv.reset()
+            actions = np.zeros((1, 2), dtype=np.float32)
+            for _ in range(3):
+                venv.step(actions)
+            obs, rewards, dones, infos = venv.step(actions)
+            assert dones[0]
+            assert "terminal_observation" in infos[0]
+            # After auto-reset, the returned obs should be the post-reset obs (zeros)
+            np.testing.assert_array_equal(obs[0], 0.0)
+        finally:
+            venv.close()
+
+    def test_get_attr_returns_each_env_attr(self):
+        venv = SubprocVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            shapes = venv.get_attr("observation_space")
+            assert len(shapes) == 2
+            for s in shapes:
+                assert s.shape == (3,)
+        finally:
+            venv.close()
+
+    def test_env_method_calls_method_per_env(self):
+        venv = SubprocVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            results = venv.env_method("add", 2, b=5)
+            assert results == [7, 7]
+        finally:
+            venv.close()
+
+    def test_close_when_step_pending(self):
+        """``close()`` must drain any in-flight step results before sending close."""
+        venv = SubprocVecEnv([_make_simple_env], start_method=_start_method())
+        venv.reset()
+        actions = np.zeros((1, 2), dtype=np.float32)
+        venv.step_async(actions)
+        # Don't call step_wait — close must clean up the pending recv
+        venv.close()
+        assert venv.closed
+
+    def test_close_is_idempotent(self):
+        venv = SubprocVecEnv([_make_simple_env], start_method=_start_method())
+        venv.close()
+        # Second close should be a no-op
+        venv.close()
+        assert venv.closed
+
+    def test_default_start_method_is_chosen(self):
+        """Passing ``start_method=None`` resolves to forkserver/spawn automatically."""
+        venv = SubprocVecEnv([_make_simple_env], start_method=None)
+        try:
+            obs = venv.reset()
+            assert obs.shape == (1, 3)
+        finally:
+            venv.close()
+
+
+# ---------------------------------------------------------------------------
+# AsyncVecEnv — full surface
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncVecEnv:
+    def test_reset_returns_stacked_obs(self):
+        venv = AsyncVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            obs = venv.reset()
+            assert obs.shape == (2, 3)
+            np.testing.assert_array_equal(obs, 0.0)
+            # All pending flags cleared
+            assert not any(venv._pending)
+        finally:
+            venv.close()
+
+    def test_step_async_then_step_wait(self):
+        venv = AsyncVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            venv.reset()
+            actions = np.zeros((2, 2), dtype=np.float32)
+            venv.step_async(actions)
+            assert all(venv._pending)
+            obs, rewards, dones, infos = venv.step_wait()
+            assert obs.shape == (2, 3)
+            np.testing.assert_array_equal(rewards, [1.0, 1.0])
+            assert not any(venv._pending)
+        finally:
+            venv.close()
+
+    def test_step_returns_full_tuple(self):
+        venv = AsyncVecEnv([_make_simple_env], start_method=_start_method())
+        try:
+            venv.reset()
+            actions = np.zeros((1, 2), dtype=np.float32)
+            obs, rewards, dones, infos = venv.step(actions)
+            assert obs.shape == (1, 3)
+            assert rewards.dtype == np.float32
+            assert dones.dtype == np.bool_
+        finally:
+            venv.close()
+
+    def test_step_wait_reuses_last_result_when_not_pending(self):
+        """If step_wait is called for an env that hasn't had step_async, prior result is reused."""
+        venv = AsyncVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            venv.reset()
+            actions = np.zeros((2, 2), dtype=np.float32)
+            # First full step populates _last_results for both envs
+            venv.step_async(actions)
+            obs1, _, _, _ = venv.step_wait()
+
+            # Now only step env 0 — env 1's pending stays False, so step_wait
+            # should reuse the previous result for env 1.
+            venv.step_env(0, actions[0])
+            assert venv._pending[0] is True
+            assert venv._pending[1] is False
+            obs2, rewards2, _, _ = venv.step_wait()
+            # env 1's result is the cached one (same step count = 1)
+            assert rewards2[1] == 1.0
+            # env 0 advanced to step 2
+            assert rewards2[0] == 2.0
+        finally:
+            venv.close()
+
+    def test_recv_env_for_single_env(self):
+        venv = AsyncVecEnv([_make_simple_env, _make_simple_env], start_method=_start_method())
+        try:
+            venv.reset()
+            actions = np.zeros((2, 2), dtype=np.float32)
+            venv.step_env(0, actions[0])
+            assert venv._pending[0] is True
+            obs, reward, done, info = venv.recv_env(0)
+            assert reward == 1.0
+            assert venv._pending[0] is False
+            # _last_results updated for env 0
+            assert venv._last_results[0] is not None
+        finally:
+            venv.close()
+
+    def test_poll_returns_ready_envs(self):
+        """``poll()`` returns indices of envs whose step result is ready."""
+        venv = AsyncVecEnv([_make_simple_env, _make_slow_env], start_method=_start_method())
+        try:
+            venv.reset()
+            actions = np.zeros((2, 2), dtype=np.float32)
+            venv.step_async(actions)
+            # The fast env should finish first; poll a few times until it appears
+            ready: list[int] = []
+            for _ in range(40):
+                ready = venv.poll()
+                if 0 in ready:
+                    break
+                time.sleep(0.01)
+            assert 0 in ready
+            # Drain all pending results before close
+            venv.step_wait()
+        finally:
+            venv.close()
+
+    def test_close_with_pending_drains(self):
+        """``close()`` must drain pending step results before sending close."""
+        venv = AsyncVecEnv([_make_simple_env], start_method=_start_method())
+        venv.reset()
+        actions = np.zeros((1, 2), dtype=np.float32)
+        venv.step_async(actions)
+        # Do not call step_wait — close should drain the pending recv
+        venv.close()
+        assert venv.closed
+
+    def test_close_is_idempotent(self):
+        venv = AsyncVecEnv([_make_simple_env], start_method=_start_method())
+        venv.close()
+        venv.close()
+        assert venv.closed
+
+    def test_default_start_method_is_chosen(self):
+        venv = AsyncVecEnv([_make_simple_env], start_method=None)
+        try:
+            obs = venv.reset()
+            assert obs.shape == (1, 3)
+        finally:
+            venv.close()

--- a/tests/test_datasets_eth_ucy.py
+++ b/tests/test_datasets_eth_ucy.py
@@ -1,0 +1,256 @@
+"""Tests for navirl.data.datasets — ETHUCYDataset parsing and SocialDataset edge paths.
+
+Covers ETH/UCY scene file parsing, ``_find_scene_file`` fallback behavior,
+``TrajectoryDataset.load`` error handling, and the small public-API helpers
+(``get_scene``, ``to_numpy``) that aren't exercised by ``tests/test_data.py``.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from navirl.data.datasets import ETHUCYDataset, SocialDataset
+
+# ---------------------------------------------------------------------------
+# ETHUCYDataset — file discovery
+# ---------------------------------------------------------------------------
+
+
+def _write_eth_file(path: Path, rows: list[tuple[float, int, float, float]]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for frame, ped, x, y in rows:
+            f.write(f"{frame}\t{ped}\t{x}\t{y}\n")
+
+
+class TestETHUCYFileDiscovery:
+    def test_finds_top_level_txt(self, tmp_path):
+        _write_eth_file(tmp_path / "eth.txt", [(0.0, 1, 1.0, 2.0)])
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+
+    def test_finds_scene_subdir_txt(self, tmp_path):
+        scene_dir = tmp_path / "hotel"
+        scene_dir.mkdir()
+        _write_eth_file(scene_dir / "hotel.txt", [(0.0, 1, 1.0, 2.0)])
+        ds = ETHUCYDataset(scenes=["hotel"])
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+
+    def test_finds_scene_subdir_csv_true_pos(self, tmp_path):
+        scene_dir = tmp_path / "univ"
+        scene_dir.mkdir()
+        # The candidate list looks for `true_pos_.csv` directly
+        (scene_dir / "true_pos_.csv").write_text("0.0\t1\t1.0\t2.0\n", encoding="utf-8")
+        ds = ETHUCYDataset(scenes=["univ"])
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+
+    def test_recursive_fallback(self, tmp_path):
+        """When no candidate path matches, a recursive ``rglob`` search runs."""
+        deep = tmp_path / "raw" / "extracted"
+        deep.mkdir(parents=True)
+        # File named with the scene prefix and a recognized suffix
+        _write_eth_file(deep / "zara1_data.txt", [(0.0, 1, 0.0, 0.0)])
+        ds = ETHUCYDataset(scenes=["zara1"])
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+
+    def test_recursive_fallback_skips_unknown_suffix(self, tmp_path):
+        """Files that match the scene name but have a non-recognized suffix are ignored."""
+        (tmp_path / "zara2.dat").write_text("garbage")
+        ds = ETHUCYDataset(scenes=["zara2"])
+        with pytest.raises(FileNotFoundError):
+            ds.load(tmp_path)
+
+    def test_missing_scene_raises(self, tmp_path):
+        # Provide eth but request hotel — the missing one should raise
+        _write_eth_file(tmp_path / "eth.txt", [(0.0, 1, 1.0, 2.0)])
+        ds = ETHUCYDataset(scenes=["eth", "hotel"])
+        with pytest.raises(FileNotFoundError, match="hotel"):
+            ds.load(tmp_path)
+
+    def test_load_nonexistent_path_raises(self, tmp_path):
+        ds = ETHUCYDataset(scenes=["eth"])
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            ds.load(tmp_path / "missing_dir")
+
+
+# ---------------------------------------------------------------------------
+# ETHUCYDataset — file parsing
+# ---------------------------------------------------------------------------
+
+
+class TestETHUCYParsing:
+    def test_parses_tab_separated(self, tmp_path):
+        rows = [
+            (0.0, 1, 1.0, 2.0),
+            (1.0, 1, 1.5, 2.5),
+            (2.0, 1, 2.0, 3.0),
+            (0.0, 2, 5.0, 5.0),
+            (1.0, 2, 5.5, 5.5),
+        ]
+        _write_eth_file(tmp_path / "eth.txt", rows)
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        scene = ds.get_scene(0)
+        assert len(scene) == 2  # two pedestrians
+        # Trajectory for ped 1 should have 3 frames sorted
+        ped1 = next(t for t in scene if t.agent_id == 1)
+        assert len(ped1) == 3
+        np.testing.assert_allclose(ped1.timestamps, [0.0, 1.0, 2.0])
+
+    def test_falls_back_to_whitespace_split(self, tmp_path):
+        """When ``delim='auto'`` and tab-split yields too few fields, retries on whitespace."""
+        path = tmp_path / "eth.txt"
+        # Space-separated rather than tab-separated
+        path.write_text("0.0 1 1.0 2.0\n1.0 1 1.5 2.5\n", encoding="utf-8")
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        scene = ds.get_scene(0)
+        assert len(scene) == 1
+
+    def test_explicit_delimiter(self, tmp_path):
+        path = tmp_path / "eth.txt"
+        path.write_text("0.0,1,1.0,2.0\n1.0,1,1.5,2.5\n", encoding="utf-8")
+        ds = ETHUCYDataset(scenes=["eth"], delim=",")
+        ds.load(tmp_path)
+        scene = ds.get_scene(0)
+        assert len(scene) == 1
+
+    def test_skips_blank_and_short_lines(self, tmp_path):
+        path = tmp_path / "eth.txt"
+        path.write_text(
+            "0.0\t1\t1.0\t2.0\n"
+            "\n"  # blank line
+            "1.0\t1\n"  # too few fields
+            "2.0\t1\t3.0\t4.0\n",
+            encoding="utf-8",
+        )
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        scene = ds.get_scene(0)
+        assert len(scene) == 1
+        ped1 = scene[0]
+        assert len(ped1) == 2  # only the two valid rows
+
+    def test_skips_unparseable_rows(self, tmp_path):
+        path = tmp_path / "eth.txt"
+        path.write_text(
+            "0.0\t1\t1.0\t2.0\n"
+            "bad\trow\twithtext\there\n"
+            "1.0\t1\t3.0\t4.0\n",
+            encoding="utf-8",
+        )
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        scene = ds.get_scene(0)
+        assert len(scene[0]) == 2
+
+    def test_sorts_frames_per_pedestrian(self, tmp_path):
+        rows = [
+            (5.0, 1, 5.0, 5.0),
+            (1.0, 1, 1.0, 1.0),
+            (3.0, 1, 3.0, 3.0),
+        ]
+        _write_eth_file(tmp_path / "eth.txt", rows)
+        ds = ETHUCYDataset(scenes=["eth"])
+        ds.load(tmp_path)
+        ped = ds.get_scene(0)[0]
+        # Should be sorted ascending by timestamp
+        assert list(ped.timestamps) == [1.0, 3.0, 5.0]
+
+
+# ---------------------------------------------------------------------------
+# TrajectoryDataset — public API surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicAPI:
+    def test_get_scene_before_load_raises(self):
+        ds = ETHUCYDataset(scenes=["eth"])
+        with pytest.raises(RuntimeError, match="not loaded"):
+            ds.get_scene(0)
+
+    def test_to_numpy_aggregates_all_scenes(self, tmp_path):
+        # Two scenes under the same root
+        _write_eth_file(tmp_path / "eth.txt", [(0.0, 1, 1.0, 2.0), (1.0, 1, 1.5, 2.5)])
+        scene_dir = tmp_path / "hotel"
+        scene_dir.mkdir()
+        _write_eth_file(scene_dir / "hotel.txt", [(0.0, 9, 9.0, 9.0)])
+        ds = ETHUCYDataset(scenes=["eth", "hotel"])
+        ds.load(tmp_path)
+        arr = ds.to_numpy()
+        # 2 + 1 = 3 positions
+        assert arr.shape == (3, 2)
+
+    def test_num_scenes_before_load_raises(self):
+        ds = ETHUCYDataset(scenes=["eth"])
+        with pytest.raises(RuntimeError, match="not loaded"):
+            _ = ds.num_scenes
+
+
+# ---------------------------------------------------------------------------
+# SocialDataset — edge paths
+# ---------------------------------------------------------------------------
+
+
+class TestSocialDatasetEdges:
+    def test_load_single_file_path(self, tmp_path):
+        """Passing a file path directly works (vs a directory)."""
+        f = tmp_path / "scene.csv"
+        with f.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["timestamp", "agent_id", "x", "y"])
+            writer.writerow([0.0, "a", 1.0, 2.0])
+            writer.writerow([1.0, "a", 1.5, 2.5])
+        ds = SocialDataset(has_header=True)
+        ds.load(f)
+        assert ds.num_scenes == 1
+
+    def test_load_directory_no_csv_falls_back_to_txt(self, tmp_path):
+        f = tmp_path / "scene.txt"
+        with f.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow([0.0, "a", 1.0, 2.0])
+            writer.writerow([1.0, "a", 1.5, 2.5])
+        ds = SocialDataset(has_header=False)
+        ds.load(tmp_path)
+        assert ds.num_scenes == 1
+
+    def test_directory_with_no_data_files_raises(self, tmp_path):
+        # Empty directory
+        (tmp_path / "notes.md").write_text("nothing here")
+        ds = SocialDataset()
+        with pytest.raises(FileNotFoundError, match="No CSV/TXT"):
+            ds.load(tmp_path)
+
+    def test_skips_short_rows(self, tmp_path):
+        f = tmp_path / "scene.csv"
+        with f.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["timestamp", "agent_id", "x", "y"])
+            writer.writerow([0.0, "a", 1.0, 2.0])
+            writer.writerow([1.0, "a"])  # too few columns
+            writer.writerow([2.0, "a", 1.5, 2.5])
+        ds = SocialDataset(has_header=True)
+        ds.load(f)
+        scene = ds.get_scene(0)
+        assert len(scene[0]) == 2  # only the two valid rows
+
+    def test_skips_unparseable_rows(self, tmp_path):
+        f = tmp_path / "scene.csv"
+        with f.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["timestamp", "agent_id", "x", "y"])
+            writer.writerow([0.0, "a", 1.0, 2.0])
+            writer.writerow(["bad", "a", "x", "y"])  # non-numeric
+            writer.writerow([1.0, "a", 2.0, 3.0])
+        ds = SocialDataset(has_header=True)
+        ds.load(f)
+        scene = ds.get_scene(0)
+        assert len(scene[0]) == 2

--- a/tests/test_executor_pool_and_worker_entry.py
+++ b/tests/test_executor_pool_and_worker_entry.py
@@ -1,0 +1,191 @@
+"""Tests for navirl.orchestration.executor — _worker_entry and the parallel branch.
+
+The existing ``tests/test_orchestration.py`` covers ``_execute_single_task`` and
+the sequential branch of ``LocalExecutor.execute_batch``.  This file targets
+the multiprocessing-pool branch (``max_workers > 1``) and the
+``_worker_entry`` adapter that is invoked across process boundaries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from navirl.orchestration.executor import (
+    LocalExecutor,
+    _execute_single_task,
+    _worker_entry,
+)
+from navirl.orchestration.models import SimulationTask, TaskResult, TaskStatus
+
+# ---------------------------------------------------------------------------
+# _worker_entry
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerEntry:
+    @patch("navirl.orchestration.executor._execute_single_task")
+    def test_reconstructs_task_and_returns_dict(self, mock_exec, tmp_path):
+        mock_exec.return_value = TaskResult(
+            task_id="abc",
+            status=TaskStatus.COMPLETED,
+            metrics={"success_rate": 1.0},
+            wall_time_s=0.5,
+        )
+        task_data = {
+            "task_id": "abc",
+            "scenario_path": "s.yaml",
+            "seed": 7,
+            "overrides": {"a": 1},
+        }
+        result = _worker_entry((task_data, str(tmp_path)))
+
+        # _execute_single_task should have been called with a reconstructed task
+        mock_exec.assert_called_once()
+        call_task = mock_exec.call_args[0][0]
+        assert isinstance(call_task, SimulationTask)
+        assert call_task.task_id == "abc"
+        assert call_task.scenario_path == "s.yaml"
+        assert call_task.seed == 7
+        assert call_task.overrides == {"a": 1}
+
+        # Result must be a serialisable dict (so it survives pickling)
+        assert isinstance(result, dict)
+        assert result["task_id"] == "abc"
+        assert result["status"] == "completed"
+        assert result["metrics"] == {"success_rate": 1.0}
+
+    @patch("navirl.orchestration.executor._execute_single_task")
+    def test_handles_missing_overrides_key(self, mock_exec, tmp_path):
+        """``_worker_entry`` should default missing overrides to an empty dict."""
+        mock_exec.return_value = TaskResult(task_id="x", status=TaskStatus.COMPLETED)
+        task_data = {"task_id": "x", "scenario_path": "s.yaml", "seed": 0}
+        result = _worker_entry((task_data, str(tmp_path)))
+        assert mock_exec.call_args[0][0].overrides == {}
+        assert result["task_id"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# _execute_single_task — overrides path (line 78)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSingleTaskOverrides:
+    @patch("navirl.orchestration.executor.run_scenario_dict")
+    @patch("navirl.orchestration.executor.load_scenario")
+    @patch("navirl.orchestration.executor.set_global_seed")
+    def test_overrides_are_applied(self, _seed, mock_load, mock_run, tmp_path):
+        mock_load.return_value = {"id": "test", "scene": {"orca": {}}}
+
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+        state = bundle / "state.jsonl"
+        state.write_text('{"step": 0}\n')
+        (bundle / "scenario.yaml").write_text("id: test\n")
+
+        episode = MagicMock()
+        episode.state_path = str(state)
+        mock_run.return_value = episode
+
+        with patch("navirl.orchestration.executor.StandardMetrics") as mock_m:
+            mock_m.return_value.compute.return_value = {"success_rate": 1.0}
+
+            task = SimulationTask(
+                task_id="ovr",
+                scenario_path="s.yaml",
+                seed=1,
+                overrides={"scene.orca.neighbor_dist": 9.5},
+            )
+            result = _execute_single_task(task, str(tmp_path))
+
+        # The scenario passed to run_scenario_dict must have the override applied
+        scenario_arg = mock_run.call_args.args[0]
+        assert scenario_arg["scene"]["orca"]["neighbor_dist"] == 9.5
+        # The overrides path must not corrupt the success result
+        assert result.status == TaskStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# LocalExecutor — parallel branch (real multiprocessing.Pool)
+# ---------------------------------------------------------------------------
+
+
+def _success_worker(args):
+    """Picklable replacement for ``_worker_entry`` used by the parallel test."""
+    task_data, _out_root = args
+    return {
+        "task_id": task_data["task_id"],
+        "status": "completed",
+        "metrics": {"seed": task_data["seed"]},
+        "bundle_dir": "",
+        "error": "",
+        "wall_time_s": 0.01,
+    }
+
+
+class TestLocalExecutorParallel:
+    def test_pool_branch_runs_all_tasks(self, tmp_path):
+        """``max_workers > 1`` should dispatch through ``mp.Pool.imap``."""
+        with patch("navirl.orchestration.executor._worker_entry", new=_success_worker):
+            executor = LocalExecutor(max_workers=2)
+            tasks = [
+                SimulationTask(task_id=f"t{i}", scenario_path="s.yaml", seed=i) for i in range(3)
+            ]
+            results = executor.execute_batch(tasks, str(tmp_path))
+        assert len(results) == 3
+        # imap preserves order
+        assert [r.task_id for r in results] == ["t0", "t1", "t2"]
+        for r in results:
+            assert r.status == TaskStatus.COMPLETED
+
+    def test_pool_branch_invokes_progress_callback(self, tmp_path):
+        callback = MagicMock()
+        with patch("navirl.orchestration.executor._worker_entry", new=_success_worker):
+            executor = LocalExecutor(max_workers=2)
+            tasks = [
+                SimulationTask(task_id=f"t{i}", scenario_path="s.yaml", seed=i) for i in range(2)
+            ]
+            executor.execute_batch(tasks, str(tmp_path), progress_callback=callback)
+        # Called once per task, with (completed, total)
+        assert callback.call_count == 2
+        callback.assert_any_call(2, 2)
+
+    def test_pool_branch_creates_out_root(self, tmp_path):
+        out = tmp_path / "new_out_root"
+        assert not out.exists()
+        with patch("navirl.orchestration.executor._worker_entry", new=_success_worker):
+            executor = LocalExecutor(max_workers=2)
+            tasks = [SimulationTask(task_id="t0", scenario_path="s.yaml", seed=0)]
+            executor.execute_batch(tasks, str(out))
+        assert out.exists()
+
+    def test_pool_branch_clamps_to_task_count(self, tmp_path):
+        """When max_workers > num_tasks, only num_tasks workers are spun up."""
+        with (
+            patch("navirl.orchestration.executor._worker_entry", new=_success_worker),
+            patch("navirl.orchestration.executor.mp") as mp_mod,
+        ):
+            # Mimic the real mp.Pool context manager but observe args
+            pool = MagicMock()
+            pool.imap.return_value = iter(
+                [
+                    {
+                        "task_id": "only",
+                        "status": "completed",
+                        "metrics": {},
+                        "bundle_dir": "",
+                        "error": "",
+                        "wall_time_s": 0.01,
+                    }
+                ]
+            )
+            mp_mod.Pool.return_value.__enter__.return_value = pool
+            mp_mod.Pool.return_value.__exit__.return_value = False
+            mp_mod.cpu_count.return_value = 16
+
+            executor = LocalExecutor(max_workers=8)
+            tasks = [SimulationTask(task_id="only", scenario_path="s.yaml", seed=0)]
+            executor.execute_batch(tasks, str(tmp_path))
+
+            # 8 workers requested, 1 task → Pool gets created with 1
+            mp_mod.Pool.assert_called_once_with(processes=1)

--- a/tests/test_pipeline_worker_helpers.py
+++ b/tests/test_pipeline_worker_helpers.py
@@ -1,0 +1,62 @@
+"""Tests for navirl.pipeline._run_scenario_worker and run_scenario_file delegation.
+
+The bulk of ``run_scenario_dict`` requires a working backend (rvo2 or grid2d
+with all dependencies); these tests target the thin adapter functions that
+delegate to it, using mocks to avoid that requirement.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from navirl.pipeline import _run_scenario_worker, run_scenario_file
+
+
+@patch("navirl.pipeline.run_scenario_dict")
+@patch("navirl.pipeline.load_scenario")
+def test_run_scenario_worker_loads_and_runs(mock_load, mock_run, tmp_path):
+    """The worker must inject the seed and synthesize a deterministic run id."""
+    mock_load.return_value = {"id": "hallway"}
+    mock_log = MagicMock()
+    mock_run.return_value = mock_log
+
+    result = _run_scenario_worker(
+        (str(tmp_path / "scn.yaml"), 99, str(tmp_path / "out"), True, False)
+    )
+
+    mock_load.assert_called_once_with(str(tmp_path / "scn.yaml"))
+
+    # The scenario passed to run_scenario_dict should have the seed overridden
+    call = mock_run.call_args
+    assert call.kwargs["scenario"]["seed"] == 99
+    assert call.kwargs["run_id"] == "hallway_seed99"
+    assert call.kwargs["render_override"] is True
+    assert call.kwargs["video_override"] is False
+    assert call.kwargs["out_root"] == str(tmp_path / "out")
+
+    assert result is mock_log
+
+
+@patch("navirl.pipeline.run_scenario_dict")
+@patch("navirl.pipeline.load_scenario")
+def test_run_scenario_file_delegates(mock_load, mock_run, tmp_path):
+    """``run_scenario_file`` is a thin wrapper around ``load_scenario`` + ``run_scenario_dict``."""
+    mock_load.return_value = {"id": "kitchen"}
+    mock_log = MagicMock()
+    mock_run.return_value = mock_log
+
+    result = run_scenario_file(
+        scenario_path=tmp_path / "scn.yaml",
+        out_root=tmp_path / "out",
+        run_id="custom_id",
+        render_override=False,
+        video_override=True,
+    )
+
+    mock_load.assert_called_once_with(tmp_path / "scn.yaml")
+    call = mock_run.call_args
+    assert call.kwargs["scenario"] == {"id": "kitchen"}
+    assert call.kwargs["run_id"] == "custom_id"
+    assert call.kwargs["render_override"] is False
+    assert call.kwargs["video_override"] is True
+    assert result is mock_log


### PR DESCRIPTION
## Summary

Targets four under-covered modules that **were not** addressed by any of the open coverage PRs (#143-#165):

| Module | Before | After | Δ |
|---|---|---|---|
| `navirl/training/parallel.py` | 80% | **96%** | +16% |
| `navirl/data/datasets.py` | 70% | **100%** | +30% |
| `navirl/orchestration/executor.py` | 82% | **100%** | +18% |
| `navirl/pipeline.py` (worker helpers) | 67% | 68% | + |

### What's new

- **`tests/test_async_vec_env.py`** (17 tests). Spawns real subprocesses (via `fork` on Linux) to exercise `AsyncVecEnv`'s full surface — `step_async`/`step_wait`, `step_env`, `recv_env`, `poll`, `step`/`reset`, close-with-pending drain, idempotent close, `start_method=None` resolution — plus `SubprocVecEnv` step/reset/get_attr/env_method round trips. The previous `test_parallel_coverage.py` only mocked the worker function, leaving the actual IPC paths untested.
- **`tests/test_datasets_eth_ucy.py`** (21 tests). Covers the full ETH/UCY scene-discovery cascade (`{scene}.txt`, `{scene}/{scene}.txt`, `{scene}/true_pos_.csv`, recursive `rglob` fallback), `_parse_scene_file` with tab/space/comma delimiters, blank/short/garbage row handling, and pedestrian-id grouping & frame sorting. Also covers `TrajectoryDataset.load`/`get_scene`/`num_scenes` not-loaded errors and `SocialDataset` single-file vs directory-with-CSV-vs-TXT-fallback paths.
- **`tests/test_executor_pool_and_worker_entry.py`** (7 tests). Covers `_worker_entry`'s task reconstruction & dict serialization for cross-process pickling, the `_execute_single_task` overrides branch, and `LocalExecutor`'s `mp.Pool.imap` parallel branch (real pool with a top-level picklable worker, plus a mocked variant that asserts worker count is clamped to task count).
- **`tests/test_pipeline_worker_helpers.py`** (2 tests). Covers `_run_scenario_worker`'s seed injection & deterministic `run_id` synthesis, and `run_scenario_file`'s delegation to `load_scenario` + `run_scenario_dict`.

### Verification

- Full suite: **5537 passed, 178 skipped** in 74s (no failures, +47 vs the 5490 baseline)
- Ruff: clean
- The 178 skips are all the same optional-dep skips as the baseline (PyTorch, gymnasium, rvo2)

## Test plan
- [x] `pytest tests/test_async_vec_env.py tests/test_datasets_eth_ucy.py tests/test_executor_pool_and_worker_entry.py tests/test_pipeline_worker_helpers.py` — all 47 pass
- [x] `pytest --ignore=tests/e2e` — 5537 pass, 178 skip, no regressions
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)