### PR TITLE
test: 64 tests cover rewards/base, scenarios/validate, RRT* planner

### DIFF
--- a/tests/test_rewards_base_coverage.py
+++ b/tests/test_rewards_base_coverage.py
@@ -1,0 +1,313 @@
+"""Fill coverage gaps in navirl/rewards/base.py.
+
+The ``test_maps_rewards.py`` suite already exercises the common happy
+paths (weighted sum, clip, warmup). This suite targets the uncovered
+branches: reset/get_info methods, the EMA normaliser path, and the
+RewardShaper exception fallback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load navirl.rewards.base directly to avoid the rewards/__init__ import
+# chain (which pulls in optional submodules that may not exist).
+_base_path = Path(__file__).resolve().parent.parent / "navirl" / "rewards" / "base.py"
+_base_spec = importlib.util.spec_from_file_location("navirl.rewards.base", _base_path)
+if "navirl.rewards.base" not in sys.modules:
+    _base_mod = importlib.util.module_from_spec(_base_spec)
+    sys.modules[_base_spec.name] = _base_mod
+    _base_spec.loader.exec_module(_base_mod)
+else:
+    _base_mod = sys.modules["navirl.rewards.base"]
+
+RewardFunction = _base_mod.RewardFunction
+RewardComponent = _base_mod.RewardComponent
+CompositeReward = _base_mod.CompositeReward
+RewardNormalizer = _base_mod.RewardNormalizer
+RewardClipper = _base_mod.RewardClipper
+RewardShaper = _base_mod.RewardShaper
+
+
+class _Counting(RewardFunction):
+    """Reward that counts compute/reset invocations and returns configured values."""
+
+    def __init__(self, values: list[float] | None = None, name: str | None = None) -> None:
+        super().__init__(name=name)
+        self._values = list(values) if values is not None else [0.0]
+        self.compute_calls = 0
+        self.reset_calls = 0
+
+    def compute(self, state, action, next_state, *, info=None):  # type: ignore[override]
+        v = self._values[min(self.compute_calls, len(self._values) - 1)]
+        self.compute_calls += 1
+        return v
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+
+class _Constant(RewardFunction):
+    def __init__(self, value: float = 0.0, name: str | None = None) -> None:
+        super().__init__(name=name)
+        self._value = value
+
+    def compute(self, state, action, next_state, *, info=None):  # type: ignore[override]
+        return self._value
+
+
+# ---------------------------------------------------------------------------
+# RewardFunction dunder methods
+# ---------------------------------------------------------------------------
+
+
+class TestRewardFunctionDunders:
+    """Coverage for __call__ and __repr__ on the base class."""
+
+    def test_call_forwards_to_compute(self):
+        r = _Constant(value=7.0, name="foo")
+        assert r({}, None, {}) == 7.0
+
+    def test_call_forwards_info_kwarg(self):
+        recorded = {}
+
+        class _Inspect(RewardFunction):
+            def compute(self, state, action, next_state, *, info=None):  # type: ignore[override]
+                recorded["info"] = info
+                return 0.0
+
+        _Inspect()({}, None, {}, info={"k": 1})
+        assert recorded["info"] == {"k": 1}
+
+    def test_repr_includes_class_and_name(self):
+        r = _Constant(name="my_reward")
+        out = repr(r)
+        assert "_Constant" in out
+        assert "my_reward" in out
+
+
+# ---------------------------------------------------------------------------
+# RewardComponent reset & __repr__ (lines 204, 214)
+# ---------------------------------------------------------------------------
+
+
+class TestRewardComponentResetAndRepr:
+    def test_reset_forwards_to_inner(self):
+        inner = _Counting()
+        comp = RewardComponent(reward_fn=inner, weight=3.0)
+        comp.reset()
+        assert inner.reset_calls == 1
+
+    def test_repr_contains_name_weight_enabled(self):
+        comp = RewardComponent(reward_fn=_Constant(name="x"), weight=2.5, enabled=False)
+        s = repr(comp)
+        assert "x" in s
+        assert "2.5" in s
+        assert "False" in s
+
+
+# ---------------------------------------------------------------------------
+# CompositeReward reset / summary / iter / components property (344-346, 363-368, 374, 377)
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeRewardExtras:
+    def test_reset_forwards_and_clears_decomposition(self):
+        inner1 = _Counting()
+        inner2 = _Counting()
+        cr = CompositeReward([RewardComponent(inner1), RewardComponent(inner2)])
+        cr.compute({}, None, {})
+        # Pre-reset: last_decomposition populated
+        assert cr._last_decomposition  # type: ignore[attr-defined]
+        cr.reset()
+        assert inner1.reset_calls == 1 and inner2.reset_calls == 1
+        assert cr._last_decomposition == {}  # type: ignore[attr-defined]
+
+    def test_components_property_returns_internal_list(self):
+        c1 = RewardComponent(_Constant(1.0, name="a"))
+        cr = CompositeReward([c1])
+        # Exposed for external mutation / inspection.
+        assert cr.components is cr._components  # type: ignore[attr-defined]
+        assert cr.components == [c1]
+
+    def test_summary_includes_name_count_and_component_lines(self):
+        c_on = RewardComponent(_Constant(1.0, name="alpha"), weight=2.0, tags=["nav", "x"])
+        c_off = RewardComponent(_Constant(name="beta"), weight=-1.0, enabled=False)
+        cr = CompositeReward([c_on, c_off], name="mix")
+        out = cr.summary()
+        assert "CompositeReward 'mix'" in out
+        assert "2 components" in out
+        assert "alpha" in out and "beta" in out
+        assert "ON " in out and "OFF" in out
+        assert "nav" in out  # tag listed
+
+    def test_summary_empty_tag_list_still_renders(self):
+        c = RewardComponent(_Constant(1.0, name="only"))
+        cr = CompositeReward([c])
+        out = cr.summary()
+        # Empty tag block should still produce a bracketed line.
+        assert "only" in out and "tags=[]" in out
+
+    def test_iter_yields_components_in_order(self):
+        comps = [RewardComponent(_Constant(float(i), name=f"c{i}")) for i in range(3)]
+        cr = CompositeReward(comps)
+        assert list(iter(cr)) == comps
+
+    def test_repr_has_n_components(self):
+        cr = CompositeReward([RewardComponent(_Constant()) for _ in range(4)])
+        assert "n_components=4" in repr(cr)
+
+    def test_untracked_composite_returns_zero_totals(self):
+        c = RewardComponent(_Constant(2.0, name="z"))
+        cr = CompositeReward([c], track_decomposition=False)
+        assert cr.compute({}, None, {}) == pytest.approx(2.0)
+        # get_info always queries _last_decomposition which stays empty here.
+        info = cr.get_info()
+        assert info["decomposition"] == {}
+        assert info["total"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# RewardNormalizer EMA branch (454, 461, 476-480, 484) + reset + get_info
+# ---------------------------------------------------------------------------
+
+
+class TestRewardNormalizerEma:
+    """Exercise the ``gamma`` exponential-moving-average branch."""
+
+    def test_ema_mean_tracks_series_via_public_property(self):
+        # Values constant => EMA mean converges to that value; with warmup=0
+        # the update is applied from call 1.
+        norm = RewardNormalizer(_Constant(5.0), warmup=0, gamma=0.5, clip=None)
+        # One compute advances EMA: mean = 0.5*0 + 0.5*5 = 2.5
+        norm.compute({}, None, {})
+        assert norm.mean == pytest.approx(2.5)
+        # Second compute: mean = 0.5*2.5 + 0.5*5 = 3.75
+        norm.compute({}, None, {})
+        assert norm.mean == pytest.approx(3.75)
+
+    def test_ema_std_is_sqrt_of_ema_var(self):
+        norm = RewardNormalizer(_Counting([0.0, 2.0, 2.0]), warmup=0, gamma=0.5, clip=None)
+        for _ in range(3):
+            norm.compute({}, None, {})
+        # std should be sqrt(max(_ema_var, 0))
+        assert norm.std == pytest.approx(math.sqrt(max(norm._ema_var, 0.0)))  # type: ignore[attr-defined]
+
+    def test_ema_normalisation_applied_when_warmup_skipped(self):
+        # With gamma set, ``_count`` is never incremented (EMA path), so
+        # ``warmup`` must be < 0 to escape the warmup guard and actually
+        # apply centering.  This exercises the ``if self._center`` branch
+        # of ``compute`` on top of the EMA update.
+        inner = _Counting([10.0, 10.0, 10.0])
+        norm = RewardNormalizer(inner, warmup=-1, gamma=0.5, clip=None, center=True, scale=False)
+        # First compute: EMA mean -> 0.5*0 + 0.5*10 = 5, centered = 10 - 5 = 5.
+        out = norm.compute({}, None, {})
+        assert out == pytest.approx(5.0)
+
+    def test_reset_forwards_but_keeps_stats(self):
+        inner = _Counting([1.0, 1.0])
+        norm = RewardNormalizer(inner, warmup=0, gamma=None)
+        norm.compute({}, None, {})
+        count_before = norm._count  # type: ignore[attr-defined]
+        norm.reset()
+        # reset() does NOT clear stats, only the inner function's state.
+        assert inner.reset_calls == 1
+        assert norm._count == count_before  # type: ignore[attr-defined]
+
+    def test_get_info_shape_and_values(self):
+        norm = RewardNormalizer(_Constant(3.0), warmup=0, gamma=None, clip=None)
+        norm.compute({}, None, {})
+        info = norm.get_info()
+        assert set(info) == {"raw", "normalised", "running_mean", "running_std", "count"}
+        assert info["raw"] == 3.0
+        assert info["count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# RewardClipper.reset forwards (line 633)
+# ---------------------------------------------------------------------------
+
+
+class TestRewardClipperReset:
+    def test_reset_forwards_to_inner(self):
+        inner = _Counting()
+        clip = RewardClipper(inner, low=-1.0, high=1.0)
+        clip.reset()
+        assert inner.reset_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# RewardShaper exception fallback + reset + get_info (763-767, 771-772, 776)
+# ---------------------------------------------------------------------------
+
+
+class TestRewardShaperErrorAndLifecycle:
+    def test_potential_exception_returns_zero_and_logs(self, caplog):
+        def bad_phi(state):
+            raise RuntimeError("boom")
+
+        shaper = RewardShaper(_Constant(5.0), bad_phi, gamma=1.0)
+        with caplog.at_level("WARNING"):
+            total = shaper.compute({}, None, {})
+        # phi raised -> both s and next_s potentials fall back to 0 -> shaping=0 -> total=base=5.
+        assert total == pytest.approx(5.0)
+        assert any("Potential function raised" in rec.message for rec in caplog.records)
+
+    def test_potential_returning_non_float_coerced_via_float(self):
+        # Returning an int goes through float(...) cleanly; string would raise -> 0.
+        called = {"n": 0}
+
+        def phi_non_float(state):
+            called["n"] += 1
+            return "not-a-number"
+
+        shaper = RewardShaper(_Constant(0.0), phi_non_float, gamma=0.5)
+        # Should still produce a finite number (0) because float("not-a-number") raises.
+        out = shaper.compute(
+            {"position": [0, 0], "goal": [0, 0]}, None, {"position": [0, 0], "goal": [0, 0]}
+        )
+        assert math.isfinite(out)
+        # phi was attempted on both s and next_s.
+        assert called["n"] == 2
+
+    def test_reset_clears_prev_potential_and_forwards(self):
+        inner = _Counting()
+
+        def phi(state):
+            return 1.0
+
+        shaper = RewardShaper(inner, phi, gamma=1.0)
+        shaper.compute({}, None, {})
+        assert shaper._prev_potential == 1.0  # type: ignore[attr-defined]
+        shaper.reset()
+        assert inner.reset_calls == 1
+        assert shaper._prev_potential is None  # type: ignore[attr-defined]
+
+    def test_get_info_exposes_base_shaping_total_gamma_scale(self):
+        # phi(s) = 0, phi(ns) = 2, gamma=0.5, scale=2 -> shaping = 2*(0.5*2-0) = 2
+        phis = iter([0.0, 2.0])
+
+        def phi(_):
+            return next(phis)
+
+        shaper = RewardShaper(_Constant(4.0), phi, gamma=0.5, scale=2.0)
+        shaper.compute({}, None, {})
+        info = shaper.get_info()
+        assert info["gamma"] == 0.5
+        assert info["scale"] == 2.0
+        assert info["base_reward"] == pytest.approx(4.0)
+        assert info["shaping_bonus"] == pytest.approx(2.0)
+        assert info["total"] == pytest.approx(6.0)
+
+    def test_with_goal_potential_factory_uses_goal_distance(self):
+        inner = _Constant(0.0)
+        shaper = RewardShaper.with_goal_potential(inner, gamma=1.0, scale=1.0)
+        s = {"position": [4.0, 0.0], "goal": [0.0, 0.0]}
+        ns = {"position": [3.0, 0.0], "goal": [0.0, 0.0]}
+        # phi(s) = -4, phi(ns) = -3, shaping = -3 - (-4) = 1.
+        assert shaper.compute(s, None, ns) == pytest.approx(1.0)

--- a/tests/test_rrt_robot_coverage.py
+++ b/tests/test_rrt_robot_coverage.py
@@ -1,0 +1,408 @@
+"""Cover the missing branches in navirl/robots/baselines/rrt.py.
+
+The existing ``test_robot_baseline_planners.py`` covers creation, node
+basics, steering and a happy-path step.  This suite targets the edge
+paths: map-metadata fallback, collision-check exception handling, the
+RRT loop's invalid-sample / invalid-path continues, the planning
+fallback to the backend, the early DONE branch, waypoint advance,
+wait/stop conditions, and the ``_current_target`` past-end guard.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import Mock
+
+from navirl.core.types import Action, AgentState
+from navirl.robots.baselines.rrt import RRTNode, RRTStarRobotController
+
+
+def _state(x: float, y: float, gx: float = 10.0, gy: float = 10.0) -> AgentState:
+    return AgentState(
+        agent_id=0,
+        kind="robot",
+        x=x,
+        y=y,
+        vx=0.0,
+        vy=0.0,
+        goal_x=gx,
+        goal_y=gy,
+        max_speed=1.0,
+        radius=0.3,
+    )
+
+
+class _FreeBackend:
+    """Backend where every point is free and ``map_metadata`` is present."""
+
+    def __init__(self, width: int = 10, height: int = 10):
+        self._w = width
+        self._h = height
+
+    def shortest_path(self, start, goal):
+        return [start, goal]
+
+    def check_obstacle_collision(self, pos):
+        return False
+
+    def sample_free_point(self):
+        return (1.0, 1.0)
+
+    def map_metadata(self):
+        return {"width": self._w, "height": self._h}
+
+
+class _BackendNoMetadata:
+    """Backend without ``map_metadata`` — forces the default-bounds path."""
+
+    def shortest_path(self, start, goal):
+        return [start, goal]
+
+    def check_obstacle_collision(self, pos):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# _get_map_bounds fallback (line 76)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMapBoundsFallback:
+    def test_backend_without_metadata_uses_defaults(self):
+        ctrl = RRTStarRobotController()
+        ctrl.backend = _BackendNoMetadata()
+        bounds = ctrl._get_map_bounds()
+        assert bounds == (0.0, 0.0, 20.0, 20.0)
+
+    def test_backend_with_metadata_uses_its_values(self):
+        ctrl = RRTStarRobotController()
+        ctrl.backend = _FreeBackend(width=7, height=13)
+        bounds = ctrl._get_map_bounds()
+        assert bounds == (0.0, 0.0, 7.0, 13.0)
+
+
+# ---------------------------------------------------------------------------
+# _is_valid_position exception path (lines 82-85)
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidPositionErrors:
+    def test_attribute_error_returns_false(self):
+        """Backend missing ``check_obstacle_collision`` triggers AttributeError
+        inside ``_is_valid_position`` and must not propagate.
+        """
+
+        class _Bad:
+            pass
+
+        ctrl = RRTStarRobotController()
+        ctrl.backend = _Bad()
+        assert ctrl._is_valid_position((0.0, 0.0)) is False
+
+    def test_type_error_returns_false(self):
+        class _Bad:
+            def check_obstacle_collision(self, pos):
+                return 1 + "nope"  # TypeError
+
+        ctrl = RRTStarRobotController()
+        ctrl.backend = _Bad()
+        assert ctrl._is_valid_position((0.0, 0.0)) is False
+
+    def test_value_error_returns_false(self):
+        class _Bad:
+            def check_obstacle_collision(self, pos):
+                raise ValueError("out of bounds")
+
+        ctrl = RRTStarRobotController()
+        ctrl.backend = _Bad()
+        assert ctrl._is_valid_position((0.0, 0.0)) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_path_valid rejects path through an obstacle (line 144)
+# + _plan_rrt_star invalid-new-pos continue (line 180)
+# ---------------------------------------------------------------------------
+
+
+class _WallBackend:
+    """Backend with an infinite vertical wall at x in [3.5, 4.5] - everywhere
+    else is free.  Used to force ``_is_path_valid`` to return False and to
+    force ``_plan_rrt_star`` down its ``continue`` branches.
+    """
+
+    def shortest_path(self, start, goal):
+        return [start, goal]
+
+    def check_obstacle_collision(self, pos):
+        return 3.5 <= pos[0] <= 4.5
+
+    def map_metadata(self):
+        return {"width": 10, "height": 10}
+
+
+class TestPathValidityAndRRTContinueBranches:
+    def test_is_path_valid_false_when_crosses_wall(self):
+        ctrl = RRTStarRobotController()
+        ctrl.backend = _WallBackend()
+        # Straight line from (0,0) to (8,0) passes through the wall.
+        assert ctrl._is_path_valid((0.0, 0.0), (8.0, 0.0)) is False
+
+    def test_is_path_valid_true_when_clear(self):
+        ctrl = RRTStarRobotController()
+        ctrl.backend = _WallBackend()
+        # A path that stays at x < 3.5 is fine.
+        assert ctrl._is_path_valid((0.0, 0.0), (3.0, 3.0)) is True
+
+    def test_rrt_star_handles_blocked_map(self):
+        """With an unreachable goal (behind a wall), _plan_rrt_star falls
+        through the loop without returning early and returns a path to the
+        closest node, appending the goal.  This exercises both the 'invalid
+        new_pos / invalid path -> continue' branches and the end-of-loop
+        fallback.
+        """
+        ctrl = RRTStarRobotController(cfg={"max_iterations": 50, "step_size": 0.5})
+        ctrl.backend = _WallBackend()
+        path = ctrl._plan_rrt_star((0.0, 0.0), (8.0, 0.0))
+        assert path, "should return a non-empty path"
+        assert path[-1] == (8.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _plan fallback when RRT planning raises (lines 257-261)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanFallback:
+    def test_exception_falls_back_to_backend_shortest_path(self):
+        """If ``_plan_rrt_star`` raises, ``_plan`` must fall back to the
+        backend's shortest_path and set the new path with path_idx=0.
+        """
+        ctrl = RRTStarRobotController(cfg={"max_iterations": 10})
+
+        class _Backend:
+            def map_metadata(self):
+                return {"width": 10, "height": 10}
+
+            def shortest_path(self, start, goal):
+                return [start, (5.0, 5.0), goal]
+
+            def check_obstacle_collision(self, pos):
+                return False
+
+        ctrl.backend = _Backend()
+        ctrl.goal = (9.0, 9.0)
+
+        # Monkey-patch _plan_rrt_star to raise a RuntimeError.
+        def _raise(*args, **kwargs):
+            raise RuntimeError("planning failed")
+
+        ctrl._plan_rrt_star = _raise  # type: ignore[assignment]
+
+        ctrl._plan((0.0, 0.0))
+        # Fallback path pulled from backend.shortest_path.
+        assert ctrl.path == [(0.0, 0.0), (5.0, 5.0), (9.0, 9.0)]
+        assert ctrl.path_idx == 0
+
+    def test_empty_plan_falls_back_to_backend(self):
+        """If ``_plan_rrt_star`` returns an empty path, fall back to
+        ``backend.shortest_path`` via the ``if not self.path`` branch.
+        """
+        ctrl = RRTStarRobotController(cfg={"max_iterations": 10})
+
+        class _Backend:
+            def map_metadata(self):
+                return {"width": 10, "height": 10}
+
+            def shortest_path(self, start, goal):
+                return [start, goal]
+
+            def check_obstacle_collision(self, pos):
+                return False
+
+        ctrl.backend = _Backend()
+        ctrl.goal = (9.0, 9.0)
+
+        # Monkey-patch to return empty.
+        ctrl._plan_rrt_star = lambda s, g: []  # type: ignore[assignment]
+
+        ctrl._plan((0.0, 0.0))
+        assert ctrl.path == [(0.0, 0.0), (9.0, 9.0)]
+        assert ctrl.path_idx == 0
+
+    def test_fallback_when_both_planner_and_backend_return_empty(self):
+        """If the planner raises and the backend returns falsy, the path
+        defaults to ``[self.goal]`` (the ``or [self.goal]`` guard).
+        """
+        ctrl = RRTStarRobotController()
+
+        class _Backend:
+            def map_metadata(self):
+                return {"width": 10, "height": 10}
+
+            def shortest_path(self, start, goal):
+                return None
+
+            def check_obstacle_collision(self, pos):
+                return False
+
+        ctrl.backend = _Backend()
+        ctrl.goal = (4.0, 7.0)
+
+        ctrl._plan_rrt_star = lambda s, g: None  # type: ignore[assignment]
+
+        # None is falsy, so the try-block hits ``self.path = None or [self.goal]``.
+        ctrl._plan((0.0, 0.0))
+        assert ctrl.path == [(4.0, 7.0)]
+
+
+# ---------------------------------------------------------------------------
+# _current_target past-end guard (line 283)
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentTargetGuard:
+    def test_returns_goal_when_path_idx_past_end(self):
+        ctrl = RRTStarRobotController()
+        ctrl.goal = (5.0, 6.0)
+        ctrl.path = [(0.0, 0.0), (1.0, 1.0)]
+        ctrl.path_idx = 99
+        assert ctrl._current_target() == (5.0, 6.0)
+
+
+# ---------------------------------------------------------------------------
+# step: DONE branch (line 300)
+# ---------------------------------------------------------------------------
+
+
+class TestStepAlreadyAtGoal:
+    def test_done_when_within_tolerance(self):
+        ctrl = RRTStarRobotController(cfg={"goal_tolerance": 0.5})
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), _FreeBackend())
+        states = {0: _state(3.0, 3.0, 3.0, 3.0)}
+        action = ctrl.step(0, 0.0, 0.1, states, Mock())
+        assert action.behavior == "DONE"
+        assert action.pref_vx == 0.0
+        assert action.pref_vy == 0.0
+
+
+# ---------------------------------------------------------------------------
+# step: waypoint advance (lines 316-318) + WAIT branch (line 321)
+# ---------------------------------------------------------------------------
+
+
+class TestStepWaypointAdvance:
+    def test_advance_waypoint_when_close(self):
+        """Put the robot at the first waypoint with a second waypoint
+        ahead.  The ``dist_target <= goal_tolerance`` branch should advance
+        path_idx.
+        """
+        ctrl = RRTStarRobotController(cfg={"goal_tolerance": 0.2, "replan_interval": 1000})
+        ctrl.reset(0, (0.0, 0.0), (9.0, 9.0), _FreeBackend())
+        # Install a custom path: (0,0) -> (1,0) -> (9,9)
+        ctrl.path = [(0.0, 0.0), (1.0, 0.0), (9.0, 9.0)]
+        ctrl.path_idx = 0
+        # Disable target_lookahead so current target == path[path_idx]
+        ctrl.target_lookahead = 1
+
+        # Robot sitting on top of the first waypoint should advance.
+        states = {0: _state(0.0, 0.0, 9.0, 9.0)}
+        ctrl.step(1, 0.1, 0.1, states, Mock())
+        assert ctrl.path_idx == 1
+
+    def test_wait_when_target_distance_zero(self):
+        """When the (post-advance) target coincides with the robot and the
+        path is exhausted, the ``dist_target < 1e-8`` branch must return
+        WAIT.
+        """
+        ctrl = RRTStarRobotController(cfg={"goal_tolerance": 0.05, "replan_interval": 1000})
+        ctrl.reset(0, (0.0, 0.0), (5.0, 5.0), _FreeBackend())
+        # Single-waypoint path at the robot's position.
+        ctrl.path = [(1.0, 1.0)]
+        ctrl.path_idx = 0
+        ctrl.target_lookahead = 1
+
+        # Robot is *at* the path waypoint but not at the goal: advance will
+        # not fire (already past end), and _current_target returns the path
+        # entry; dist_target == 0.
+        states = {0: _state(1.0, 1.0, 5.0, 5.0)}
+        action = ctrl.step(1, 0.1, 0.1, states, Mock())
+        assert action.behavior == "WAIT"
+
+
+# ---------------------------------------------------------------------------
+# step: stop_speed branch (line 341)
+# ---------------------------------------------------------------------------
+
+
+class TestStepStopSpeed:
+    def test_velocity_zeroed_when_below_stop_speed_near_goal(self):
+        """Configure a very small computed velocity with the robot closer
+        than ``goal_tolerance`` but not quite at the goal.  The final
+        ``if math.hypot(vx, vy) < stop_speed and dist_target < goal_tolerance``
+        branch should fire and zero out the velocity.
+        """
+        ctrl = RRTStarRobotController(
+            cfg={
+                "goal_tolerance": 0.3,
+                "slowdown_dist": 10.0,  # so speed_scale = dist/slowdown is tiny
+                "max_speed": 1.0,
+                "stop_speed": 0.5,  # any velocity magnitude below this triggers stop
+                "replan_interval": 1000,
+                "velocity_smoothing": 1.0,
+            }
+        )
+        # Goal is 3 away (not within tolerance), so step() won't take the DONE
+        # branch. Goal must equal the robot's state goal, since that's what
+        # the DONE check uses.
+        ctrl.reset(0, (0.0, 0.0), (3.0, 0.0), _FreeBackend())
+        # Single-waypoint path close to the robot: path_idx=0 == len-1 means
+        # the waypoint-advance branch won't fire.
+        ctrl.path = [(0.2, 0.0)]
+        ctrl.path_idx = 0
+        ctrl.target_lookahead = 1
+
+        states = {0: _state(0.0, 0.0, 3.0, 0.0)}
+        action = ctrl.step(1, 0.1, 0.1, states, Mock())
+        # dist_target = 0.2 (<goal_tolerance=0.3). speed_scale = 0.2/10 = 0.02.
+        # speed = min(1, 1) * 0.02 = 0.02. hypot < stop_speed (0.5) AND
+        # dist_target < goal_tolerance -> zeroed.
+        assert action.pref_vx == 0.0
+        assert action.pref_vy == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Periodic replan event (line 305-309 already covered by happy path, but
+# pin it down explicitly so regressions surface).
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodicReplan:
+    def test_emit_event_when_step_is_replan_interval_multiple(self):
+        ctrl = RRTStarRobotController(cfg={"replan_interval": 5, "max_iterations": 10})
+        ctrl.reset(0, (0.0, 0.0), (3.0, 3.0), _FreeBackend())
+        emit = Mock()
+        states = {0: _state(0.0, 0.0, 3.0, 3.0)}
+        # step % 5 == 0 -> replan event fires.
+        ctrl.step(5, 0.5, 0.1, states, emit)
+        assert any(call.args[0] == "robot_rrt_replan" for call in emit.call_args_list)
+
+
+# ---------------------------------------------------------------------------
+# RRTNode basics (sanity — cheap test that pins the observable behavior
+# of ``path_to_root`` and ``_distance_to`` even for a single node).
+# ---------------------------------------------------------------------------
+
+
+class TestRRTNodeExtras:
+    def test_path_to_root_single_node(self):
+        root = RRTNode((2.0, 3.0))
+        assert root.path_to_root() == [(2.0, 3.0)]
+
+    def test_cost_accumulates_along_chain(self):
+        a = RRTNode((0.0, 0.0))
+        b = RRTNode((3.0, 4.0), a)  # dist 5
+        c = RRTNode((3.0, 4.0 + 5.0), b)  # dist 5
+        assert math.isclose(b.cost, 5.0)
+        assert math.isclose(c.cost, 10.0)
+        path = c.path_to_root()
+        assert len(path) == 3 and path[0] == (0.0, 0.0)

--- a/tests/test_scenarios_validate_coverage.py
+++ b/tests/test_scenarios_validate_coverage.py
@@ -1,0 +1,217 @@
+"""Cover the missing branches in navirl/scenarios/validate.py.
+
+``test_scenarios.py`` exercises the happy path (library scenarios must
+validate) and one ValueError path.  The uncovered lines are early-return
+guards for non-dict sub-objects, the mpp-only / ppm-mpp-inconsistent map
+branches, ``load_schema`` itself, and the ``scenario must be an object``
+top-level rejection.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from navirl.scenarios.validate import load_schema, validate_scenario_dict
+
+# ---------------------------------------------------------------------------
+# Helper: a minimal scenario that passes validation, which individual tests
+# mutate to exercise specific error paths.
+# ---------------------------------------------------------------------------
+
+
+def _base_scenario() -> dict:
+    return {
+        "id": "test",
+        "seed": 0,
+        "scene": {
+            "backend": "grid2d",
+            "map": {"source": "builtin", "id": "empty_10x10"},
+        },
+        "horizon": {"steps": 10, "dt": 0.1},
+        "humans": {"controller": {"type": "orca"}, "count": 0},
+        "robot": {
+            "controller": {"type": "baseline_astar"},
+            "start": [0.0, 0.0],
+            "goal": [1.0, 1.0],
+        },
+    }
+
+
+def _assert_has_error(scn: dict, needle: str) -> None:
+    with pytest.raises(ValueError, match=needle):
+        validate_scenario_dict(scn)
+
+
+# ---------------------------------------------------------------------------
+# load_schema (lines 15-16)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSchema:
+    def test_returns_dict(self):
+        schema = load_schema()
+        assert isinstance(schema, dict)
+
+    def test_schema_file_is_valid_json_schema(self):
+        schema = load_schema()
+        # The schema is a JSON Schema doc; confirm a couple of well-known keys.
+        assert "$schema" in schema or "type" in schema or "properties" in schema
+
+
+# ---------------------------------------------------------------------------
+# Top-level: scenario must be an object (line 180)
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelNotDict:
+    def test_list_raises(self):
+        with pytest.raises(ValueError, match="scenario must be an object"):
+            validate_scenario_dict([])  # type: ignore[arg-type]
+
+    def test_string_raises(self):
+        with pytest.raises(ValueError, match="scenario must be an object"):
+            validate_scenario_dict("not-a-dict")  # type: ignore[arg-type]
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="scenario must be an object"):
+            validate_scenario_dict(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Early-return guards for non-dict sub-objects (lines 37, 69, 94, 154)
+# ---------------------------------------------------------------------------
+
+
+class TestNonDictSubObjects:
+    """When a sub-object is the wrong type, validation records the error
+    and short-circuits further checks in that branch rather than
+    attempting attribute access.
+    """
+
+    def test_scene_not_dict(self):
+        scn = _base_scenario()
+        scn["scene"] = "not a scene"
+        _assert_has_error(scn, "scene must be an object")
+
+    def test_horizon_not_dict(self):
+        scn = _base_scenario()
+        scn["horizon"] = [10, 0.1]
+        _assert_has_error(scn, "horizon must be an object")
+
+    def test_humans_not_dict(self):
+        scn = _base_scenario()
+        scn["humans"] = "lots"
+        _assert_has_error(scn, "humans must be an object")
+
+    def test_robot_not_dict(self):
+        scn = _base_scenario()
+        scn["robot"] = 42
+        _assert_has_error(scn, "robot must be an object")
+
+
+# ---------------------------------------------------------------------------
+# Map: mpp-only branch + inconsistent ppm/mpp (lines 114, 120-121)
+# ---------------------------------------------------------------------------
+
+
+class TestMapScaleBranches:
+    def test_mpp_only_valid(self):
+        """meters_per_pixel alone, with no ppm, validates without error."""
+        scn = _base_scenario()
+        scn["scene"]["map"] = {
+            "source": "path",
+            "path": "data/maps/Wainscott_0.png",
+            "meters_per_pixel": 0.02,
+        }
+        # No ValueError expected.
+        validate_scenario_dict(scn)
+
+    def test_mpp_must_be_positive(self):
+        scn = _base_scenario()
+        scn["scene"]["map"] = {
+            "source": "path",
+            "path": "data/maps/Wainscott_0.png",
+            "meters_per_pixel": 0.0,
+        }
+        _assert_has_error(scn, "meters_per_pixel must be > 0")
+
+    def test_mpp_non_numeric(self):
+        scn = _base_scenario()
+        scn["scene"]["map"] = {
+            "source": "path",
+            "path": "data/maps/Wainscott_0.png",
+            "meters_per_pixel": "no",
+        }
+        _assert_has_error(scn, "meters_per_pixel must be > 0")
+
+    def test_ppm_and_mpp_inconsistent(self):
+        """Providing both ppm and mpp such that mpp != 1/ppm triggers the
+        consistency check (lines 120-121).
+        """
+        scn = _base_scenario()
+        scn["scene"]["map"] = {
+            "source": "path",
+            "path": "data/maps/Wainscott_0.png",
+            "pixels_per_meter": 100.0,
+            "meters_per_pixel": 0.5,  # 1/100 = 0.01, vastly different
+        }
+        _assert_has_error(scn, "pixels_per_meter and scene.map.meters_per_pixel are inconsistent")
+
+    def test_ppm_and_mpp_consistent_passes(self):
+        scn = _base_scenario()
+        scn["scene"]["map"] = {
+            "source": "path",
+            "path": "data/maps/Wainscott_0.png",
+            "pixels_per_meter": 100.0,
+            "meters_per_pixel": 0.01,
+        }
+        # Within the 2% tolerance, so this should pass.
+        validate_scenario_dict(scn)
+
+
+# ---------------------------------------------------------------------------
+# Exercise a couple of extra branches to round out confidence — these are
+# already covered but a regression here would be especially painful.
+# ---------------------------------------------------------------------------
+
+
+class TestOtherFailurePaths:
+    def test_missing_id(self):
+        scn = _base_scenario()
+        del scn["id"]
+        _assert_has_error(scn, "id is required")
+
+    def test_missing_seed(self):
+        scn = _base_scenario()
+        del scn["seed"]
+        _assert_has_error(scn, "seed is required")
+
+    def test_humans_controller_unknown_type(self):
+        scn = _base_scenario()
+        scn["humans"]["controller"]["type"] = "no_such_controller"
+        _assert_has_error(scn, "humans.controller.type must be one of")
+
+    def test_robot_controller_unknown_type(self):
+        scn = _base_scenario()
+        scn["robot"]["controller"]["type"] = "no_such_planner"
+        _assert_has_error(scn, "robot.controller.type must be one of")
+
+    def test_humans_starts_not_point(self):
+        scn = _base_scenario()
+        scn["humans"]["starts"] = [[0.0, 0.0], "not-a-point"]
+        _assert_has_error(scn, r"humans.starts\[1\] must be \[x, y\]")
+
+    def test_robot_start_not_point(self):
+        scn = _base_scenario()
+        scn["robot"]["start"] = "origin"
+        _assert_has_error(scn, r"robot.start must be \[x, y\]")
+
+    def test_horizon_steps_must_be_positive(self):
+        scn = _base_scenario()
+        scn["horizon"]["steps"] = 0
+        _assert_has_error(scn, "horizon.steps must be >= 1")
+
+    def test_horizon_dt_must_be_positive(self):
+        scn = _base_scenario()
+        scn["horizon"]["dt"] = -0.1
+        _assert_has_error(scn, "horizon.dt must be > 0")


### PR DESCRIPTION
## Summary

Targets three modules that none of the 10 open test-coverage PRs are touching, with 64 new tests focused on meaningful uncovered branches rather than boilerplate:

| Module | Before | After | New tests |
|---|---|---|---|
| `navirl/rewards/base.py` | 88% | **99%** | 22 |
| `navirl/scenarios/validate.py` | 90% | **100%** | 22 |
| `navirl/robots/baselines/rrt.py` | 90% | **99%** | 19 |

(Plus 1 small helper test that cross-checks RRTNode chain cost.)

## What's new

### `tests/test_rewards_base_coverage.py` (23 tests)
- `RewardFunction` `__call__` / `__repr__` and info-kwarg forwarding.
- `RewardComponent.reset()` delegates to the inner function; `__repr__` contains name/weight/enabled.
- `CompositeReward`: `reset()` forwards to all components and clears `_last_decomposition`; `components` property returns the internal list; `summary()` renders the header, per-component ON/OFF/tags lines and the empty-tags case; `__iter__` yields in order; `__repr__` shows `n_components`; `track_decomposition=False` leaves `_last_decomposition` empty.
- `RewardNormalizer` EMA branch (`gamma` set): `mean`/`std` use EMA accumulators; the centering path runs when `warmup=-1` (since EMA never increments `_count`). `reset()` forwards but keeps stats; `get_info()` shape.
- `RewardClipper.reset()` forwards to the inner function.
- `RewardShaper`: exception in the user-supplied potential falls back to 0.0 with a warning; string-returning potential exercises the `float(...)` coercion failure path; `reset()` clears `_prev_potential` and forwards; `get_info()` exposes base/shaping/total/gamma/scale; `with_goal_potential` factory using negative goal distance.

### `tests/test_scenarios_validate_coverage.py` (22 tests)
- `load_schema()` returns a dict that looks like a JSON Schema.
- Top-level `scenario must be an object` raises for `list` / `str` / `None`.
- Early-return guards for non-dict `scene` / `horizon` / `humans` / `robot` sub-objects.
- Map scaling: `meters_per_pixel` alone passes; zero / non-numeric `mpp` raises; `ppm`/`mpp` inconsistency triggers the consistency check; in-tolerance pair passes.
- Fills in the rest of the error matrix (missing id/seed, unknown controller types, invalid point shapes, non-positive horizon) as regression guards.

### `tests/test_rrt_robot_coverage.py` (19 tests)
- `_get_map_bounds()` fallback for backends without `map_metadata`.
- `_is_valid_position()` swallows `AttributeError` / `TypeError` / `ValueError` and returns `False`.
- `_is_path_valid()` rejects paths crossing a wall; `_plan_rrt_star` survives a fully-blocked map and appends the goal via the end-of-loop fallback.
- `_plan()` fallback to `backend.shortest_path` when RRT raises `RuntimeError`; when RRT returns empty; and the `or [self.goal]` guard when the backend also returns falsy.
- `_current_target()` past-end-of-path returns the goal.
- `step()`: DONE branch when within goal tolerance; waypoint advance when close to an intermediate waypoint; WAIT branch when target coincides with the robot; final stop-speed branch that zeroes velocity near the goal.
- Periodic replan emits `robot_rrt_replan` on `step % replan_interval == 0`.
- RRTNode cost accumulates along a multi-node chain; `path_to_root` handles single-node root.

## Verification

- `PYTHONPATH=. python3 -m pytest tests/test_rewards_base_coverage.py tests/test_scenarios_validate_coverage.py tests/test_rrt_robot_coverage.py -q` — **64 passed**
- Full suite: `PYTHONPATH=. python3 -m pytest --ignore=tests/e2e -q` — **5559 passed, 173 skipped** (baseline was 5495)
- `python3 -m ruff check` on the new files — clean
- `python3 -m ruff format --check` on the new files — clean
- Targeted coverage measured via `pytest --cov=navirl --cov-report=term-missing` (run against the full suite):
  - `navirl/rewards/base.py`: 88% → **99%** (remaining line 117 is the unreachable `raise NotImplementedError` inside an `@abstractmethod`)
  - `navirl/scenarios/validate.py`: 90% → **100%**
  - `navirl/robots/baselines/rrt.py`: 90% → **99%** (remaining lines 184, 333 are dead branches — 184 is unreachable when the first collision check already rejects the endpoint, 333 is the `vx = vy = 0.0` fallback that's preempted by the `dist_target < 1e-8` WAIT exit above it)

## Test plan
- [x] New tests pass in isolation (64/64)
- [x] Full suite regression check (5559 pass, 173 optional-dep skips, no new failures)
- [x] `ruff check` clean on new files
- [x] `ruff format --check` clean on new files
- [x] Coverage verified against all three target modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)