### PR TITLE
test: 14 tests bring training curriculum/schedulers to 100% coverage

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -259,6 +259,23 @@ class TestStagedCurriculum:
         sc.update(2, {"eval/success_rate": 0.8})
         assert sc.current_stage == 2
 
+    def test_get_difficulty_returns_active_stage_value(self, stages):
+        sc = StagedCurriculum(stages)
+        assert sc.get_difficulty(0) == pytest.approx(0.0)
+        sc.update(1, {"eval/success_rate": 0.9})
+        assert sc.get_difficulty(1) == pytest.approx(0.5)
+
+    def test_update_no_metrics_keeps_stage(self, stages):
+        sc = StagedCurriculum(stages)
+        sc.update(1, metrics=None)
+        assert sc.current_stage == 0
+
+    def test_update_missing_metric_key_is_no_op(self, stages):
+        sc = StagedCurriculum(stages)
+        # Metric_key absent from dict — must not promote nor raise.
+        sc.update(1, {"some_other_metric": 1.0})
+        assert sc.current_stage == 0
+
 
 class TestCurriculumManager:
     def test_manager_updates_dimensions(self):
@@ -272,6 +289,13 @@ class TestCurriculumManager:
         config = mgr.get_env_config()
         assert config["density"] == pytest.approx(10.5)
         assert config["speed"] == pytest.approx(1.25)
+
+    def test_manager_get_difficulty_delegates_to_scheduler(self):
+        dims = [DifficultyDimension("density", 1.0, 20.0)]
+        scheduler = LinearCurriculum(0.0, 1.0, total_steps=100)
+        mgr = CurriculumManager(dims, scheduler)
+        assert mgr.get_difficulty(50) == pytest.approx(0.5)
+        assert mgr.get_difficulty(100) == pytest.approx(1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +330,12 @@ class TestCosineAnnealingSchedule:
         s = CosineAnnealingSchedule(max_value=1.0, min_value=0.0, total_steps=100, warmup_steps=20)
         assert s.value(0) == pytest.approx(0.0)
         assert s.value(20) == pytest.approx(1.0)
+
+    def test_warmup_eq_total_steps_returns_min(self):
+        # warmup_steps == total_steps means decay_steps == 0; post-warmup falls
+        # straight to min_value rather than dividing by zero.
+        s = CosineAnnealingSchedule(max_value=1.0, min_value=0.25, total_steps=20, warmup_steps=20)
+        assert s.value(25) == pytest.approx(0.25)
 
 
 class TestStepSchedule:
@@ -343,6 +373,17 @@ class TestCyclicSchedule:
         val = s.value(25)
         assert 0.0 <= val <= 1.0
 
+    def test_triangular_descending_half(self):
+        # Triangular mode repeats up/down twice per cycle; the descending
+        # branch (half_pos > 0.5) is exercised at step 38 of a 100-step cycle.
+        s = CyclicSchedule(base_value=0.0, max_value=1.0, cycle_steps=100, mode="triangular")
+        # Peak at 25 (half_pos == 0.5), descending after.
+        peak = s.value(25)
+        descending = s.value(38)
+        assert peak == pytest.approx(1.0)
+        assert descending < peak
+        assert descending > 0.0
+
 
 class TestExplorationSchedule:
     def test_linear_decay(self):
@@ -354,6 +395,11 @@ class TestExplorationSchedule:
         s = ExplorationSchedule(1.0, 0.01, total_steps=100, mode="exponential")
         assert s.value(0) == pytest.approx(1.0)
         assert s.value(100) == pytest.approx(0.01, abs=1e-3)
+
+    def test_exponential_zero_initial_returns_final(self):
+        # Avoid division-by-zero when initial_eps is non-positive.
+        s = ExplorationSchedule(0.0, 0.05, total_steps=100, mode="exponential")
+        assert s.value(50) == pytest.approx(0.05)
 
 
 class TestWarmupSchedule:
@@ -415,6 +461,11 @@ class TestCompositeSchedule:
     def test_past_all_phases(self):
         s = CompositeSchedule([(LinearSchedule(1.0, 0.0, 10), 10)])
         assert s.value(100) == pytest.approx(0.0)
+
+    def test_empty_phases_returns_zero(self):
+        s = CompositeSchedule([])
+        assert s.value(0) == pytest.approx(0.0)
+        assert s.value(99999) == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_training_parallel.py
+++ b/tests/test_training_parallel.py
@@ -637,3 +637,51 @@ class TestSubprocVecEnv:
             np.testing.assert_array_equal(obs[0], [0.0, 0.0])
         finally:
             venv.close()
+
+    def test_default_start_method_is_auto_detected(self):
+        """When start_method is None, SubprocVecEnv picks forkserver if
+        available else spawn — both branches must yield a working env."""
+        import multiprocessing as mp
+
+        from navirl.training.parallel import SubprocVecEnv
+
+        venv = SubprocVecEnv([_make_simple_env, _make_simple_env])
+        try:
+            obs = venv.reset()
+            assert obs.shape == (2, 4)
+            assert venv.num_envs == 2
+        finally:
+            venv.close()
+
+        # Sanity: the path we exercised matches what get_all_start_methods
+        # would surface, i.e. at least one of the two acceptable methods
+        # exists on this platform.
+        methods = mp.get_all_start_methods()
+        assert "forkserver" in methods or "spawn" in methods
+
+    def test_close_drains_pending_step(self):
+        """Calling close() while step_async is still in-flight must drain
+        the pipes (`waiting=True` branch) without deadlocking."""
+        from navirl.training.parallel import SubprocVecEnv
+
+        def _make():
+            return SimpleEnv(obs_dim=2, episode_length=10)
+
+        venv = SubprocVecEnv([_make, _make], start_method="fork")
+        try:
+            venv.reset()
+            venv.step_async(np.array([0, 0]))
+            assert venv.waiting is True
+            # close() must consume the pending step results before sending
+            # the close command.
+            venv.close()
+            assert venv.closed is True
+        finally:
+            if not venv.closed:
+                venv.close()
+
+
+def _make_simple_env():
+    """Module-level factory required for the spawn/forkserver start methods,
+    which pickle the callable into worker processes."""
+    return SimpleEnv(obs_dim=4, episode_length=5)

--- a/tests/test_training_trainer.py
+++ b/tests/test_training_trainer.py
@@ -576,3 +576,156 @@ class TestTrainerNullUpdate:
         )
         summary = trainer.train()
         assert summary["total_timesteps"] >= 5
+
+
+# ---------------------------------------------------------------------------
+# Trainer — periodic checkpoint saving
+# ---------------------------------------------------------------------------
+
+
+class TestTrainerPeriodicCheckpoint:
+    def test_save_interval_creates_step_checkpoint(self, tmp_path):
+        """With n_envs=1 and save_interval=2, a step-N checkpoint dir appears."""
+        cfg = TrainerConfig(
+            total_timesteps=4,
+            eval_interval=100,
+            save_interval=2,
+            log_interval=100,
+            n_envs=1,
+            checkpoint_dir=str(tmp_path / "ckpt"),
+            log_dir=str(tmp_path / "log"),
+        )
+        trainer = Trainer(
+            agent=MockAgent(),
+            env_fn=lambda: MockEnv(episode_length=10),
+            config=cfg,
+        )
+        trainer.train()
+
+        ckpt_root = tmp_path / "ckpt"
+        # Step-keyed checkpoint dirs should be present alongside any best_model.
+        step_dirs = [
+            p
+            for p in ckpt_root.iterdir()
+            if p.is_dir() and p.name.startswith("checkpoint_")
+        ]
+        assert step_dirs, f"expected step checkpoints under {ckpt_root}, got {list(ckpt_root.iterdir())}"
+        # Each step checkpoint must carry the trainer metadata file.
+        for d in step_dirs:
+            assert (d / "trainer_meta.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Trainer._make_envs branches
+# ---------------------------------------------------------------------------
+
+
+class TestTrainerMakeEnvs:
+    def test_make_envs_returns_dummy_when_n_envs_one(self, tmp_path):
+        from navirl.training.parallel import DummyVecEnv
+
+        cfg = TrainerConfig(
+            n_envs=1,
+            checkpoint_dir=str(tmp_path / "ckpt"),
+            log_dir=str(tmp_path / "log"),
+        )
+        trainer = Trainer(
+            agent=MockAgent(),
+            env_fn=lambda: MockEnv(episode_length=2),
+            config=cfg,
+        )
+        envs = trainer._make_envs()
+        try:
+            assert isinstance(envs, DummyVecEnv)
+            assert envs.num_envs == 1
+        finally:
+            envs.close()
+
+    def test_make_envs_returns_subproc_when_n_envs_gt_one(self, tmp_path):
+        from navirl.training.parallel import SubprocVecEnv
+
+        cfg = TrainerConfig(
+            n_envs=2,
+            checkpoint_dir=str(tmp_path / "ckpt"),
+            log_dir=str(tmp_path / "log"),
+        )
+        # SubprocVecEnv pickles env_fn into worker processes, so the callable
+        # has to be picklable — module-level helper rather than a closure.
+        trainer = Trainer(
+            agent=MockAgent(),
+            env_fn=_picklable_env_fn,
+            config=cfg,
+        )
+        envs = trainer._make_envs()
+        try:
+            assert isinstance(envs, SubprocVecEnv)
+            assert envs.num_envs == 2
+        finally:
+            envs.close()
+
+    def test_make_envs_falls_back_to_shim_on_import_error(self, tmp_path, monkeypatch):
+        """When the parallel module fails to import, _make_envs returns a
+        single-env shim instead of raising."""
+        import builtins
+
+        cfg = TrainerConfig(
+            n_envs=2,
+            checkpoint_dir=str(tmp_path / "ckpt"),
+            log_dir=str(tmp_path / "log"),
+        )
+        trainer = Trainer(
+            agent=MockAgent(),
+            env_fn=lambda: MockEnv(episode_length=2),
+            config=cfg,
+        )
+
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "navirl.training.parallel":
+                raise ImportError("simulated parallel import failure")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        envs = trainer._make_envs()
+        # _SingleEnvShim is the fallback wrapper.
+        assert isinstance(envs, _SingleEnvShim)
+
+
+class _PicklableSpace:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class _PicklableEnv:
+    """Minimal picklable env for SubprocVecEnv tests; MockEnv uses MagicMock
+    spaces which cannot survive a process boundary."""
+
+    def __init__(self, obs_dim: int = 4, episode_length: int = 3) -> None:
+        self.obs_dim = obs_dim
+        self.episode_length = episode_length
+        self._step_count = 0
+        self.observation_space = _PicklableSpace((obs_dim,))
+        self.action_space = _PicklableSpace((1,))
+
+    def reset(self):
+        self._step_count = 0
+        return np.zeros(self.obs_dim, dtype=np.float32)
+
+    def step(self, action):
+        self._step_count += 1
+        obs = np.full(self.obs_dim, self._step_count, dtype=np.float32)
+        reward = 1.0
+        done = self._step_count >= self.episode_length
+        info = {"is_success": True} if done else {}
+        return obs, reward, done, info
+
+    def close(self):
+        pass
+
+
+def _picklable_env_fn():
+    """Top-level factory used by SubprocVecEnv tests — closures and lambdas
+    referencing test-local classes are not picklable across spawn/forkserver
+    boundaries."""
+    return _PicklableEnv(obs_dim=4, episode_length=3)


### PR DESCRIPTION
## Summary

- Targets the **training** package, which no other open coverage PR touches.
- Brings `training/curriculum.py` from 96% → **100%** and `training/schedulers.py` from 97% → **100%**.
- Lifts `training/trainer.py` from 92% → 95% (remaining gaps are TensorBoard/W&B integrations that need optional deps) and `training/parallel.py` from 80% → 82% by covering the SubprocVecEnv default-start-method and close-while-waiting branches.

## Edge cases now covered

- `StagedCurriculum.get_difficulty`, no-metrics path, and missing-`metric_key` path.
- `CurriculumManager.get_difficulty` (delegation to scheduler).
- `CosineAnnealingSchedule` when `warmup_steps == total_steps` (`decay_steps` becomes 0).
- `CyclicSchedule` triangular descending half (the `half_pos > 0.5` branch).
- `ExplorationSchedule` exponential mode with non-positive `initial_eps`.
- `CompositeSchedule` with an empty `phases` list.
- Periodic checkpointing in `Trainer.train` (the `save_interval` branch creating `checkpoint_<step>/` dirs).
- `Trainer._make_envs` returning `DummyVecEnv` (n=1), `SubprocVecEnv` (n>1, real subprocesses), and the `_SingleEnvShim` fallback when `navirl.training.parallel` fails to import.
- `SubprocVecEnv` default `start_method` auto-detect (`forkserver`/`spawn`).
- `SubprocVecEnv.close()` draining a pending `step_async` without deadlock.

The SubprocVecEnv test required a module-level picklable env factory because `MockEnv` uses `MagicMock` spaces that cannot cross a process boundary.

## Test plan

- [x] All 14 new tests pass: `PYTHONPATH=. pytest tests/test_training.py tests/test_training_trainer.py tests/test_training_parallel.py`.
- [x] Full suite still green: `5509 passed, 173 skipped` (was 5495).
- [x] `ruff check` clean on the three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)